### PR TITLE
wrapper: force ssh config file permissions

### DIFF
--- a/cmd/konvoy-image-wrapper/cmd/wrapper.go
+++ b/cmd/konvoy-image-wrapper/cmd/wrapper.go
@@ -379,6 +379,10 @@ func (r *Runner) Run(args []string) error {
 	if err != nil {
 		return err
 	}
+	// Make sure that that the file is only `rw` by the user.
+	if err = f.Chmod(os.FileMode(0600)); err != nil { //nolint:gomnd // File modes are not magic.
+		return err
+	}
 	f.Close()
 
 	// Mask the ssh known_hosts file from the host.

--- a/cmd/konvoy-image-wrapper/cmd/wrapper.go
+++ b/cmd/konvoy-image-wrapper/cmd/wrapper.go
@@ -228,7 +228,6 @@ func (r *Runner) dockerRun(args []string) error {
 		r.addBindVolume(r.tempDir+"/passwd", "/etc/passwd")
 		r.addBindVolume(r.tempDir+"/group", "/etc/group")
 		r.addBindVolume(r.homeDir, r.homeDir)
-		r.addBindVolume(r.tempDir+"/ssh_config", r.usr.HomeDir+"/.ssh/config")
 		r.addBindVolume(r.tempDir+"/ssh_known_hosts", r.usr.HomeDir+"/.ssh/known_hosts")
 	}
 
@@ -375,19 +374,24 @@ func (r *Runner) Run(args []string) error {
 	// Mask the ssh config from the host. The ssh config format on OSX is
 	// slightly different than that in Linux, which will cause Ansible to
 	// fail sometimes.
-	f, err := os.Create(filepath.Join(r.tempDir, "ssh_config"))
-	if err != nil {
-		return err
+	if _, err = os.Stat(r.usr.HomeDir + "/.ssh/config"); err == nil {
+		f, ferr := os.Create(filepath.Join(r.tempDir, "ssh_config"))
+		if ferr != nil {
+			return ferr
+		}
+
+		// Make sure that that the file is only `rw` by the user.
+		if ferr := f.Chmod(os.FileMode(0600)); ferr != nil { //nolint:gomnd // File modes are not magic.
+			return ferr
+		}
+		f.Close()
+
+		r.addBindVolume(r.tempDir+"/ssh_config", r.usr.HomeDir+"/.ssh/config")
 	}
-	// Make sure that that the file is only `rw` by the user.
-	if err = f.Chmod(os.FileMode(0600)); err != nil { //nolint:gomnd // File modes are not magic.
-		return err
-	}
-	f.Close()
 
 	// Mask the ssh known_hosts file from the host.
 	// This will prevent multiple runs from interfering with each other when targeting hosts with the same IPs.
-	f, err = os.Create(filepath.Join(r.tempDir, "ssh_known_hosts"))
+	f, err := os.Create(filepath.Join(r.tempDir, "ssh_known_hosts"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Set the ssh config file permissions to `0600` in the event that the
environment's `umask` allows group or other write permissions by
default.