### PR TITLE
fix: override flags not passed on generate command

### DIFF
--- a/cmd/konvoy-image/cmd/build.go
+++ b/cmd/konvoy-image/cmd/build.go
@@ -32,7 +32,7 @@ var buildCmd = &cobra.Command{
 		var workDir string
 		var err error
 		if buildFlags.workDir == "" {
-			workDir, err = builder.InitConfig(newInitOptions(args[0]))
+			workDir, err = builder.InitConfig(newInitOptions(args[0], buildFlags.generateCLIFlags))
 			if err != nil {
 				bail("error rendering builder configuration", err, 2)
 			}

--- a/cmd/konvoy-image/cmd/generate.go
+++ b/cmd/konvoy-image/cmd/generate.go
@@ -22,19 +22,19 @@ var generateCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		builder := newBuilder()
-		_, err := builder.InitConfig(newInitOptions(args[0]))
+		_, err := builder.InitConfig(newInitOptions(args[0], generateFlags))
 		if err != nil {
 			bail("error rendering builder configuration", err, 2)
 		}
 	},
 }
 
-func newInitOptions(image string) app.InitOptions {
+func newInitOptions(image string, flags generateCLIFlags) app.InitOptions {
 	return app.InitOptions{
 		CommonConfigPath: app.CommonConfigDefaultPath,
 		Image:            image,
-		Overrides:        buildFlags.overrides,
-		UserArgs:         buildFlags.userArgs,
+		Overrides:        flags.overrides,
+		UserArgs:         flags.userArgs,
 	}
 }
 


### PR DESCRIPTION
The `generate` command was ignoring `overrides` CLI flag.

```
./bin/konvoy-images generate [path] --overrides [override-path]
```