### PR TITLE
Disable automatic updates for Flatcar

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,13 +25,17 @@ jobs:
           env-file: .github/super-linter.env
 
       - name: Run Super-Linter
-        uses: github/super-linter@v3.17.1
+        uses: github/super-linter@v4.2.2
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # NOTE(jkoelker) super-linter is broken for go packages
           #                https://github.com/github/super-linter/issues/143
           VALIDATE_GO: false
+          # NOTE(jongiddy) super-linter is broken for Packer HCL files
+          #                https://github.com/github/super-linter/pull/1707
+          # This can be removed when a release > 4.2.2 exists.
+          VALIDATE_TERRAGRUNT: false
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2.5.2

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ manifest.json
 .docker-*
 .cache
 .ansible
+flatcar-version.yaml
 /work/
 /bin/
 /report/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,9 +42,8 @@ linters-settings:
   gomnd:
     settings:
       mnd:
-        # don't include the "operation" and "assign"
+        # don't include "argument", "operation", and "assign"
         checks:
-          - argument
           - case
           - condition
           - return

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ export DOCKER_DEVKIT_AWS_ARGS ?= \
 	--env AWS_PROFILE \
 	--env AWS_SECRET_ACCESS_KEY \
 	--env AWS_SESSION_TOKEN \
-	--env AWS_REGION \
+	--env AWS_DEFAULT_REGION \
 	--volume "$(HOME)/.aws":"/home/$(USER_NAME)/.aws"
 
 ifneq ($(wildcard $(DOCKER_SOCKET)),)
@@ -134,7 +134,7 @@ centos8-nvidia: ## Build Centos 8 image
 	./bin/konvoy-image build images/ami/centos-8.yaml --overrides overrides/nvidia.yaml
 
 flatcar-version.yaml:
-	AWS_DEFAULT_REGION=$(AWS_REGION) ./hack/fetch-flatcar-ami.sh
+	./hack/fetch-flatcar-ami.sh
 
 .PHONY: flatcar
 flatcar: build flatcar-version.yaml

--- a/Makefile
+++ b/Makefile
@@ -133,10 +133,13 @@ centos8-nvidia: build
 centos8-nvidia: ## Build Centos 8 image
 	./bin/konvoy-image build images/ami/centos-8.yaml --overrides overrides/nvidia.yaml
 
+flatcar-version.yaml:
+	AWS_DEFAULT_REGION=$(AWS_REGION) ./hack/fetch-flatcar-ami.sh
+
 .PHONY: flatcar
-flatcar: build
+flatcar: build flatcar-version.yaml
 flatcar: ## Build flatcar image
-	./bin/konvoy-image build images/ami/flatcar.yaml
+	./bin/konvoy-image build images/ami/flatcar.yaml --overrides flatcar-version.yaml
 
 .PHONY: dev
 dev: ## dev build
@@ -151,6 +154,7 @@ clean: ## remove files created during build
 	$(call print-target)
 	rm -rf bin
 	rm -rf dist
+	rm -f flatcar-version.yaml
 	rm -f $(COVERAGE)*
 	docker image rm $(DOCKER_DEVKIT_IMG) || echo "image already removed"
 
@@ -310,7 +314,8 @@ ci.e2e.build.all:
 	make docker.clean-latest-ami
 	WHAT="./bin/konvoy-image build images/ami/centos-8.yaml --overrides overrides/nvidia.yaml -v 6" make devkit.run
 	make docker.clean-latest-ami
-	WHAT="./bin/konvoy-image build images/ami/flatcar.yaml -v 6" make devkit.run
+	WHAT="make flatcar-version.yaml" make devkit.run
+	WHAT="./bin/konvoy-image build images/ami/flatcar.yaml --overrides flatcar-version.yaml -v 6" make devkit.run
 	make docker.clean-latest-ami
 
 # use sibling containers to handle dependencies and avoid DinD

--- a/cmd/konvoy-image-wrapper/cmd/wrapper.go
+++ b/cmd/konvoy-image-wrapper/cmd/wrapper.go
@@ -381,7 +381,7 @@ func (r *Runner) Run(args []string) error {
 		}
 
 		// Make sure that that the file is only `rw` by the user.
-		if ferr := f.Chmod(os.FileMode(0600)); ferr != nil { //nolint:gomnd // File modes are not magic.
+		if ferr := f.Chmod(os.FileMode(0600)); ferr != nil {
 			return ferr
 		}
 		f.Close()

--- a/hack/fetch-flatcar-ami.sh
+++ b/hack/fetch-flatcar-ami.sh
@@ -19,6 +19,8 @@ then
     exit 1
 fi
 
+export AWS_DEFAULT_REGION
+
 # Directory containing this script
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 

--- a/hack/fetch-flatcar-ami.sh
+++ b/hack/fetch-flatcar-ami.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Flatcar provides a basic free OS, supported for 9 months, and premium OS's.
+# All of these, except for the most recent free OS, are provided through an
+# AMI Marketplace subscription.  This prevents generation of a public AMI from
+# these images.  Without further configuration, we must use the latest Flatcar
+# release.  Hence, we run a Packer build to identify the latest Flatcar AMI
+# and provide an override file to select it.
+
+set -e -x
+
+if [ -z "${AWS_DEFAULT_REGION}" ]
+then
+    # If running in an AWS region, use it
+    AWS_DEFAULT_REGION=$(curl -sSL http://169.254.169.254/latest/meta-data/placement/region) || true
+fi
+if [ -z "${AWS_DEFAULT_REGION}" ]
+then
+    echo "Need AWS_DEFAULT_REGION to be set" >&2
+    exit 1
+fi
+
+# Directory containing this script
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+packer build "${SCRIPT_DIR}/flatcar-ami.pkr.hcl"

--- a/hack/flatcar-ami.pkr.hcl
+++ b/hack/flatcar-ami.pkr.hcl
@@ -1,0 +1,22 @@
+data "amazon-ami" "flatcar" {
+  filters = {
+    virtualization-type = "hvm"
+    name                = "Flatcar-stable-*-hvm"
+  }
+  owners      = ["075585003325"]
+  most_recent = true
+}
+local "flatcar_version" {
+  expression = format(
+    "packer: {distribution_version: %q, source_ami: %q}",
+    element(split("-", data.amazon-ami.flatcar.name), 2),
+    data.amazon-ami.flatcar.id
+    )
+}
+source "file" "basic-example" {
+  content =  local.flatcar_version
+  target =  "flatcar-version.yaml"
+}
+build {
+  sources = ["sources.file.basic-example"]
+}

--- a/hack/setup_environment.py
+++ b/hack/setup_environment.py
@@ -32,6 +32,8 @@ def main():
     for k in keys:
         print("export {}={}".format(k.upper(), creds[k]))
 
+    print("export {}={}".format("AWS_DEFAULT_REGION", DEFAULT_REGION))
+
 
 if __name__ == "__main__":
     main()

--- a/images/ami/flatcar.yaml
+++ b/images/ami/flatcar.yaml
@@ -1,12 +1,15 @@
 download_images: true
 
 packer:
+  # Selectors for source AMI:
   ami_filter_name: "Flatcar*stable*"
   ami_filter_owners: "075585003325"
+  # Tags applied to generated AMI:
   distribution: "Flatcar"
   distribution_release: "Stable"
-  distribution_version: "2765.2.1"
+  distribution_version: "2765.2.6"
   source_ami: ""
+  # Other variables:
   ssh_username: "core"
   root_device_name: "/dev/sda1"
 

--- a/images/ami/flatcar.yaml
+++ b/images/ami/flatcar.yaml
@@ -4,11 +4,10 @@ packer:
   # Selectors for source AMI:
   ami_filter_name: "Flatcar*stable*"
   ami_filter_owners: "075585003325"
+  source_ami: ""
   # Tags applied to generated AMI:
   distribution: "Flatcar"
-  distribution_release: "Stable"
-  distribution_version: "2765.2.6"
-  source_ami: ""
+  distribution_version: null
   # Other variables:
   ssh_username: "core"
   root_device_name: "/dev/sda1"

--- a/packer/files/no-update-flatcar.sh
+++ b/packer/files/no-update-flatcar.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Flatcar's update typically occurs 10 minutes after boot. We need to turn it
+# off before then. Hence, we run this script before all other Flatcar scripts.
+# We should check if this can be moved to Ansible and still work or if we can
+# configure even earlier with a cloud-init / Container Linux Config.
+set -e
+
+[[ "$BUILD_NAME" != *"flatcar"* ]] && exit 0
+
+# Prevent systemd from starting `update-engine` and `locksmithd`. The default
+# system unit files check for `/usr/.noupdate`, but since `/usr` is a read-only
+# filesystem we cannot create this. Add `/etc/.noupdate` to perform the same
+# role.
+for service in locksmithd update-engine
+do
+    mkdir -p /etc/systemd/system/${service}.service.d
+    cat > /etc/systemd/system/${service}.service.d/10-noupdate.conf <<EOF
+[Unit]
+ConditionPathExists=!/etc/.noupdate
+EOF
+done
+touch /etc/.noupdate
+systemctl daemon-reload
+
+# Stop the currently running service instances.
+systemctl stop locksmithd
+systemctl stop update-engine
+
+# Disable automated reboots.  With `locksmithd` disabled, no reboot strategy is
+# required. However, setting this ensures that we are conservative if
+# `locksmithd` is re-enabled.
+sed -i '/^REBOOT_STRATEGY=.*/d' /etc/flatcar/update.conf
+echo 'REBOOT_STRATEGY=off' >> /etc/flatcar/update.conf

--- a/pkg/app/build.go
+++ b/pkg/app/build.go
@@ -234,6 +234,7 @@ func genPackerVars(config map[string]interface{}, extraVarsPath string) ([]byte,
 	p[kubernetesFullVersionKey] = getString(config, kubernetesFullVersionKey)
 	p[containerdVersionKey] = getString(config, containerdVersionKey)
 	p[buildNameKey] = buildName(config)
+	p[buildNameExtraKey] = getString(config, buildNameExtraKey)
 	p[ansibleExtraVarsKey] = fmt.Sprintf("@%s", extraVarsPath)
 
 	data, err := json.Marshal(p)

--- a/pkg/packer/manifests/aws/packer.json.tmpl
+++ b/pkg/packer/manifests/aws/packer.json.tmpl
@@ -75,7 +75,7 @@
         "image_builder_version": "{{user `konvoy_image_builder_version`}}",
         "kubernetes_cni_version": "{{user `kubernetes_cni_semver`}}",
         "kubernetes_version": "{{user `kubernetes_version`}}",
-        "source_ami": "{{user `source_ami`}}"
+        "source_ami": "{{.SourceAMI}}"
       },
       "launch_block_device_mappings": [
         {
@@ -98,6 +98,14 @@
         "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
         "sudo apt-get -qq update && sudo DEBIAN_FRONTEND=noninteractive apt-get -qqy install python python-pip"
       ]
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "BUILD_NAME={{user `build_name`}}"
+      ],
+      "script": "./packer/files/no-update-flatcar.sh",
+      "execute_command": "BUILD_NAME={{user `build_name`}}; if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi"
     },
     {
       "type": "shell",

--- a/pkg/packer/manifests/aws/packer.json.tmpl
+++ b/pkg/packer/manifests/aws/packer.json.tmpl
@@ -1,6 +1,5 @@
 {
   "variables": {
-    "ami_description": "Konvoy base for {{user `kubernetes_full_version`}}",
     "ami_groups": "all",
     "ami_regions": "us-west-2",
     "ami_users": "",
@@ -27,7 +26,7 @@
   },
   "builders": [
     {
-      "name": "{{user `build_name`}}",
+      "name": "{{(user `distribution`) | lower}}-{{user `distribution_version`}}{{user `build_name_extra`}}",
       "type": "amazon-ebs",
       "instance_type": "t3.small",
       ((- if .SourceAMIDefined ))
@@ -44,13 +43,13 @@
         "most_recent": true
       },
       ((- end ))
-      "ami_name": "konvoy-ami-{{user `build_name`}}-{{user `kubernetes_full_version` | clean_resource_name}}-{{user `build_timestamp`}}",
+      "ami_name": "konvoy-ami-{{build_name}}-{{user `kubernetes_full_version` | clean_resource_name}}-{{user `build_timestamp`}}",
       "snapshot_tags": {
-        "ami_name": "konvoy-ami-{{user `build_name`}}-{{user `kubernetes_full_version` | clean_resource_name}}-{{user `build_timestamp`}}"
+        "ami_name": "konvoy-ami-{{build_name}}-{{user `kubernetes_full_version` | clean_resource_name}}-{{user `build_timestamp`}}"
       },
       "ami_groups": "{{user `ami_groups`}}",
       "ami_users": "{{user `ami_users`}}",
-      "ami_description": "{{user `ami_description`}}",
+      "ami_description": "Konvoy base for Kubernetes {{user `kubernetes_full_version`}} on {{user `distribution`}}-{{user `distribution_version`}}",
       "snapshot_groups": "{{user `snapshot_groups`}}",
       "snapshot_users": "{{user `snapshot_users`}}",
       "encrypt_boot": "{{user `encrypted`}}",
@@ -73,8 +72,8 @@
         "distribution": "{{user `distribution`}}",
         "distribution_version": "{{user `distribution_version`}}",
         "image_builder_version": "{{user `konvoy_image_builder_version`}}",
-        "kubernetes_cni_version": "{{user `kubernetes_cni_semver`}}",
-        "kubernetes_version": "{{user `kubernetes_version`}}",
+        "kubernetes_cni_version": "{{user `kubernetes_cni_version`}}",
+        "kubernetes_version": "{{user `kubernetes_full_version` | clean_resource_name}}",
         "source_ami": "{{.SourceAMI}}"
       },
       "launch_block_device_mappings": [
@@ -91,7 +90,7 @@
     {
       "type": "shell",
       "environment_vars": [
-        "BUILD_NAME={{user `build_name`}}"
+        "BUILD_NAME={{build_name}}"
       ],
       "inline": [
         "if [ $BUILD_NAME != \"ubuntu-1804\" ]; then exit 0; fi",
@@ -102,18 +101,18 @@
     {
       "type": "shell",
       "environment_vars": [
-        "BUILD_NAME={{user `build_name`}}"
+        "BUILD_NAME={{build_name}}"
       ],
       "script": "./packer/files/no-update-flatcar.sh",
-      "execute_command": "BUILD_NAME={{user `build_name`}}; if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi"
+      "execute_command": "BUILD_NAME={{build_name}}; if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi"
     },
     {
       "type": "shell",
       "environment_vars": [
-        "BUILD_NAME={{user `build_name`}}"
+        "BUILD_NAME={{build_name}}"
       ],
       "script": "./packer/files/bootstrap-flatcar.sh",
-      "execute_command": "BUILD_NAME={{user `build_name`}}; if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi"
+      "execute_command": "BUILD_NAME={{build_name}}; if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi"
     },
     {
       "type": "ansible",


### PR DESCRIPTION
To ensure the Nvidia driver continues to work, we need to be conservative with kernel upgrades. Flatcar in particular upgrades automatically. Disable upgrades (and their reboots) on Flatcar to provide a similar model to other OS's.

Since the OS does not upgrade, encode the OS version in the AMI name. This requires retrieval of the AMI data before running the AMI build. This is done by running a small HCL build (in `hack/flatcar-ami.pkr.hcl`) that fetches the latest Flatcar AMI and creates an override file to set the `distribution_version`.

https://jira.d2iq.com/browse/D2IQ-76956