### PR TITLE
feat: version bumps

### DIFF
--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -1,16 +1,16 @@
 ---
 python_path: ""
 kubernetes_version: "1.21.3"
-containerd_version: "1.3.9"
+containerd_version: "1.4.7"
 kubernetes_cni_version: "0.9.1"
 etcd_version: "3.4.13-0"
 coredns_version: "1.8.0"
 pause_image_version: "3.4.1"
 crictl_version: "1.20.0"
 
-# https://github.com/containerd/containerd/releases/download/v1.3.9/cri-containerd-cni-1.3.9-linux-amd64.tar.gz
+# https://github.com/containerd/containerd/releases/download/v1.4.7/cri-containerd-cni-1.4.7-linux-amd64.tar.gz
 containerd_url: https://github.com/containerd/containerd/releases/download/v{{ containerd_version }}/cri-containerd-cni-{{ containerd_version }}-linux-amd64.tar.gz
-containerd_sha256: 96663699e0f888fbf232ae6629a367aa7421f6b95044e7ee5d4d4e02841fac75
+containerd_sha256: 3ef2cc781be6e9c06ba405ddd630ac91a3f32858117a040f66110407bb82d83a
 kubernetes_http_source: https://storage.googleapis.com/kubernetes-release/release
 kubernetes_cni_semver: v{{ kubernetes_cni_version }}
 kubernetes_cni_http_checksum: sha256:https://storage.googleapis.com/k8s-artifacts-cni/release/{{ kubernetes_cni_semver }}/cni-plugins-linux-amd64-{{ kubernetes_cni_semver }}.tgz.sha256

--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -1,12 +1,11 @@
 ---
 python_path: ""
-kubernetes_version: "1.20.6"
+kubernetes_version: "1.21.3"
 containerd_version: "1.3.9"
 kubernetes_cni_version: "0.9.1"
 etcd_version: "3.4.13-0"
-coredns_version: "1.7.0"
-pause_image_version: "3.2"
-pause_image_version_prev: "3.1"
+coredns_version: "1.8.0"
+pause_image_version: "3.4.1"
 crictl_version: "1.20.0"
 
 # https://github.com/containerd/containerd/releases/download/v1.3.9/cri-containerd-cni-1.3.9-linux-amd64.tar.gz

--- a/ansible/roles/images/defaults/main.yaml
+++ b/ansible/roles/images/defaults/main.yaml
@@ -5,9 +5,8 @@ control_plane_images:
   - "k8s.gcr.io/kube-scheduler:v{{ kubernetes_version }}"
   - "k8s.gcr.io/kube-proxy:v{{ kubernetes_version }}"
   - "k8s.gcr.io/pause:{{ pause_image_version }}"
-  - "k8s.gcr.io/pause:{{ pause_image_version_prev }}"
   - "k8s.gcr.io/etcd:{{ etcd_version }}"
-  - "k8s.gcr.io/coredns:{{ coredns_version }}"
+  - "k8s.gcr.io/coredns/coredns:v{{ coredns_version }}"
 
 aws_images: []
 

--- a/images/ami/flatcar.yaml
+++ b/images/ami/flatcar.yaml
@@ -15,7 +15,8 @@ packer:
 build_name: "flatcar-stable"
 packer_builder_type: "amazon"
 
-containerd_version: 1.4.4 # match this with the flatcar distribution version
+containerd_version: 1.5.4 # match this with the flatcar distribution version
+containerd_sha256: 591e4e087ea2f5007e6c64deb382df58d419b7b6922eab45a1923d843d57615f # matching sha to the version override above
 kubernetes_cni_version: 0.8.7
 
 ansible_python_interpreter: /opt/bin/python

--- a/images/common.yaml
+++ b/images/common.yaml
@@ -1,7 +1,7 @@
 download_images: false
 
 kubernetes_version: "1.21.3"
-containerd_version: "1.3.9"
+containerd_version: "1.4.7"
 kubernetes_cni_version: "0.9.1"
 etcd_version: "3.4.13-0"
 coredns_version: "1.8.0"
@@ -9,7 +9,7 @@ pause_image_version: "3.4.1"
 crictl_version: "1.20.0"
 
 containerd_url: https://github.com/containerd/containerd/releases/download/v{{ containerd_version }}/cri-containerd-cni-{{ containerd_version }}-linux-amd64.tar.gz
-containerd_sha256: 96641849cb78a0a119223a427dfdc1ade88412ef791a14193212c8c8e29d447b
+containerd_sha256: 3ef2cc781be6e9c06ba405ddd630ac91a3f32858117a040f66110407bb82d83a
 kubernetes_http_source: https://storage.googleapis.com/kubernetes-release/release
 kubernetes_cni_semver: v{{ kubernetes_cni_version }}
 kubernetes_cni_http_checksum: sha256:https://storage.googleapis.com/k8s-artifacts-cni/release/{{ kubernetes_cni_semver }}/cni-plugins-linux-amd64-{{ kubernetes_cni_semver }}.tgz.sha256

--- a/images/common.yaml
+++ b/images/common.yaml
@@ -2,7 +2,7 @@ download_images: false
 
 kubernetes_version: "1.21.3"
 containerd_version: "1.3.9"
-kubernetes_cni_version: "1.1.1"
+kubernetes_cni_version: "0.9.1"
 etcd_version: "3.4.13-0"
 coredns_version: "1.8.0"
 pause_image_version: "3.4.1"

--- a/images/common.yaml
+++ b/images/common.yaml
@@ -1,12 +1,11 @@
 download_images: false
 
-kubernetes_version: "1.20.6"
+kubernetes_version: "1.21.3"
 containerd_version: "1.3.9"
 kubernetes_cni_version: "1.1.1"
 etcd_version: "3.4.13-0"
-coredns_version: "1.7.0"
-pause_image_version: "3.2"
-pause_image_version_prev: "3.1"
+coredns_version: "1.8.0"
+pause_image_version: "3.4.1"
 crictl_version: "1.20.0"
 
 containerd_url: https://github.com/containerd/containerd/releases/download/v{{ containerd_version }}/cri-containerd-cni-{{ containerd_version }}-linux-amd64.tar.gz


### PR DESCRIPTION
Fixes https://jira.d2iq.com/browse/D2IQ-77290

- Kubernetes `v1.21.3` and bumped pause and coredns image versions
- Containerd `v1.4.7`

Verified locally
```
==> Wait completed after 10 minutes 28 seconds

==> Builds finished. The artifacts of successful builds are:
--> centos-7: AMIs were created:
us-west-2: ami-0b5f91ff66c0d5bb7

--> centos-7: AMIs were created:
us-west-2: ami-0b5f91ff66c0d5bb7
```
```
[root@ip-172-31-25-100 centos]# kubeadm version
kubeadm version: &version.Info{Major:"1", Minor:"21", GitVersion:"v1.21.3", GitCommit:"ca643a4d1f7bfe34773c74f79527be4afd95bf39", GitTreeState:"clean", BuildDate:"2021-07-15T21:03:28Z", GoVersion:"go1.16.6", Compiler:"gc", Platform:"linux/amd64"}
[root@ip-172-31-25-100 centos]# kubelet --version
Kubernetes v1.21.3
[root@ip-172-31-25-100 centos]# containerd --version
containerd containerd.io 1.4.7 3194fb46e8311ae0eeae5a7a5843573adfebb16d
[root@ip-172-31-25-100 centos]# crictl images
IMAGE                                TAG                 IMAGE ID            SIZE
k8s.gcr.io/coredns/coredns           v1.8.0              296a6d5035e2d       12.9MB
k8s.gcr.io/etcd                      3.4.13-0            0369cf4303ffd       86.7MB
k8s.gcr.io/kube-apiserver            v1.21.3             3d174f00aa39e       30.5MB
k8s.gcr.io/kube-controller-manager   v1.21.3             bc2bb319a7038       29.4MB
k8s.gcr.io/kube-proxy                v1.21.3             adb2816ea823a       35.9MB
k8s.gcr.io/kube-scheduler            v1.21.3             6be0dc1302e30       14.5MB
k8s.gcr.io/pause                     3.4.1               0f8457a4c2eca       301kB
```