### PR TITLE
fix: remove refs to subscription manager

### DIFF
--- a/ansible/molecule/ec2_full/molecule.yml
+++ b/ansible/molecule/ec2_full/molecule.yml
@@ -39,6 +39,20 @@ platforms:
     region: us-east-1
     instance_type: t3.small
     ssh_user: ec2-user
+  - name: konvoyimage-rhel7.9-${USER:-ci}-${HOSTNAME:-local}
+    image_search_name: "RHEL-7.9_HVM-*"
+    image_search_owner: "309956199498"
+    region: us-east-1
+    instance_type: p2.xlarge
+    spot_price: false
+    ssh_user: ec2-user
+  - name: konvoyimage-rhel8.4-${USER:-ci}-${HOSTNAME:-local}
+    image_search_name: "RHEL-8.4.0_HVM-*"
+    image_search_owner: "309956199498"
+    region: us-east-1
+    instance_type: p2.xlarge
+    spot_price: false
+    ssh_user: ec2-user
 
 provisioner:
   name: ansible

--- a/ansible/molecule/ec2_full/molecule.yml
+++ b/ansible/molecule/ec2_full/molecule.yml
@@ -43,14 +43,14 @@ platforms:
     image_search_name: "RHEL-7.9_HVM-*"
     image_search_owner: "309956199498"
     region: us-east-1
-    instance_type: p2.xlarge
+    instance_type: t3.small
     spot_price: false
     ssh_user: ec2-user
   - name: konvoyimage-rhel8.4-${USER:-ci}-${HOSTNAME:-local}
     image_search_name: "RHEL-8.4.0_HVM-*"
     image_search_owner: "309956199498"
     region: us-east-1
-    instance_type: p2.xlarge
+    instance_type: t3.small
     spot_price: false
     ssh_user: ec2-user
 

--- a/ansible/roles/packages/tasks/install-redhat.yaml
+++ b/ansible/roles/packages/tasks/install-redhat.yaml
@@ -1,9 +1,15 @@
 ---
+- name: add epel gpg key
+  rpm_key:
+    state: present
+    key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
+  when:
+    - ansible_distribution_major_version == '8'
+
 - name: install epel-release
   yum:
-    name: epel-release
+    name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
     state: present
-    update_cache: true
 
 - name: install common RPMS
   yum:

--- a/ansible/roles/sysprep/tasks/redhat.yml
+++ b/ansible/roles/sysprep/tasks/redhat.yml
@@ -26,18 +26,6 @@
     masked: true
   when: ansible_memory_mb.swap.total != 0
 
-- name: Remove RHEL subscription
-  block:
-    - name: Remove subscriptions
-      rhsm_repository:
-        name: '*'
-        state: absent
-    - name: Unregister system
-      redhat_subscription:
-        state: absent
-    - name: clean local subscription data
-      command: subscription-manager clean
-  when: ansible_distribution == "RedHat"
 
 - name: Remove yum package caches
   yum:


### PR DESCRIPTION
Image builder, which this tool is based off of states that we need subscription manager to build rhel images. This PR removes that dependency by using the public key and repository directly. 


RHEL 8 GPG key bits taken from here https://github.com/ansible/ansible/issues/71634#issuecomment-687229416