### PR TITLE
fix: use dev/xvda as default volume for flatcar

### DIFF
--- a/images/ami/flatcar.yaml
+++ b/images/ami/flatcar.yaml
@@ -10,7 +10,7 @@ packer:
   distribution_version: "Stable"
   # Other variables:
   ssh_username: "core"
-  root_device_name: "/dev/sda1"
+  root_device_name: "/dev/xvda"
 
 build_name: "flatcar-stable"
 packer_builder_type: "amazon"


### PR DESCRIPTION
I was able to get p2 and m5 instances to boot with the following AMI 

```
us-west-2: ami-04dda24fc991fe75a
```

```
{
    "Images": [
        {
            "Architecture": "x86_64",
            "CreationDate": "2021-08-17T21:37:40.000Z",
            "ImageId": "ami-04dda24fc991fe75a",
            "ImageLocation": "999867407951/konvoy-ami-flatcar-stable-1.21.3-1629235858",
            "ImageType": "machine",
            "Public": true,
            "OwnerId": "999867407951",
            "PlatformDetails": "Linux/UNIX",
            "UsageOperation": "RunInstances",
            "State": "available",
            "BlockDeviceMappings": [
                {
                    "DeviceName": "/dev/xvda",
                    "Ebs": {
                        "DeleteOnTermination": true,
                        "Iops": 3000,
                        "SnapshotId": "snap-00a43140346afe811",
                        "VolumeSize": 10,
                        "VolumeType": "gp3",
                        "Throughput": 125,
                        "Encrypted": false
                    }
                },
                {
                    "DeviceName": "/dev/xvdb",
                    "VirtualName": "ephemeral0"
                }
            ],
            "Description": "Konvoy base for Kubernetes 1.21.3 on Flatcar-Stable",
            "EnaSupport": true,
            "Hypervisor": "xen",
            "Name": "konvoy-ami-flatcar-stable-1.21.3-1629235858",
            "RootDeviceName": "/dev/xvda",
            "RootDeviceType": "ebs",
            "SriovNetSupport": "simple",
            "Tags": [
                {
                    "Key": "source_ami",
                    "Value": "ami-0459c48186a4a3839"
                },
                {
                    "Key": "distribution_version",
                    "Value": "Stable"
                },
                {
                    "Key": "build_timestamp",
                    "Value": "1629235858"
                },
                {
                    "Key": "image_builder_version",
                    "Value": "0.0.1"
                },
                {
                    "Key": "build_date",
                    "Value": "2021-08-17T21:30:58Z"
                },
                {
                    "Key": "distribution",
                    "Value": "Flatcar"
                },
                {
                    "Key": "kubernetes_cni_version",
                    "Value": ""
                },
                {
                    "Key": "kubernetes_version",
                    "Value": "1.21.3"
                },
                {
                    "Key": "containerd_version",
                    "Value": "1.5.4"
                }
            ],
            "VirtualizationType": "hvm"
        }
    ]
}
```

This was properly able to spin a p2 instance see screenshot

![Screenshot from 2021-08-17 15-08-34](https://user-images.githubusercontent.com/5673456/129807188-77a1c9f9-073f-4cfb-a69c-82eaa21246c3.png)

As well as a m5 
![Screenshot from 2021-08-17 15-09-37](https://user-images.githubusercontent.com/5673456/129807253-dfc4bc63-ac9e-4493-8bbe-f5e950a084b9.png)

