### PR TITLE
fix: use dev/xvda as default volume for flatcar

### DIFF
--- a/docs/cli/konvoy-image_provision.md
+++ b/docs/cli/konvoy-image_provision.md
@@ -9,7 +9,7 @@ konvoy-image provision <inventory.yaml|hostname,> [flags]
 ### Examples
 
 ```
-build ./inventory.yaml
+provision --inventory-file inventory.yaml images/generic/centos-7.yaml
 ```
 
 ### Options
@@ -17,6 +17,9 @@ build ./inventory.yaml
 ```
       --extra-vars stringArray   flag passed Ansible's extra-vars
   -h, --help                     help for provision
+      --inventory-file string    an ansible inventory defining your infrastructure
+      --overrides stringArray    a list of override YAML files
+      --provider string          specify a provider if you wish to install provider specific utilities
 ```
 
 ### Options inherited from parent commands

--- a/images/ami/flatcar.yaml
+++ b/images/ami/flatcar.yaml
@@ -10,7 +10,7 @@ packer:
   distribution_version: "Stable"
   # Other variables:
   ssh_username: "core"
-  root_device_name: "/dev/sda1"
+  root_device_name: "/dev/xvda"
 
 build_name: "flatcar-stable"
 packer_builder_type: "amazon"


### PR DESCRIPTION
pulled out of the gpu feature branch to get it landed asap.

The upstream/base image is not offering an `/dev/sda1` volume, instead just a `xvda`. We need to match the upstream image block device setup.