### PR TITLE
feat: adds instance type override option to build app

### DIFF
--- a/cmd/konvoy-image/cmd/args.go
+++ b/cmd/konvoy-image/cmd/args.go
@@ -21,4 +21,5 @@ func addAWSUserArgs(fs *pflag.FlagSet, userArgs *app.UserArgs) {
 	fs.StringVar(&userArgs.SourceAMI, "source-ami", "", "a specific ami available in the builder region to source from")
 	fs.StringVar(&userArgs.AMIFilterName, "source-ami-filter-name", "", "a ami name filter on for selecting the source image")
 	fs.StringVar(&userArgs.AMIFilterOwner, "source-ami-filter-owner", "", "only search AMIs belonging to this owner id")
+	fs.StringVar(&userArgs.AWSInstanceType, "aws-instance-type", "", "an instance type available in the builder region to work on")
 }

--- a/pkg/app/build.go
+++ b/pkg/app/build.go
@@ -41,6 +41,7 @@ const (
 	packerFilterOwnerKey       = "ami_filter_owners"
 	packerBuilderRegionKey     = "aws_region"
 	packerAMIRegionsKey        = "ami_regions"
+	packerInstanceType         = "aws_instance_type"
 
 	ansibleVarsFilename = "ansible_vars.yaml"
 )
@@ -73,6 +74,7 @@ type UserArgs struct {
 	AMIFilterOwner   string   `json:"ami_filter_owner"`
 	AWSBuilderRegion string   `json:"aws_region"`
 	AMIRegions       []string `json:"ami_regions"`
+	AWSInstanceType  string   `json:"aws_instance_type"`
 }
 
 type ClusterArgs struct {
@@ -391,6 +393,10 @@ func mergeUserArgs(config map[string]interface{}, initOptions InitOptions) {
 
 	if initOptions.UserArgs.AMIFilterOwner != "" {
 		packerMap[packerFilterOwnerKey] = initOptions.UserArgs.AMIFilterOwner
+	}
+
+	if initOptions.UserArgs.AWSInstanceType != "" {
+		packerMap[packerInstanceType] = initOptions.UserArgs.AWSInstanceType
 	}
 
 	if len(initOptions.UserArgs.AMIRegions) > 0 {

--- a/pkg/packer/manifests/aws/packer.json.tmpl
+++ b/pkg/packer/manifests/aws/packer.json.tmpl
@@ -8,6 +8,7 @@
     "aws_profile": "",
     "aws_region": "us-west-2",
     "aws_secret_key": "",
+    "aws_instance_type": "t3.small",
     "build_timestamp": "{{timestamp}}",
     "encrypted": "false",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
@@ -33,7 +34,7 @@
     {
       "name": "{{(user `distribution`) | lower}}-{{user `distribution_version`}}{{user `build_name_extra`}}",
       "type": "amazon-ebs",
-      "instance_type": "t3.small",
+      "instance_type": "{{user `aws_instance_type`}}",
       ((- if .SourceAMIDefined ))
       "source_ami": "{{user `source_ami`}}",
       ((- else ))


### PR DESCRIPTION
We need to be able to make sure that flatcar images are built on p2.xlarge instances. 

I would like to avoid the command line option and instead have this somehow based on the parameters given. Don't know how though. In this specific case, we need to enable p2.xlarge when a user selected flatcar and enabled gpu overrides.