### PR TITLE
fix flatcar containerd config

### DIFF
--- a/ansible/roles/packages/templates/config.toml.tmpl
+++ b/ansible/roles/packages/templates/config.toml.tmpl
@@ -140,7 +140,7 @@ imports = ["/etc/containerd/config-konvoy-*.toml"]
   [plugins."io.containerd.runtime.v1.linux"]
     shim = "containerd-shim"
 {% if gpu is defined and 'nvidia' in gpu.types  %}
-    runtime = "/usr/bin/nvidia-container-runtime"
+    runtime = "nvidia-container-runtime"
 {% else %}
     runtime = "runc"
 {% endif %}


### PR DESCRIPTION
The nvidia-container-runtime is in the path of containerd, in should not need an absolute path. Especially not an incorrect one.