### PR TITLE
chore: switched flatcar to start with containerd.sock

### DIFF
--- a/images/ami/flatcar.yaml
+++ b/images/ami/flatcar.yaml
@@ -26,8 +26,6 @@ sysusr_prefix: /opt
 sysusrlocal_prefix: /opt
 systemd_prefix: /etc/systemd
 
-containerd_cri_socket: /run/docker/libcontainerd/docker-containerd.sock
-
 containerd_flatcar_bins:
   - ctr
   - containerd


### PR DESCRIPTION
We have to discuss this. It enables flatcar GPU images to properly provide working access to containers via `ctr` as well as `docker` but somehow entirely prevents a proper deployment via `kubeadm`. 


