### PR TITLE
feat: flatcar gpu support

### DIFF
--- a/ansible/roles/gpu/files/Dockerfile.ubuntu
+++ b/ansible/roles/gpu/files/Dockerfile.ubuntu
@@ -1,7 +1,7 @@
-FROM ubuntu
+FROM ubuntu@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3
 RUN apt update && apt install gpg curl -y
 RUN distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
     && curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey |  apt-key add - \
     && curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | tee /etc/apt/sources.list.d/nvidia-docker.list
 
-RUN  apt-get update &&  apt-get install -y nvidia-container-runtime
+RUN  apt-get update &&  apt-get install -y nvidia-container-runtime=3.5.0-1 -V

--- a/ansible/roles/gpu/files/Dockerfile.ubuntu
+++ b/ansible/roles/gpu/files/Dockerfile.ubuntu
@@ -1,0 +1,7 @@
+FROM ubuntu
+RUN apt update && apt install gpg curl -y
+RUN distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
+    && curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey |  apt-key add - \
+    && curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | tee /etc/apt/sources.list.d/nvidia-docker.list
+
+RUN  apt-get update &&  apt-get install -y nvidia-container-runtime

--- a/ansible/roles/gpu/tasks/nvidia-gpu-Flatcar.yaml
+++ b/ansible/roles/gpu/tasks/nvidia-gpu-Flatcar.yaml
@@ -201,6 +201,17 @@
     dest: "/opt/lib/x86_64-linux-gnu/libnvidia-container.so"
     state: link
 
+- name: copy ubuntu build Dockerfile to copy container-hook binary
+  copy:
+    src: "./Dockerfile.ubuntu"
+    dest: "/tmp/Dockerfile.ubuntu"
+
+- name: build the ubuntu image
+  command: docker build -f /tmp/Dockerfile.ubuntu --tag hook-build ./
+
+- name: copy hook from image
+  command: docker run -v /opt/bin:/opt/bin -w /opt/bin hook-build:latest cp /bin/nvidia-container-runtime-hook .
+
 - name: run ldconfig
   command: ldconfig /opt/lib/x86_64-linux-gnu
 

--- a/ansible/roles/gpu/tasks/nvidia-gpu-Flatcar.yaml
+++ b/ansible/roles/gpu/tasks/nvidia-gpu-Flatcar.yaml
@@ -210,7 +210,7 @@
   command: docker build -f /tmp/Dockerfile.ubuntu --tag hook-build ./
 
 - name: copy hook from image
-  command: docker run -v /opt/bin:/opt/bin -w /opt/bin hook-build:latest cp /bin/nvidia-container-runtime-hook .
+  command: docker run -v /opt/bin:/opt/bin -w /opt/bin hook-build:latest cp -L /bin/nvidia-container-runtime-hook .
 
 - name: run ldconfig
   command: ldconfig /opt/lib/x86_64-linux-gnu

--- a/ansible/roles/packages/templates/config.toml.tmpl
+++ b/ansible/roles/packages/templates/config.toml.tmpl
@@ -75,6 +75,7 @@ imports = ["/etc/containerd/config-konvoy-*.toml"]
     [plugins."io.containerd.grpc.v1.cri".containerd]
       snapshotter = "overlayfs"
 {% if gpu is defined and 'nvidia' in gpu.types %}
+      default_runtime_name = "nvidia-container-runtime"
 {% else %}
       default_runtime_name = "runc"
 {% endif %}

--- a/ansible/roles/packages/templates/config.toml.tmpl
+++ b/ansible/roles/packages/templates/config.toml.tmpl
@@ -75,7 +75,6 @@ imports = ["/etc/containerd/config-konvoy-*.toml"]
     [plugins."io.containerd.grpc.v1.cri".containerd]
       snapshotter = "overlayfs"
 {% if gpu is defined and 'nvidia' in gpu.types %}
-      default_runtime_name = "nvidia-container-runtime"
 {% else %}
       default_runtime_name = "runc"
 {% endif %}


### PR DESCRIPTION
Fixes socket mixup introduced via https://github.com/mesosphere/konvoy-image-builder/commit/8cf3a5ffbeecae2a9c4ad141834007975a476fbe#diff-6cd7dde3b0707c4663c2e23028d4da79899f916586421e3364621480207aaf71 and copies a needed binary to have nvidia-container-runtime work