### PR TITLE
fix: set docker containerd shim socket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,14 @@ flatcar: build flatcar-version.yaml
 flatcar: ## Build flatcar image
 	./bin/konvoy-image build images/ami/flatcar.yaml --overrides flatcar-version.yaml
 
+.PHONY: flatcar-nvidia
+flatcar-nvidia: build flatcar-version.yaml
+flatcar-nvidia: ## Build flatcar image
+	./bin/konvoy-image build --region us-west-2 \
+	--aws-instance-type p2.xlarge \
+	images/ami/flatcar.yaml \
+	--overrides overrides/nvidia.yaml
+
 .PHONY: dev
 dev: ## dev build
 dev: clean generate build lint test mod-tidy build.snapshot

--- a/ansible/vars/flatcar/flatcar.yaml
+++ b/ansible/vars/flatcar/flatcar.yaml
@@ -3,6 +3,7 @@ containerd_sha256: "2697a342e3477c211ab48313e259fd7e32ad1f5ded19320e6a559f50a82b
 
 ansible_python_interpreter: /opt/bin/python
 python_path: /opt/bin/builder-env/site-packages
+containerd_cri_socket: /run/docker/libcontainerd/docker-containerd.sock
 
 sysusr_prefix: /opt
 sysusrlocal_prefix: /opt


### PR DESCRIPTION
Fixes socket mixup introduced via https://github.com/mesosphere/konvoy-image-builder/commit/8cf3a5ffbeecae2a9c4ad141834007975a476fbe#diff-6cd7dde3b0707c4663c2e23028d4da79899f916586421e3364621480207aaf71 