### PR TITLE
fix: restart containerd upon reconfig

### DIFF
--- a/ansible/roles/packages/tasks/install-flatcar.yaml
+++ b/ansible/roles/packages/tasks/install-flatcar.yaml
@@ -13,7 +13,8 @@
   template:
     src: "config.toml.tmpl"
     dest: "/etc/containerd/config.toml"
-
+  notify:
+    - restart containerd
 
 - name: Fail if pre-installed containerd version does not match for Flatcar
   shell: containerd --version | cut -d\  -f 3

--- a/ansible/roles/packages/tasks/install.yaml
+++ b/ansible/roles/packages/tasks/install.yaml
@@ -27,6 +27,8 @@
   template:
     src: "config.toml.tmpl"
     dest: "/etc/containerd/config.toml"
+  notify:
+    - restart containerd
 
 - name: create containerd proxy conf
   template:


### PR DESCRIPTION
Upon containerd reconfiguraiton, we should restart containerd so that it picks up the new configuration. This PR restarts containerd when the config.toml is updated on RedHat based OSes.

Flatcar will require additional changes to implement this.