### PR TITLE
feat: push image on release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .cache
 .git
 dist/
+*.swp

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -25,9 +25,17 @@ jobs:
         env:
           WHAT: make build.snapshot
 
+      - name: Docker Login
+        uses: docker/login-action@v1
+        with:
+          registry: docker.io
+          username: mesosphereci
+          password: ${{ secrets.DOCKER_PASS }}
+
       - name: Release
         if: startsWith(github.ref, 'refs/tags/')
         run: make devkit.run
         env:
+          DOCKER_CLI_EXPERIMENTAL: "enabled"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WHAT: make release

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -95,9 +95,12 @@ dockers:
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.source={{ .GitURL }}"
       - "--platform=linux/amd64"
-    skip_push: true
+    skip_push: auto
     extra_files:
       - bin
+      - images
+      - ansible
+      - packer
 
 archives:
   - id: konvoy-image-bundle

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,8 @@ RUN apk add --no-cache \
 COPY --from=devkit /usr/local/bin/packer /usr/local/bin/
 COPY --from=devkit /usr/local/bin/packer-provisioner-goss /usr/local/bin/
 COPY bin/konvoy-image /usr/local/bin
-
+COPY images /root/images
+COPY ansible /root/ansible
+COPY packer /root/packer
+WORKDIR /root
 ENTRYPOINT ["/usr/local/bin/konvoy-image"]


### PR DESCRIPTION
Configures the goreleaser release job to push the docker image. The `auto` option ignores pushes for pre-releases https://goreleaser.com/customization/docker_manifest/


Related JIRA: https://jira.d2iq.com/browse/D2IQ-78865