### PR TITLE
fix: use "v" in versions

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
       - -trimpath
     ldflags:
       - -s -w
-      - -X {{ .ModulePath }}/pkg/version.version={{ .Version }}
+      - -X {{ .ModulePath }}/pkg/version.version=v{{trimprefix .Version "v"}}
       - -X {{ .ModulePath }}/pkg/version.major={{ .Major }}
       - -X {{ .ModulePath }}/pkg/version.minor={{ .Minor }}
       - -X {{ .ModulePath }}/pkg/version.patch={{ .Patch }}
@@ -41,7 +41,7 @@ builds:
       - EMBED_DOCKER_IMAGE
     ldflags:
       - -s -w
-      - -X {{ .ModulePath }}/pkg/version.version={{ .Version }}
+      - -X {{ .ModulePath }}/pkg/version.version=v{{trimprefix .Version "v"}}
       - -X {{ .ModulePath }}/pkg/version.major={{ .Major }}
       - -X {{ .ModulePath }}/pkg/version.minor={{ .Minor }}
       - -X {{ .ModulePath }}/pkg/version.patch={{ .Patch }}
@@ -72,7 +72,7 @@ dockers:
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.name={{ .ProjectName }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - '--label=org.opencontainers.image.version=v{{trimprefix .Version "v"}}'
       - "--label=org.opencontainers.image.source={{ .GitURL }}"
       - "--platform=linux/amd64"
     skip_push: true
@@ -92,7 +92,7 @@ dockers:
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.name={{ .ProjectName }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - '--label=org.opencontainers.image.version=v{{trimprefix .Version "v"}}'
       - "--label=org.opencontainers.image.source={{ .GitURL }}"
       - "--platform=linux/amd64"
     skip_push: auto


### PR DESCRIPTION
Saw an issue when using the latest v1.1.0 version, the image tagged is `mesosphere/konvoy-image-builder:v1.1.0` but the wrapper is looking for `mesosphere/konvoy-image-builder:1.1.0`

This because its based on the `version` see [here](https://github.com/mesosphere/konvoy-image-builder/blob/ed8c4ebdb27134af905dd483545c77434e4e92f5/cmd/konvoy-image-wrapper/image/common.go#L29) and with goreleaser the version being set was without the "v".
The previous v1.0.0 had the "v" from the [Makefile](https://github.com/mesosphere/konvoy-image-builder/blob/main/Makefile#L10).

```
➜  konvoy-image-bundle-v1.1.0_darwin_amd64 ./konvoy-image --version
e2eb06d8af82: Loading layer [==================================================>]  5.865MB/5.865MB
8282b5af8ab6: Loading layer [==================================================>]  375.5MB/375.5MB
136db300ce88: Loading layer [==================================================>]  144.8MB/144.8MB
dacc21848556: Loading layer [==================================================>]  24.36MB/24.36MB
0504e495aaca: Loading layer [==================================================>]   4.07MB/4.07MB
feda72a5897a: Loading layer [==================================================>]  15.87kB/15.87kB
9a36b8f578e2: Loading layer [==================================================>]  245.8kB/245.8kB
d3687902ece7: Loading layer [==================================================>]  6.656kB/6.656kB
Loaded image: mesosphere/konvoy-image-builder:v1.1.0
Unable to find image 'mesosphere/konvoy-image-builder:1.1.0' locally
docker: Error response from daemon: manifest for mesosphere/konvoy-image-builder:1.1.0 not found: manifest unknown: manifest unknown.
See 'docker run --help'.
error encountered: exit status 125
```