### PR TITLE
Increased retries for SLES

### DIFF
--- a/ansible/roles/gpu/tasks/nvidia-gpu-SLES15.yaml
+++ b/ansible/roles/gpu/tasks/nvidia-gpu-SLES15.yaml
@@ -28,18 +28,22 @@
     autorefresh: true
   register: cuda_repo_installation_rpm
   until: cuda_repo_installation_rpm is success
-  retries: 3
+  retries: 15
   delay: 3
 
 - name: Install current kernel devel
   zypper:
     name: "kernel-{{ ansible_kernel | regex_search('.*-(\\w+)$', '\\1') | first }}-devel={{ ansible_kernel | regex_search('(.*)-\\w+$', '\\1') | first }}"
     state: present
+  retries: 15
+  delay: 3
 
 - name: Install Nvidia drivers
   zypper:
     name: cuda-drivers-{{ nvidia_cuda_version }}
     state: present
+  retries: 15
+  delay: 3
 
 - name: Import libnvidia-container repository key
   rpm_key:
@@ -58,6 +62,8 @@
   zypper:
     name: libnvidia-container1
     state: present
+  retries: 15
+  delay: 3
 
 - name: Import nvidia-container-runtime repository key
   rpm_key:
@@ -71,13 +77,19 @@
     autorefresh: true
     repo: "{{ nvidia_container_runtime_repo_sles }}"
   changed_when: false # zypper repo is updating for this resource all the time
+  retries: 15
+  delay: 3
 
 - name: Install nvidia-container-tools
   zypper:
     name: libnvidia-container-tools
     state: present
+  retries: 15
+  delay: 3
 
 - name: Install nvidia-container-runtime
   zypper:
     name: "{{ nvidia_container_runtime_package }}"
     state: present
+  retries: 15
+  delay: 3

--- a/ansible/roles/gpu/tasks/nvidia-gpu-SLES15.yaml
+++ b/ansible/roles/gpu/tasks/nvidia-gpu-SLES15.yaml
@@ -10,17 +10,17 @@
   changed_when: "'Successfully registered' in connect_register.stdout"
   when: not 'PackageHub' in suseconnect_status.stdout
 
-- name: import CUDA rpm repository key
+- name: Import CUDA rpm repository key
   rpm_key:
     state: present
     key: "{{ nvidia_repo_gpgkey }}"
 
-- name: import Nvidia repository key
+- name: Import Nvidia repository key
   rpm_key:
     state: present
     key: "{{ nvidia_repo_gpgkey }}"
 
-- name: Add NVIDIA repo
+- name: Add Nvidia repo
   zypper_repository:
     name: cuda
     repo: "{{ nvidia_repo_baseurl }}"
@@ -41,7 +41,7 @@
     name: cuda-drivers-{{ nvidia_cuda_version }}
     state: present
 
-- name: import libnvidia-container repository key
+- name: Import libnvidia-container repository key
   rpm_key:
     state: present
     key: "{{ libnvidia_container_repo_gpgkey }}"
@@ -54,12 +54,12 @@
     repo: "{{ libnvidia_container_repo_sles }}"
   changed_when: false # zypper repo is updating for this resource all the time
 
-- name: install libnvidia-container
+- name: Install libnvidia-container
   zypper:
     name: libnvidia-container1
     state: present
 
-- name: import nvidia-container-runtime repository key
+- name: Import nvidia-container-runtime repository key
   rpm_key:
     state: present
     key: "{{ nvidia_container_runtime_repo_gpgkey }}"

--- a/ansible/roles/packages/tasks/install-suse.yaml
+++ b/ansible/roles/packages/tasks/install-suse.yaml
@@ -18,7 +18,7 @@
     state: present
   register: result
   until: result is success
-  retries: 5
+  retries: 15
   delay: 3
 
 - name: check if versionlock exists


### PR DESCRIPTION
In two control runs we saw two failures that might be retryable:


```
TASK [gpu : Install Nvidia drivers]
[...]
Failed to provide Package libX11-data-1.6.5-3.21.1.noarch (SLE-Module-Basesystem15-SP3-Updates). Do you want to retry retrieval?
```

```
TASK [packages : install common packages]
[...]
sles-15: fatal: [default]: FAILED! => {"attempts": 5, "changed": false, "cmd": ["/usr/bin/zypper", "--quiet", "--non-interactive", "--xmlout", "install", "--type", "package", "--auto-agree-with-licenses", "--no-recommends", "--", "+audit", "+conntrack-tools", "+open-vm-tools", "+python3-pip", "+python3-netifaces", "+socat", "+sysstat", "+nfs-utils"], "msg": "Zypper run command failed with return code 1.", "rc": 1, "stderr": "", "stderr_lines": [], "stdout": "<?xml version='1.0'?>\n<stream>\n<message type=\"error\">Unexpected 
```

In another run I also saw multiple instances of retries happening:
```
     sles-15: TASK [packages : add Konvoy Containerd rpm repository] *************************
16:02:59
      sles-15: FAILED - RETRYING: add Konvoy Containerd rpm repository (15 retries left).
16:03:10
      sles-15: FAILED - RETRYING: add Konvoy Containerd rpm repository (14 retries left).
16:03:21
      sles-15: FAILED - RETRYING: add Konvoy Containerd rpm repository (13 retries left).
16:03:31
      sles-15: FAILED - RETRYING: add Konvoy Containerd rpm repository (12 retries left).
16:03:42
      sles-15: FAILED - RETRYING: add Konvoy Containerd rpm repository (11 retries left).
16:03:53
      sles-15: FAILED - RETRYING: add Konvoy Containerd rpm repository (10 retries left).
16:04:04
      sles-15: FAILED - RETRYING: add Konvoy Containerd rpm repository (9 retries left).
16:04:15
      sles-15: changed: [default]
```
This hints that 5 retries are often times not enough.


The nvidia installation did not have any retries at all, adding some.
The common package installation did have a retry set to 5 but maybe that is not enough as @fatz also hinted to me.