### PR TITLE
bump crictl

### DIFF
--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -8,7 +8,7 @@ coredns_version: "1.8.0"
 pause_image_version: "3.4.1"
 # TODO: figure out where this image is used and why the Kubelet tries to pull it
 pause_image_version_prev: "3.2"
-crictl_version: "1.20.0"
+crictl_version: "1.22.0"
 kfips_version: "0.1.0"
 
 # https://github.com/containerd/containerd/releases/download/v1.4.7/cri-containerd-cni-1.4.7-linux-amd64.tar.gz

--- a/docs/cli/konvoy-image_provision.md
+++ b/docs/cli/konvoy-image_provision.md
@@ -9,7 +9,7 @@ konvoy-image provision <inventory.yaml|hostname,> [flags]
 ### Examples
 
 ```
-provision --inventory-file inventory.yaml images/generic/centos-7.yaml
+provision --inventory-file inventory.yaml
 ```
 
 ### Options


### PR DESCRIPTION
This only effects flatcar installations. The kubelet packages depends on a specific version of cri-tools for debian and rpm bases systems. 