### PR TITLE
fix: don't run goreleaser on PRs

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -3,9 +3,6 @@ name: GoReleaser
 
 # yamllint disable-line rule:truthy
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main

--- a/Dockerfile.devkit
+++ b/Dockerfile.devkit
@@ -1,5 +1,5 @@
 #
-FROM hashicorp/packer:1.7.8 as packer
+FROM hashicorp/packer:1.7.7 as packer
 FROM golangci/golangci-lint:v1.42.1-alpine as golangci-lint
 FROM goreleaser/goreleaser:v0.183.0 as goreleaser
 FROM docker:20.10 as docker

--- a/Dockerfile.devkit
+++ b/Dockerfile.devkit
@@ -1,5 +1,5 @@
 #
-FROM hashicorp/packer:1.7.7 as packer
+FROM hashicorp/packer:1.7.8 as packer
 FROM golangci/golangci-lint:v1.42.1-alpine as golangci-lint
 FROM goreleaser/goreleaser:v0.183.0 as goreleaser
 FROM docker:20.10 as docker


### PR DESCRIPTION
We don't need to run this on PRs, only on merges to main and when we cut tags.