### PR TITLE
chore: refactor build to use epel params

### DIFF
--- a/ansible/roles/gpu/defaults/main.yaml
+++ b/ansible/roles/gpu/defaults/main.yaml
@@ -11,9 +11,6 @@ mirror_repo_baseurl: "http://mirror.centos.org/centos/{{ os_release_file['conten
 nvidia_repo_rpm: https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-repo-rhel7-10.1.168-1.x86_64.rpm
 nvidia_cuda_package: cuda-10-2
 nvidia_driver_package: "nvidia-driver-branch-{{ nvidia_cuda_version }}"
-epel_centos_7_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-epel_centos_8_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-epel_centos_8_rpm_gpg_key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
 nvidia_repo_distributionmap:
   CentOS: "rhel"
   RedHat: "rhel"

--- a/ansible/roles/packages/tasks/install-redhat.yaml
+++ b/ansible/roles/packages/tasks/install-redhat.yaml
@@ -2,14 +2,24 @@
 - name: add epel gpg key
   rpm_key:
     state: present
-    key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
+    key: "{{ epel_centos_8_rpm_gpg_key }}"
   when:
     - ansible_distribution_major_version == '8'
 
 - name: install epel-release
   yum:
-    name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
+    name: "{{ epel_centos_8_rpm }}"
     state: present
+  when:
+    - ansible_distribution_major_version == '8'
+
+- name: install epel-release
+  yum:
+    name: "{{ epel_centos_7_rpm }}"
+    state: present
+  when:
+    - ansible_distribution_major_version == '7'
+
 
 - name: install common RPMS
   yum:

--- a/ansible/roles/packages/tasks/install-redhat.yaml
+++ b/ansible/roles/packages/tasks/install-redhat.yaml
@@ -6,6 +6,13 @@
   when:
     - ansible_distribution_major_version == '8'
 
+- name: add epel gpg key
+  rpm_key:
+    state: present
+    key: "{{ epel_centos_7_rpm_gpg_key }}"
+  when:
+    - ansible_distribution_major_version == '7'
+
 - name: install epel-release
   yum:
     name: "{{ epel_centos_8_rpm }}"

--- a/cmd/konvoy-image-wrapper/cmd/wrapper.go
+++ b/cmd/konvoy-image-wrapper/cmd/wrapper.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	envAWSCredentialsFile = "AWS_SHARED_CREDENTIALS_FILE"
+	envAWSCredentialsFile = "AWS_SHARED_CREDENTIALS_FILE" //nolint:gosec // environment var set by user
 
 	envAWSDefaultRegion = "AWS_DEFAULT_REGION"
 	envAWSRegion        = "AWS_REGION"

--- a/images/common.yaml
+++ b/images/common.yaml
@@ -24,6 +24,7 @@ sysusrlocal_prefix: /usr/local
 epel_centos_7_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 epel_centos_8_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 epel_centos_8_rpm_gpg_key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
+epel_centos_7_rpm_gpg_key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
 
 
 kubernetes_goarch: amd64

--- a/images/common.yaml
+++ b/images/common.yaml
@@ -21,6 +21,10 @@ containerd_cri_socket: /run/containerd/containerd.sock
 systemd_prefix: /usr/lib/systemd/site-packages
 sysusr_prefix: /usr
 sysusrlocal_prefix: /usr/local
+epel_centos_7_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+epel_centos_8_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+epel_centos_8_rpm_gpg_key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
+
 
 kubernetes_goarch: amd64
 kubernetes_bins:


### PR DESCRIPTION
Allows the user to specify an epel source that can be different from the upstream ones. This allows the user to download packages from their own local mirror or yum repository