### PR TITLE
chore: remove double dash from fips.yaml

### DIFF
--- a/overrides/fips.yaml
+++ b/overrides/fips.yaml
@@ -1,4 +1,3 @@
----
 fips:
   enabled: true
   etcdImageTag: v3.4.13_fips


### PR DESCRIPTION
Without this, the konvoy2 build-image.sh script will possibly create an override.yaml that has a `--` in its middle.