### PR TITLE
feat: RHEL 8.4, RHEL 8.2 & RHEL 7.9 GPU support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,16 @@ rhel79-nvidia: ## Build RHEL 7.9 image with GPU support
 	--overrides overrides/nvidia.yaml \
 	--aws-instance-type p2.xlarge
 
+.PHONY: sles15
+sles15: build
+sles15: ## Build SLES 15 image
+	./bin/konvoy-image build images/ami/sles-15.yaml
+
+.PHONY: sles15-nvidia
+sles15-nvidia: build
+sles15-nvidia: ## Build SLES 15 image with GPU support
+	./bin/konvoy-image build images/ami/sles-15.yaml --overrides overrides/nvidia.yaml
+
 flatcar-version.yaml:
 	./hack/fetch-flatcar-ami.sh
 

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,9 @@ rhel8: ## Build RHEL 8.2 image
 .PHONY: rhel8-nvidia
 rhel8-nvidia: build
 rhel8-nvidia: ## Build RHEL 8.2 image with GPU support
-	./bin/konvoy-image build images/ami/rhel-8.yaml --overrides overrides/nvidia.yaml
+	./bin/konvoy-image build images/ami/rhel-8.yaml \
+	--overrides overrides/nvidia.yaml \
+	--aws-instance-type p2.xlarge
 
 .PHONY: rhel84
 rhel84: build
@@ -180,7 +182,9 @@ rhel84: ## Build RHEL 8.4 image
 .PHONY: rhel84-nvidia
 rhel84-nvidia: build
 rhel84-nvidia: ## Build RHEL 8.4 image with GPU support
-	./bin/konvoy-image build images/ami/rhel-84.yaml --overrides overrides/nvidia.yaml
+	./bin/konvoy-image build images/ami/rhel-84.yaml \
+	--overrides overrides/nvidia.yaml \
+	--aws-instance-type p2.xlarge
 
 flatcar-version.yaml:
 	./hack/fetch-flatcar-ami.sh

--- a/Makefile
+++ b/Makefile
@@ -162,15 +162,15 @@ centos8-nvidia: build
 centos8-nvidia: ## Build Centos 8 image with GPU support
 	./bin/konvoy-image build images/ami/centos-8.yaml --overrides overrides/nvidia.yaml
 
-.PHONY: rhel8
-rhel8: build
-rhel8: ## Build RHEL 8.2 image
-	./bin/konvoy-image build images/ami/rhel-8.yaml
+.PHONY: rhel82
+rhel82: build
+rhel82: ## Build RHEL 8.2 image
+	./bin/konvoy-image build images/ami/rhel-82.yaml
 
-.PHONY: rhel8-nvidia
-rhel8-nvidia: build
-rhel8-nvidia: ## Build RHEL 8.2 image with GPU support
-	./bin/konvoy-image build images/ami/rhel-8.yaml \
+.PHONY: rhel82-nvidia
+rhel82-nvidia: build
+rhel82-nvidia: ## Build RHEL 8.2 image with GPU support
+	./bin/konvoy-image build images/ami/rhel-82.yaml \
 	--overrides overrides/nvidia.yaml \
 	--aws-instance-type p2.xlarge
 

--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,18 @@ rhel84-nvidia: ## Build RHEL 8.4 image with GPU support
 	--overrides overrides/nvidia.yaml \
 	--aws-instance-type p2.xlarge
 
+.PHONY: rhel79
+rhel79: build
+rhel79: ## Build RHEL 7.9 image
+	./bin/konvoy-image build images/ami/rhel-79.yaml
+
+.PHONY: rhel79-nvidia
+rhel79-nvidia: build
+rhel79-nvidia: ## Build RHEL 7.9 image with GPU support
+	./bin/konvoy-image build images/ami/rhel-79.yaml \
+	--overrides overrides/nvidia.yaml \
+	--aws-instance-type p2.xlarge
+
 flatcar-version.yaml:
 	./hack/fetch-flatcar-ami.sh
 

--- a/ansible/molecule/ec2_full/molecule.yml
+++ b/ansible/molecule/ec2_full/molecule.yml
@@ -39,7 +39,7 @@ platforms:
     image_search_name: "RHEL-7.9_HVM-*"
     image_search_owner: "309956199498"
     region: us-east-1
-    instance_type: t3.small
+    instance_type: p2.xlarge
     spot_price: false
     ssh_user: ec2-user
   - name: konvoyimage-rhel8.2-${USER:-ci}-${HOSTNAME:-local}

--- a/ansible/molecule/ec2_full/molecule.yml
+++ b/ansible/molecule/ec2_full/molecule.yml
@@ -43,7 +43,7 @@ platforms:
     spot_price: false
     ssh_user: ec2-user
   - name: konvoyimage-rhel8.2-${USER:-ci}-${HOSTNAME:-local}
-    image_search_name: "RHEL-8.2*-x86_64-*"
+    image_search_name: "RHEL-8.2.0*2020*-x86_64-*"
     image_search_owner: "309956199498"
     region: us-east-1
     instance_type: t3.small

--- a/ansible/molecule/ec2_full/molecule.yml
+++ b/ansible/molecule/ec2_full/molecule.yml
@@ -42,6 +42,13 @@ platforms:
     instance_type: t3.small
     spot_price: false
     ssh_user: ec2-user
+  - name: konvoyimage-rhel8.2-${USER:-ci}-${HOSTNAME:-local}
+    image_search_name: "RHEL-8.2*-x86_64-*"
+    image_search_owner: "309956199498"
+    region: us-east-1
+    instance_type: t3.small
+    spot_price: false
+    ssh_user: ec2-user
   - name: konvoyimage-rhel8.4-${USER:-ci}-${HOSTNAME:-local}
     image_search_name: "RHEL-8.4.0_HVM-*"
     image_search_owner: "309956199498"

--- a/ansible/molecule/ec2_full/molecule.yml
+++ b/ansible/molecule/ec2_full/molecule.yml
@@ -53,7 +53,7 @@ platforms:
     image_search_name: "RHEL-8.4.0_HVM-*"
     image_search_owner: "309956199498"
     region: us-east-1
-    instance_type: t3.small
+    instance_type: p2.xlarge
     spot_price: false
     ssh_user: ec2-user
   - name: konvoyimage-sles15-sp3-${USER:-ci}-${HOSTNAME:-local}

--- a/ansible/molecule/ec2_full/molecule.yml
+++ b/ansible/molecule/ec2_full/molecule.yml
@@ -36,7 +36,7 @@ platforms:
     spot_price: false
     volume_name: /dev/xvda
   - name: konvoyimage-rhel7.9-${USER:-ci}-${HOSTNAME:-local}
-    image_search_name: "RHEL-7.9_HVM-*"
+    image_search_name: "RHEL-7.9*-x86_64-*"
     image_search_owner: "309956199498"
     region: us-east-1
     instance_type: p2.xlarge

--- a/ansible/molecule/ec2_gpu/molecule.yml
+++ b/ansible/molecule/ec2_gpu/molecule.yml
@@ -26,6 +26,13 @@ platforms:
     instance_type: p2.xlarge
     spot_price: false
     ssh_user: ec2-user
+  - name: konvoyimage-rhel8.2-${USER:-ci}-${HOSTNAME:-local}
+    image_search_name: "RHEL-8.2*-x86_64-*"
+    image_search_owner: "309956199498"
+    region: us-east-1
+    instance_type: p2.xlarge
+    spot_price: false
+    ssh_user: ec2-user
   - name: konvoyimage-rhel8.4-${USER:-ci}-${HOSTNAME:-local}
     image_search_name: "RHEL-8.4.0_HVM-*"
     image_search_owner: "309956199498"

--- a/ansible/molecule/ec2_gpu/molecule.yml
+++ b/ansible/molecule/ec2_gpu/molecule.yml
@@ -27,7 +27,7 @@ platforms:
     spot_price: false
     ssh_user: ec2-user
   - name: konvoyimage-rhel8.2-${USER:-ci}-${HOSTNAME:-local}
-    image_search_name: "RHEL-8.2*-x86_64-*"
+    image_search_name: "RHEL-8.2.0*2020*-x86_64-*"
     image_search_owner: "309956199498"
     region: us-east-1
     instance_type: p2.xlarge

--- a/ansible/roles/gpu/defaults/main.yaml
+++ b/ansible/roles/gpu/defaults/main.yaml
@@ -48,3 +48,6 @@ suse_packagehub_product: PackageHub/{{ ansible_distribution_version }}/{{ ansibl
 
 # the nvidia-container-runtime package no longer exists for rhel8 so we must install the last available version
 nvidia_container_runtime_package: "{{ 'nvidia-container-runtime' if ansible_distribution_major_version|int < 8 else 'nvidia-container-runtime-3.4.0-1.x86_64' }}"
+
+nvidia_runfile_installer: NVIDIA-Linux-x86_64-470.82.01.run
+nvidia_runfile_installer_url: "https://us.download.nvidia.com/tesla/470.82.01/{{ nvidia_runfile_installer }}"

--- a/ansible/roles/gpu/defaults/main.yaml
+++ b/ansible/roles/gpu/defaults/main.yaml
@@ -39,6 +39,11 @@ nvidia_container_runtime_repo_gpgkey: https://nvidia.github.io/nvidia-container-
 rhel7_vulkan_repo_baseurl: http://mirror.centos.org/centos/7/os/$basearch/
 rhel7_vulkan_repo_gpgkey: http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-7
 
+epel_centos_7_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+epel_centos_8_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+epel_centos_8_rpm_gpg_key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
+epel_centos_7_rpm_gpg_key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+
 suse_packagehub_product: PackageHub/{{ ansible_distribution_version }}/{{ ansible_architecture }}
 
 # the nvidia-container-runtime package no longer exists for rhel8 so we must install the last available version

--- a/ansible/roles/gpu/tasks/nvidia-gpu-RHEL7.yaml
+++ b/ansible/roles/gpu/tasks/nvidia-gpu-RHEL7.yaml
@@ -1,19 +1,18 @@
 ---
-# If possible we use headers from main OS repo for this kernel.
-- name: Install Kernel Header and Devel from OS repo for Current Kernel
+- name: install kernel headers and devel
   yum:
-      name:
-        - "kernel-headers-{{ hostvars[inventory_hostname].ansible_kernel }}"
-        - "kernel-devel-{{ hostvars[inventory_hostname].ansible_kernel }}"
+    name:
+      - "kernel-headers-{{ hostvars[inventory_hostname].ansible_kernel }}"
+      - "kernel-devel-{{ hostvars[inventory_hostname].ansible_kernel }}"
 
 # ensure nouveau being unloaded
-- name: Ensure nouveau being unloaded
+- name: ensure nouveau being unloaded
   modprobe:
     name: nouveau
     state: absent
   changed_when: False
 
-- name: Use Centos Base Repo for vulkan-filesystem
+- name: use Centos Base Repo for vulkan-filesystem
   yum_repository:
     name: vulkanfs-repo
     description: Workaround repo to get vulkan-filesystem
@@ -21,18 +20,24 @@
     gpgkey: "{{ rhel7_vulkan_repo_gpgkey }}"
     enabled: false
 
-- name: Use vulkan-filesystem from centos
+- name: use vulkan-filesystem from centos
   yum:
     name: vulkan-filesystem
     enablerepo: vulkanfs-repo
 
-- name: Install EPEL release
+- name: install EPEL release
   yum:
     name: "{{ epel_centos_7_rpm }}"
     state: present
 
-# Install NVIDIA repository, driver and tools
-- name: Add NVIDIA repository for CUDA drivers and tools
+- name: install additional Nvidia runfile prerequisites
+  yum:
+    name:
+      - elfutils-libelf-devel
+      - make
+      - gcc
+
+- name: add Nvidia repository for cuda drivers and tools
   yum_repository:
     name: cuda
     description: NVIDIA cuda repository
@@ -40,17 +45,30 @@
     baseurl: "{{ nvidia_repo_baseurl }}"
     gpgkey: "{{ nvidia_repo_gpgkey }}"
     gpgcheck: true
-- name: Install cuda drivers and tools
-  yum:
-    enablerepo:
-      - rhel-7-server-rhui-extras-rpms
-      - rhel-7-server-rhui-optional-rpms
-    name:
-      - "{{ nvidia_cuda_package }}"
-    state: present
+
+- name: create temporary run file directory
+  ansible.builtin.tempfile:
+    state: directory
+    suffix: build
+  register: runfile_dir
+
+# It appears impossible to pin a specific CUDA version on RHEL7 unless
+# one uses the runfile installer.
+# Installing `cuda-XX-X` will result in sliding CUDA versions.
+# TODO(tillt): Find a way that spares us the runfile.
+- name: download Nvidia driver installer
+  get_url:
+    url: "{{ nvidia_runfile_installer_url }}"
+    dest: "{{ runfile_dir.path }}/{{ nvidia_runfile_installer }}"
+    mode: 0755
+  retries: 3
+  delay: 3
+
+- name: run Nvidia driver installer
+  command: "{{ runfile_dir.path }}/{{ nvidia_runfile_installer }} --silent"
 
 # libnvidia-container
-- name: Add libnvidia-container repository
+- name: add libnvidia-container repository
   yum_repository:
     name: libnvidia-container
     description: NVIDIA cuda repository
@@ -65,7 +83,7 @@
     enablerepo: libnvidia-container
     state: present
 
-- name: Add libnvidia-container-runtime repository
+- name: add libnvidia-container-runtime repository
   yum_repository:
     name: nvidia-container-runtime
     description: NVIDIA cuda repository
@@ -74,14 +92,14 @@
     gpgkey: "{{ nvidia_container_runtime_repo_gpgkey }}"
     gpgcheck: true
 
-- name: Install nvidia-container-tools
+- name: install nvidia-container-tools
   yum:
     name: libnvidia-container-tools
     enablerepo:
       - libnvidia-container
     state: present
 
-- name: Install nvidia-container-runtime
+- name: install nvidia-container-runtime
   yum:
     name: "{{ nvidia_container_runtime_package }}"
     enablerepo:

--- a/ansible/roles/gpu/tasks/nvidia-gpu-RHEL8.yaml
+++ b/ansible/roles/gpu/tasks/nvidia-gpu-RHEL8.yaml
@@ -1,21 +1,29 @@
 ---
-# If possible we use headers from main OS repo for this kernel.
-- name: Install Kernel Header and Devel from OS repo for Current Kernel
-  dnf:
-      name:
-        - "kernel-headers-{{ hostvars[inventory_hostname].ansible_kernel }}"
-        - "kernel-devel-{{ hostvars[inventory_hostname].ansible_kernel }}"
-
-- name: import epel repository key
+- name: add epel gpg key
   rpm_key:
     state: present
     key: "{{ epel_centos_8_rpm_gpg_key }}"
 
-- name: Install EPEL release
-  dnf:
+- name: install epel-release
+  yum:
     name: "{{ epel_centos_8_rpm }}"
     state: present
-    disable_gpg_check: true
+
+- name: find this kernel headers
+  yum:
+    list: "kernel-headers-{{ hostvars[inventory_hostname].ansible_kernel }}"
+  register: pkgheaders
+
+# If possible we use headers from the main OS repo for this kernel. When
+# this comes back empty, the next step will implicitly install what is
+# needed.
+# TODO(tillt): There must be a more deterministic way.
+- name: Install Kernel Header and Devel from OS repo for Current Kernel
+  yum:
+    name:
+      - "kernel-headers-{{ hostvars[inventory_hostname].ansible_kernel }}"
+      - "kernel-devel-{{ hostvars[inventory_hostname].ansible_kernel }}"
+  when: pkgheaders.results|length > 0
 
 # Install NVIDIA repository, driver and tools
 - name: Add NVIDIA repository for CUDA drivers and tools

--- a/ansible/roles/gpu/tasks/nvidia-gpu-RHEL8.yaml
+++ b/ansible/roles/gpu/tasks/nvidia-gpu-RHEL8.yaml
@@ -5,28 +5,26 @@
     key: "{{ epel_centos_8_rpm_gpg_key }}"
 
 - name: install epel-release
-  yum:
+  dnf:
     name: "{{ epel_centos_8_rpm }}"
     state: present
 
-- name: find this kernel headers
-  yum:
-    list: "kernel-headers-{{ hostvars[inventory_hostname].ansible_kernel }}"
-  register: pkgheaders
-
-# If possible we use headers from the main OS repo for this kernel. When
-# this comes back empty, the next step will implicitly install what is
-# needed.
-# TODO(tillt): There must be a more deterministic way.
-- name: Install Kernel Header and Devel from OS repo for Current Kernel
-  yum:
+- name: install kernel {{ hostvars[inventory_hostname].ansible_kernel }} headers and devel
+  dnf:
     name:
       - "kernel-headers-{{ hostvars[inventory_hostname].ansible_kernel }}"
       - "kernel-devel-{{ hostvars[inventory_hostname].ansible_kernel }}"
-  when: pkgheaders.results|length > 0
+    state: present
 
-# Install NVIDIA repository, driver and tools
-- name: Add NVIDIA repository for CUDA drivers and tools
+- name: install additional Nvidia runfile prerequisites
+  dnf:
+    name:
+      - elfutils-libelf-devel
+      - gcc
+      - make
+    state: present
+
+- name: add Nvidia repository for cuda drivers and tools
   yum_repository:
     name: cuda
     description: NVIDIA cuda repository
@@ -35,18 +33,28 @@
     gpgkey: "{{ nvidia_repo_gpgkey }}"
     gpgcheck: true
 
-- name: Install cuda drivers and tools
-  dnf:
-    enablerepo:
-      - "codeready-builder-for-rhel-8-{{ ansible_architecture }}-rpms"
-      - "rhel-8-for-{{ ansible_architecture }}-baseos-rpms"
-      - "rhel-8-for-{{ ansible_architecture }}-appstream-rpms"
-    name:
-      - "{{ nvidia_cuda_package }}"
-    state: present
+- name: create temporary run file directory
+  ansible.builtin.tempfile:
+    state: directory
+    suffix: build
+  register: runfile_dir
 
-# libnvidia-container
-- name: Add libnvidia-container repository
+# It appears impossible to pin a specific CUDA version on RHEL8 unless
+# one uses the runfile installer.
+# Installing `cuda-XX-X` will result in sliding CUDA versions.
+# TODO(tillt): Find a way that spares us the runfile.
+- name: download Nvidia driver installer
+  get_url:
+    url: "{{ nvidia_runfile_installer_url }}"
+    dest: "{{ runfile_dir.path }}/{{ nvidia_runfile_installer }}"
+    mode: 0755
+  retries: 3
+  delay: 3
+
+- name: run Nvidia driver installer
+  command: "{{ runfile_dir.path }}/{{ nvidia_runfile_installer }} --silent"
+
+- name: add libnvidia-container repository
   yum_repository:
     name: libnvidia-container
     description: NVIDIA cuda repository
@@ -61,7 +69,7 @@
     enablerepo: libnvidia-container
     state: present
 
-- name: Add libnvidia-container-runtime repository
+- name: add libnvidia-container-runtime repository
   yum_repository:
     name: nvidia-container-runtime
     description: NVIDIA cuda repository
@@ -70,14 +78,14 @@
     gpgkey: "{{ nvidia_container_runtime_repo_gpgkey }}"
     gpgcheck: true
 
-- name: Install nvidia-container-tools
+- name: install nvidia-container-tools
   dnf:
     name: libnvidia-container-tools
     enablerepo:
       - libnvidia-container
     state: present
 
-- name: Install nvidia-container-runtime
+- name: install nvidia-container-runtime
   dnf:
     name: "{{ nvidia_container_runtime_package }}"
     enablerepo:

--- a/ansible/roles/gpu/tasks/nvidia-gpu-SLES15.yaml
+++ b/ansible/roles/gpu/tasks/nvidia-gpu-SLES15.yaml
@@ -29,21 +29,21 @@
   register: cuda_repo_installation_rpm
   until: cuda_repo_installation_rpm is success
   retries: 15
-  delay: 3
+  delay: 60
 
 - name: Install current kernel devel
   zypper:
     name: "kernel-{{ ansible_kernel | regex_search('.*-(\\w+)$', '\\1') | first }}-devel={{ ansible_kernel | regex_search('(.*)-\\w+$', '\\1') | first }}"
     state: present
   retries: 15
-  delay: 3
+  delay: 60
 
 - name: Install Nvidia drivers
   zypper:
     name: cuda-drivers-{{ nvidia_cuda_version }}
     state: present
   retries: 15
-  delay: 3
+  delay: 60
 
 - name: Import libnvidia-container repository key
   rpm_key:
@@ -63,7 +63,7 @@
     name: libnvidia-container1
     state: present
   retries: 15
-  delay: 3
+  delay: 60
 
 - name: Import nvidia-container-runtime repository key
   rpm_key:
@@ -78,18 +78,18 @@
     repo: "{{ nvidia_container_runtime_repo_sles }}"
   changed_when: false # zypper repo is updating for this resource all the time
   retries: 15
-  delay: 3
+  delay: 60
 
 - name: Install nvidia-container-tools
   zypper:
     name: libnvidia-container-tools
     state: present
   retries: 15
-  delay: 3
+  delay: 60
 
 - name: Install nvidia-container-runtime
   zypper:
     name: "{{ nvidia_container_runtime_package }}"
     state: present
   retries: 15
-  delay: 3
+  delay: 60

--- a/ansible/roles/packages/tasks/repo-suse.yaml
+++ b/ansible/roles/packages/tasks/repo-suse.yaml
@@ -10,13 +10,12 @@
   register: konvoy_repo_installation_rpm
   until: konvoy_repo_installation_rpm is success
   retries: 15
-  delay: 10
+  delay: 60
 
 - name: import Konvoy Kubernetes rpm repository key
   rpm_key:
     state: present
     key: "{{ kubernetes_rpm_suse_gpg_key_url }}"
-
 
 - name: add Konvoy Containerd rpm repository
   zypper_repository:
@@ -28,7 +27,7 @@
   register: konvoy_repo_installation_rpm
   until: konvoy_repo_installation_rpm is success
   retries: 15
-  delay: 10
+  delay: 60
 
 - name: add Konvoy Containerd rpm repository key
   rpm_key:

--- a/images/ami/centos-7.yaml
+++ b/images/ami/centos-7.yaml
@@ -4,7 +4,7 @@ packer:
   ami_filter_name: "CentOS 7.9.2009 x86_64"
   ami_filter_owners: "125523088429"
   distribution: "CentOS"
-  distribution_version: "7"
+  distribution_version: "7.9"
   source_ami: ""
   ssh_username: "centos"
   root_device_name: "/dev/sda1"

--- a/images/ami/centos-8.yaml
+++ b/images/ami/centos-8.yaml
@@ -4,7 +4,7 @@ packer:
   ami_filter_name: "CentOS 8.3.2011 x86_64"
   ami_filter_owners: "125523088429"
   distribution: "CentOS"
-  distribution_version: "8"
+  distribution_version: "8.3"
   source_ami: ""
   ssh_username: "centos"
   root_device_name: "/dev/sda1"

--- a/images/ami/oracle-7.yaml
+++ b/images/ami/oracle-7.yaml
@@ -4,7 +4,7 @@ packer:
   ami_filter_name: "OL7.9-x86_64-HVM-2020-12-07"
   ami_filter_owners: "131827586825"
   distribution: "Oracle"
-  distribution_version: "7"
+  distribution_version: "7.9"
   source_ami: ""
   ssh_username: "ec2-user"
   root_device_name: "/dev/sda1"

--- a/images/ami/rhel-79.yaml
+++ b/images/ami/rhel-79.yaml
@@ -4,7 +4,7 @@ packer:
   ami_filter_name: "RHEL-7.9*-x86_64-*"
   ami_filter_owners: "309956199498"
   distribution: "RHEL"
-  distribution_version: "7"
+  distribution_version: "7.9"
   source_ami: ""
   ssh_username: "ec2-user"
   root_device_name: "/dev/sda1"

--- a/images/ami/rhel-82.yaml
+++ b/images/ami/rhel-82.yaml
@@ -1,7 +1,7 @@
 download_images: true
 
 packer:
-  ami_filter_name: "RHEL-8.2*-x86_64-*"
+  ami_filter_name: "RHEL-8.2.0*2020*-x86_64-*"
   ami_filter_owners: "309956199498"
   distribution: "RHEL"
   distribution_version: "8"

--- a/images/ami/rhel-82.yaml
+++ b/images/ami/rhel-82.yaml
@@ -10,6 +10,6 @@ packer:
   root_device_name: "/dev/sda1"
   volume_size: "15"
 
-build_name: "rhel-8"
+build_name: "rhel-8.2"
 packer_builder_type: "amazon"
 python_path: ""

--- a/images/ami/rhel-82.yaml
+++ b/images/ami/rhel-82.yaml
@@ -4,7 +4,7 @@ packer:
   ami_filter_name: "RHEL-8.2.0*2020*-x86_64-*"
   ami_filter_owners: "309956199498"
   distribution: "RHEL"
-  distribution_version: "8"
+  distribution_version: "8.2"
   source_ami: ""
   ssh_username: "ec2-user"
   root_device_name: "/dev/sda1"

--- a/images/ami/rhel-84.yaml
+++ b/images/ami/rhel-84.yaml
@@ -4,7 +4,7 @@ packer:
   ami_filter_name: "RHEL-8.4.0_HVM-*"
   ami_filter_owners: "309956199498"
   distribution: "RHEL"
-  distribution_version: "8"
+  distribution_version: "8.4"
   source_ami: ""
   ssh_username: "ec2-user"
   root_device_name: "/dev/sda1"


### PR DESCRIPTION
- adds rhel82 molecule target
- renames rhel8 ami image template and build-result to rhel82 for consistency
- adds missing Makefile target for sles15
- increases retry delays for sles15 significantly to avoid rate limits

CONTROVERSIAL:
- limits rhel8.2 to a base image that has kernel headers available
- adds rhel8 support for run file driver installation
- adds rhel7 support for run file driver installation

TESTING:
All touched image variants were tested on GPU nodes using Konvoy's provisioning on AWS.
RHEL8.4 showed GPU unrelated issues which are still being debugged.

RHEL 7.9 / 470.x: konvoy-ami-rhel-7-nvidia-1.21.6-1637360496: ami-03fd6597fbe7bdb7b
RHEL 8.2 / 470.x: konvoy-ami-rhel-8-nvidia-1.21.6-1637506302: ami-09bd720906c3ba58e
RHEL 8.4 / 470.x: konvoy-ami-rhel-8.4-nvidia-1.21.6-1637284130: ami-0da5fe116861cb57e
SLES 15 / 470.x: konvoy-ami-sles-15-nvidia-1.21.6-1637452948: ami-089489d5ce4c46624
