### PR TITLE
ansible: fix container-selinux gpg key

### DIFF
--- a/ansible/roles/packages/tasks/install-redhat.yaml
+++ b/ansible/roles/packages/tasks/install-redhat.yaml
@@ -87,7 +87,7 @@
 - name: install container-selinux GPG key
   rpm_key:
     state: present
-    key: http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-7
+    key: "{{ docker_rpm_container_selinux_gpg_key_url }}"
   register: result
   until: result is success
   retries: 3


### PR DESCRIPTION
There is a variable for this, but it was not being used.