### PR TITLE
fix: RHEL8.2 now needs GPU nodes for builds and tests

### DIFF
--- a/ansible/molecule/ec2_full/molecule.yml
+++ b/ansible/molecule/ec2_full/molecule.yml
@@ -46,7 +46,7 @@ platforms:
     image_search_name: "RHEL-8.2.0*2020*-x86_64-*"
     image_search_owner: "309956199498"
     region: us-east-1
-    instance_type: t3.small
+    instance_type: p2.xlarge
     spot_price: false
     ssh_user: ec2-user
   - name: konvoyimage-rhel8.4-${USER:-ci}-${HOSTNAME:-local}


### PR DESCRIPTION
The Nvidia run file installer as currently used for RHEL8.2 demands a GPU node for tests.