### PR TITLE
ansible: remove swap from fstab during sysprep

### DIFF
--- a/ansible/roles/sysprep/tasks/main.yml
+++ b/ansible/roles/sysprep/tasks/main.yml
@@ -187,3 +187,21 @@
   loop:
     - path: /root/.bash_history
     - path: "/home/{{ ansible_env.SUDO_USER }}/.bash_history"
+
+- name: Remove swap from /etc/fstab
+  mount:
+    name: "{{ item }}"
+    fstype: swap
+    state: absent
+  with_items:
+    - swap
+    - none
+
+- name: Check if swap is on
+  command: swapon -s
+  register: swapon
+  changed_when: false
+
+- name: Disable Swap
+  command: swapoff -a
+  when: swapon.stdout


### PR DESCRIPTION
Remove swap lines from fstab during sysprep phase so provisioning physical hosts that may have it setup during the install will not fail the setup later when kubelet tries to start.