### PR TITLE
fix: flatcar gpu build fix for kernel 5.10.80.

### DIFF
--- a/ansible/roles/gpu/files/nvidia-driver
+++ b/ansible/roles/gpu/files/nvidia-driver
@@ -32,12 +32,8 @@ _install_development_env() {
     # The environment is mounted on a loop device and then we chroot into
     # the mount to build the NVIDIA kernel driver interface.
     # The resulting module files and module dependencies are then archived.
-    local kernel
-    kernel=$(echo "${KERNEL_VERSION}" | cut -d "-" -f1)
-    local os_release
-    os_release=$(curl -Ls "${COREOS_ALL_RELEASES}" | jq -r --arg kernel_ver "${kernel}" 'to_entries[] | select ((.value.major_software.kernel[0] == $kernel_ver) and (.key != "current")) | .key')
     local latest_release
-    latest_release=$(echo "${os_release}" | awk '{ print $1 }')
+    latest_release=$(echo "${FLATCAR_OS_VERSION}" | awk '{ print $1 }')
     local dev_image="flatcar_developer_container.bin"
     local dev_image_url="https://${COREOS_RELEASE_CHANNEL}.release.flatcar-linux.net/${COREOS_RELEASE_BOARD}/${latest_release}/${dev_image}.bz2"
 
@@ -103,6 +99,10 @@ _install_prerequisites() (
     rm -rf "/lib/modules/${KERNEL_VERSION}"
     rm -rf /usr/src/linux*
 
+    local kernel
+    kernel=$(echo "${KERNEL_VERSION}" | cut -d "-" -f1)
+    export FLATCAR_OS_VERSION=$(curl -Ls "${COREOS_ALL_RELEASES}" | jq -r --arg kernel_ver "${kernel}" 'to_entries[] | select ((.value.major_software.kernel[0] == $kernel_ver) and (.key != "current")) | .key')
+
     _install_development_env
     echo "Installing the Flatcar kernel sources into the development environment..."
 
@@ -116,8 +116,8 @@ source /etc/os-release
  sed -i -e "s;http://builds.developer.core-os.net/boards/;https://storage.googleapis.com/flatcar-jenkins/boards/;g" /etc/portage/make.conf
 export $(cat /usr/src/version.txt | xargs)
 emerge-gitclone \
-&& export OVERLAY_VERSION="flatcar-${FLATCAR_BUILD}" \
-&& export PORTAGE_VERSION="flatcar-${FLATCAR_BUILD}" \
+&& export OVERLAY_VERSION="stable-${FLATCAR_OS_VERSION}" \
+&& export PORTAGE_VERSION="stable-${FLATCAR_OS_VERSION}" \
 && git -C /var/lib/portage/coreos-overlay checkout "$OVERLAY_VERSION" \
 && git -C /var/lib/portage/portage-stable checkout "$PORTAGE_VERSION"
 emerge -gKq coreos-sources \


### PR DESCRIPTION
Since the release of flatcar 5.10.82 the build for 5.10.80 is broken. @joejulian identified the problem in the nvidia prerequisites installer, this is the fix. 

The original version was targeting the kernel sources in a way that would occasionally work, but definitely not reliably.

Tested directly in molecule ec2_full run;
```
$ uname -r
5.10.80-flatcar

$ sudo nvidia-smi
Wed Dec  1 23:21:25 2021
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 470.82.01    Driver Version: 470.82.01    CUDA Version: N/A      |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  Tesla K80           Off  | 00000000:00:1E.0 Off |                    0 |
| N/A   28C    P0    55W / 149W |      0MiB / 11441MiB |     99%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+

+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|  No running processes found                                                 |
+-----------------------------------------------------------------------------+
``` 