### PR TITLE
fix: prevents use of cgroupsv2 for flatcar gpu

### DIFF
--- a/ansible/roles/gpu/tasks/nvidia-gpu-Flatcar.yaml
+++ b/ansible/roles/gpu/tasks/nvidia-gpu-Flatcar.yaml
@@ -229,6 +229,22 @@
         src: "./usr/share/containers/oci/hooks.d/oci-nvidia-hook.json"
         dest: "/opt/usr/share/containers/oci/hooks.d/oci-nvidia-hook.json"
 
+    # The Nvidia container runtime is not compatible with cgroups v2.
+    - name: ensure cgroups v2 are disabled
+      command: grep -q systemd.unified_cgroup_hierarchy=0 /usr/share/oem/grub.cfg
+      changed_when: no
+      failed_when: false
+      register: cgroupsv2_check
+
+    - name: cgroups setup
+      when:
+        - cgroupsv2_check.rc != 0
+      block:
+        - name: disable cgroups v2
+          command: sed -E -i 's/^(set linux_append=.*)"$/\1 systemd.unified_cgroup_hierarchy=0 systemd.legacy_systemd_cgroup_controller"/g' /usr/share/oem/grub.cfg
+        - name: reboot to activate new kernel settings
+          reboot:
+
 # Check if libnvidia-container exists.
 - name: check if the libnvidia-container exists
   changed_when: false


### PR DESCRIPTION
Without this change the nvidia-container-runtime will fail isolating the GPU devices as it is not CGroups V2 compatible. Flatcar switched to CGroups V2 by default a while ago.

Without the change, the runtime will barf like this:
```
sudo ctr -a /run/docker/libcontainerd/docker-containerd.sock run --rm --gpus 0 -t docker.io/nvidia/cuda:11.0-base cuda-11.0-base nvidia-smi
ctr: failed to create shim: OCI runtime create failed: container_linux.go:380: starting container process caused: process_linux.go:545: container init caused: Running hook #0:: error running hook: exit status 1, stdout: , stderr: nvidia-container-cli: container error: cgroup subsystem devices not found: unknown
```

Testing this change on a molecule test node:
```
$ sudo ctr -a /run/docker/libcontainerd/docker-containerd.sock image pull docker.io/nvidia/cuda:11.0-base
[..]
$ sudo ctr -a /run/docker/libcontainerd/docker-containerd.sock run --rm --gpus 0 -t docker.io/nvidia/cuda:11.0-base cuda-11.0-base nvidia-smi
Sat Dec  4 02:31:38 2021
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 470.82.01    Driver Version: 470.82.01    CUDA Version: 11.0     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  Tesla K80           On   | 00000000:00:1E.0 Off |                    0 |
| N/A   34C    P8    30W / 149W |      0MiB / 11441MiB |      0%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+

+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|  No running processes found                                                 |
+-----------------------------------------------------------------------------+
```