### PR TITLE
fix: allows for selecting nvidia runtime via docker cli

### DIFF
--- a/ansible/roles/gpu/files/daemon.json
+++ b/ansible/roles/gpu/files/daemon.json
@@ -1,0 +1,8 @@
+{
+    "runtimes": {
+        "nvidia": {
+            "path": "/opt/bin/nvidia-container-runtime",
+            "runtimeArgs": []
+        }
+    }
+}

--- a/ansible/roles/gpu/tasks/nvidia-gpu-Flatcar.yaml
+++ b/ansible/roles/gpu/tasks/nvidia-gpu-Flatcar.yaml
@@ -229,6 +229,12 @@
         src: "./usr/share/containers/oci/hooks.d/oci-nvidia-hook.json"
         dest: "/opt/usr/share/containers/oci/hooks.d/oci-nvidia-hook.json"
 
+    # Allow for selecting the nvidia container runtime via docker cli.
+    - name: docker daemon nvidia container runtime definition
+      copy:
+        src: "./daemon.json"
+        dest: "/etc/docker/daemon.json"
+
     # The Nvidia container runtime is not compatible with cgroups v2.
     - name: ensure cgroups v2 are disabled
       command: grep -q systemd.unified_cgroup_hierarchy=0 /usr/share/oem/grub.cfg


### PR DESCRIPTION
Just for having a neatly setup system for users trying to run GPU workload on the CLI for some reason. Without this patch, one can not use the docker cli for GPU workload on container level (but only `ctr`).

Tested: 
```
$ docker run --runtime=nvidia --rm nvidia/cuda:11.0-base nvidia-smi

Sun Dec  5 23:54:00 2021
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 470.82.01    Driver Version: 470.82.01    CUDA Version: 11.0     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  Tesla K80           On   | 00000000:00:1E.0 Off |                    0 |
| N/A   33C    P8    30W / 149W |      0MiB / 11441MiB |      0%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+

+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|  No running processes found                                                 |
+-----------------------------------------------------------------------------+
```
