### PR TITLE
feat: disable firewalld and flush Iptable rules

### DIFF
--- a/ansible/roles/networking/tasks/main.yaml
+++ b/ansible/roles/networking/tasks/main.yaml
@@ -36,6 +36,12 @@
       state: present
       reload: yes
 
+  - name: Flush Iptable rules
+    iptables:
+      flush: true
+    when:
+      - flush_iptables_rules | default(true)
+
   - name: add iptable ALLOW rules for control-plane
     iptables:
       chain: INPUT
@@ -44,7 +50,7 @@
       jump: ACCEPT
       comment: "{{ item.comment }}"
     with_items:
-      - port: "{{ apiserver.secure_port }}"
+      - port: "{{ apiserver_port }}"
         comment: "Konvoy: kube-apiserver --secure-port"
       - port: 10250
         comment: "Konvoy: kubelet --port"

--- a/ansible/roles/networking/tasks/main.yaml
+++ b/ansible/roles/networking/tasks/main.yaml
@@ -36,11 +36,23 @@
       state: present
       reload: yes
 
-  - name: Flush Iptable rules
-    iptables:
-      flush: true
+  - name: Check if iptables service exists
+    command: systemctl cat iptables
+    check_mode: no
+    register: iptables_exists
+    changed_when: False
+    failed_when: iptables_exists.rc not in [0, 1]
     when:
-      - flush_iptables_rules | default(true)
+      - disable_iptables | default(true)
+
+  - name: Stop and disable defualt iptables service
+    systemd:
+      name: iptables
+      enabled: false
+      masked: false
+      state: stopped
+    when:
+      - iptables_exists.rc == 0
 
   - name: add iptable ALLOW rules for control-plane
     iptables:

--- a/ansible/roles/sysprep/tasks/main.yml
+++ b/ansible/roles/sysprep/tasks/main.yml
@@ -205,3 +205,22 @@
 - name: Disable Swap
   command: swapoff -a
   when: swapon.stdout
+
+- name: Check if firewalld service exists
+  command: systemctl cat firewalld
+  check_mode: no
+  register: firewalld_exists
+  changed_when: False
+  failed_when: firewalld_exists.rc not in [0, 1]
+  when:
+    - disable_firewalld | default(true)
+
+- name: Stop and disable firewalld service
+  systemd:
+    name: firewalld
+    enabled: false
+    masked: false
+    state: stopped
+  when:
+    - disable_firewalld | default(true)
+    - firewalld_exists.rc == 0


### PR DESCRIPTION
Allows the user to disable firewalld as a last step in system prep. The default will be to keep firewalld running. 

JIRAs: 
- https://jira.d2iq.com/browse/D2IQ-82085
- https://jira.d2iq.com/browse/D2IQ-82086
- https://jira.d2iq.com/browse/D2IQ-82087