### PR TITLE
feat: bump k8s to 1.22.8

### DIFF
--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -3,7 +3,7 @@ python_path: ""
 
 # This is also in images/common.yaml as that's where the go code expects it to be.
 # If it's not there, the kubernetes_full_version will have "None" for a version number.
-kubernetes_version: "1.21.6"
+kubernetes_version: "1.22.4"
 
 containerd_version: "1.4.11"
 kubernetes_cni_version: "0.9.1"

--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -3,7 +3,7 @@ python_path: ""
 
 # This is also in images/common.yaml as that's where the go code expects it to be.
 # If it's not there, the kubernetes_full_version will have "None" for a version number.
-kubernetes_version: "1.22.4"
+kubernetes_version: "1.22.8"
 
 containerd_version: "1.4.11"
 kubernetes_cni_version: "0.9.1"

--- a/ansible/group_vars/all/system.yaml
+++ b/ansible/group_vars/all/system.yaml
@@ -3,11 +3,8 @@ alma_linux_extra_repo_base_url: https://repo.almalinux.org/almalinux/$releasever
 alma_linux_extra_repo_mirror_list_url: https://mirrors.almalinux.org/mirrorlist/$releasever/extras
 alma_linux_gpg_key_url: https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux
 # TODO: use overrides to set these
-kubernetes_rpm_repository_url: "https://packages.d2iq.com/konvoy/rpm/stable/centos/7/x86_64"
-kubernetes_rpm_gpg_key_url: "https://packages.d2iq.com/konvoy/rpm-gpg-pub-key"
-
-kubernetes_rpm_suse_repository_url: "https://packages.d2iq.com/konvoy/rpm/stable/suse/{{ ansible_distribution_major_version|int }}/x86_64"
-kubernetes_rpm_suse_gpg_key_url: "https://packages.d2iq.com/konvoy/rpm-gpg-pub-key"
+kubernetes_rpm_repository_url: "https://packages.d2iq.com/konvoy/stable/linux/repos/el/kubernetes-v{{ kubernetes_version }}-nokmem/x86_64"
+kubernetes_rpm_gpg_key_url: "https://packages.d2iq.com/konvoy/stable/linux/repos/d2iq-sign-authority-gpg-public-key"
 
 ## Debian
 kubernetes_deb_repository_url: "https://packages.cloud.google.com/apt/"

--- a/ansible/group_vars/all/system.yaml
+++ b/ansible/group_vars/all/system.yaml
@@ -27,8 +27,6 @@ docker_rpm_gpg_key_url: "{{ docker_rpm_repository_url }}/gpg.asc"
 docker_rpm_suse_repository_url: "https://packages.d2iq.com/konvoy/stable/linux/opensuse/leap/{{ ansible_distribution_major_version|int }}/x86_64"
 docker_rpm_suse_gpg_key_url: "{{ docker_rpm_suse_repository_url }}/gpg.asc"
 
-# docker_deb_repository_url: "https://konvoy-packages-test.s3.amazonaws.com/stable/linux/{{ ansible_distribution |lower }}/{{ ansible_distribution_release }}"
-## focal does not yet have a promote to staging job. Need to create one and wait for the 24 hour sync to production s3
 docker_deb_repository_url: "https://packages.d2iq.com/konvoy/stable/linux/{{ ansible_distribution |lower }}/{{ ansible_distribution_release }}"
 docker_deb_gpg_key_url: "https://packages.d2iq.com/konvoy/stable/linux/{{ ansible_distribution |lower }}/{{ ansible_distribution_release }}/gpg.asc"
 docker_deb_release_name: "{{ ansible_distribution_release }}"

--- a/ansible/roles/repo/tasks/suse.yaml
+++ b/ansible/roles/repo/tasks/suse.yaml
@@ -4,7 +4,7 @@
   zypper_repository:
     name: kubernetes
     description: Konvoy Kubernetes package repository
-    repo: "{{ kubernetes_rpm_suse_repository_url }}"
+    repo: "{{ kubernetes_rpm_repository_url }}"
     disable_gpg_check: true
     autorefresh: true
   register: konvoy_repo_installation_rpm
@@ -15,7 +15,7 @@
 - name: import Konvoy Kubernetes rpm repository key
   rpm_key:
     state: present
-    key: "{{ kubernetes_rpm_suse_gpg_key_url }}"
+    key: "{{ kubernetes_rpm_gpg_key_url }}"
 
 - name: add Konvoy Containerd rpm repository
   zypper_repository:

--- a/ansible/roles/version/tasks/main.yaml
+++ b/ansible/roles/version/tasks/main.yaml
@@ -1,26 +1,25 @@
 ---
 # NOTE(jkoelker) Grab the build tag (eg. `fips.0` from `v1.21.6+fips.0`)
 - name: detect build
-  shell: kubeadm version -o short | cut -d+ -f2 -s
-  register: kubeadm_build_tag
+  shell: kubeadm version -o short
+  register: kubeadm_version_out
 
-- name: set kubernetes build tag
+- name: set kubeadm version
   set_fact:
-    kubernetes_build_tag: "{{ kubeadm_build_tag.stdout | trim }}"
+    kubeadm_version: "{{ kubeadm_version_out.stdout | trim }}"
 
-# NOTE(jkoelker) If `kubeadm` has a build tag, append that to the images.
-#                Since kubernets uses a build tag on their `etcd` images (e.g
-#                `-0` from `k8s.gcr.io/etcd:3.4.13-0`), strip it prior to
-#                appending the build tag from `kubeadm`. Since the `pause`
-#                image does not need a fips version, it is not tagged with
-#                the build tag.
+# TODO(dkoshkin) remove this hardcoded version when additional images are built for FIPS
+- name: set hardcoded etcd image
+  set_fact:
+    hardcoded_etcd_fips_version:  "{{ 'v3.4.13_fips.0' if 'fips' in kubeadm_version else '' }}"
+
+- name: copy kubeadm config
+  template:
+    src: "kubeadm-conf.yaml.tmpl"
+    dest: "kubeadm-conf.yaml"
+
 - name: determine kubernetes images
-  shell: |
-    kubeadm config images list --kubernetes-version='{{ kubernetes_semver }}' --image-repository '{{ k8s_image_registry }}' |
-    sed 's/^\(.\+etcd:\)\(.\+\)-\([0-9]\+\)$/\1{{ "\2-\3" if not kubernetes_build_tag else "v\2"}}/' |
-    sed 's/$/{{ '_' + kubernetes_build_tag if kubernetes_build_tag }}/' |
-    sed 's/^\(.\+pause:.\+\)_{{ kubernetes_build_tag }}$/\1/' |
-    sed 's#^\(.\+coredns:\)\(.\+\)_{{ kubernetes_build_tag }}#{{ coredns_image_registry_repository }}:\2#'
+  shell: kubeadm config images list --config kubeadm-conf.yaml
   register: kubernetes_kubeadm_images
 
 - name: set kubernetes images

--- a/ansible/roles/version/templates/kubeadm-conf.yaml.tmpl
+++ b/ansible/roles/version/templates/kubeadm-conf.yaml.tmpl
@@ -1,0 +1,11 @@
+---
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: ClusterConfiguration
+dns:
+  imageRepository: k8s.gcr.io
+etcd:
+  local:
+    imageRepository: {{ k8s_image_registry }}
+    imageTag: {{ hardcoded_etcd_fips_version }}
+imageRepository: {{ k8s_image_registry }}
+kubernetesVersion: {{ kubeadm_version }}

--- a/images/common.yaml
+++ b/images/common.yaml
@@ -1,4 +1,5 @@
-kubernetes_version: "1.21.6"
+---
+kubernetes_version: "1.22.4"
 
 download_images: true
 

--- a/images/common.yaml
+++ b/images/common.yaml
@@ -1,5 +1,5 @@
 ---
-kubernetes_version: "1.22.4"
+kubernetes_version: "1.22.8"
 
 download_images: true
 

--- a/overrides/fips.yaml
+++ b/overrides/fips.yaml
@@ -7,14 +7,7 @@ fips:
 build_name_extra: -fips
 kubernetes_build_metadata: fips.0
 default_image_repo: hub.docker.io/mesosphere
-kubernetes_rpm_repository_url: "\
-  https://kubernetes-fips.s3.us-east-2.amazonaws.com\
-  /{{ ansible_distribution_major_version|int }}\
-  /x86_64"
-kubernetes_rpm_gpg_key_url: "\
-  https://kubernetes-fips.s3.us-east-2.amazonaws.com\
-  /{{ ansible_distribution_major_version|int }}\
-  /rpm-gpg-pub-key"
+kubernetes_rpm_repository_url: "https://packages.d2iq.com/konvoy/stable/linux/repos/el/kubernetes-v{{ kubernetes_version }}-fips/x86_64"
 docker_rpm_repository_url: "\
   https://containerd-fips.s3.us-east-2.amazonaws.com\
   /{{ ansible_distribution_major_version|int }}\


### PR DESCRIPTION
**What problem does this PR solve?**:

* Bumps k8s to 1.22.4
* Removed old note (repository promotion job now exists)

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-81792


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note
Feature: Default to Kubernetes 1.22.7
```
