### PR TITLE
ansible: fix ubuntu-18 build

### DIFF
--- a/ansible/roles/images/tasks/main.yaml
+++ b/ansible/roles/images/tasks/main.yaml
@@ -2,7 +2,7 @@
 - name: start containerd
   service:
     name: containerd
-    state: started
+    state: restarted
 
 - name: pull control plane images
   shell: "crictl pull {{ item }}"


### PR DESCRIPTION
Fixes https://jira.d2iq.com/browse/D2IQ-82054

The default configuration for the `containerd` disables the `cri`
plugin. Since debian distros start services on install, we need to make
sure to `restart` containerd prior to pulling the images so it is using
our generated config.