### PR TITLE
Make ssh-agent available in the devkit container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,10 @@ export DOCKER_DEVKIT_USER_ARGS ?= \
 	--user $(UID):$(GID) \
 	--group-add $(DOCKER_SOCKET_GID)
 
+export DOCKER_DEVKIT_SSH_ARGS ?= \
+	--env SSH_AUTH_SOCK=/run/ssh-agent.sock \
+	--volume $(SSH_AUTH_SOCK):/run/ssh-agent.sock
+
 export DOCKER_DEVKIT_ARGS ?= \
 	$(DOCKER_ULIMIT_ARGS) \
 	$(DOCKER_DEVKIT_USER_ARGS) \
@@ -82,7 +86,8 @@ export DOCKER_DEVKIT_ARGS ?= \
 	$(DOCKER_SOCKET_ARGS) \
 	$(DOCKER_DEVKIT_AWS_ARGS) \
 	$(DOCKER_DEVKIT_PUSH_ARGS) \
-	$(DOCKER_DEVKIT_ENV_ARGS)
+	$(DOCKER_DEVKIT_ENV_ARGS) \
+	$(DOCKER_DEVKIT_SSH_ARGS)
 
 
 export DOCKER_DEVKIT_DEFAULT_ARGS ?= \


### PR DESCRIPTION
**What problem does this PR solve?**:
Make it possible to use ssh keys in the devkit container. I wasn't able to run kib without this on my Linux machine. Was it user error? Feedback welcome.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
