### PR TITLE
Use canonical name for mesosphere/kfips image

### DIFF
--- a/ansible/roles/images/defaults/main.yaml
+++ b/ansible/roles/images/defaults/main.yaml
@@ -10,7 +10,7 @@ control_plane_images:
   - "k8s.gcr.io/pause:{{ pause_image_version }}"
   - "k8s.gcr.io/pause:{{ pause_image_version_prev }}"
   - "k8s.gcr.io/coredns/coredns:v{{ coredns_version }}"
-  - "mesosphere/kfips:v{{ kfips_version }}"
+  - "docker.io/mesosphere/kfips:v{{ kfips_version }}"
 
 aws_images: []
 


### PR DESCRIPTION
**What problem does this PR solve?**:
The images in konvoy's image bundle have [canonical](https://pkg.go.dev/github.com/docker/distribution/reference#Canonical) names (ok, they don't have their digest in the name, so I guess they're not technically canonical...) 

In this case, kib used a _different_ name, without a fully-qualified registry, i.e., `mesosphere/kfips` instead of `docker.io/mesosphere/kfips`. Because the name is different, kib cannot find the image, although it is present.

**I think there's more to discuss here. Let's consider whether image names can/do/should change when users source them from private registries (or mirrors).**

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
