### PR TITLE
fix: always select x86_64 arch for Flatcar

### DIFF
--- a/ansible/roles/networking/tasks/main.yaml
+++ b/ansible/roles/networking/tasks/main.yaml
@@ -53,9 +53,9 @@
       masked: false
       state: stopped
     when:
+      - ansible_os_family != "Flatcar"
       - disable_iptables | default(true)
       - iptables_exists.rc == 0
-      - ansible_os_family != "Flatcar"
 
   - name: add iptable ALLOW rules for control-plane
     iptables:

--- a/hack/flatcar-ami.pkr.hcl
+++ b/hack/flatcar-ami.pkr.hcl
@@ -2,6 +2,7 @@ data "amazon-ami" "flatcar" {
   filters = {
     virtualization-type = "hvm"
     name                = "Flatcar-stable-*-hvm"
+    architecture        = "x86_64"
   }
   owners      = ["075585003325"]
   most_recent = true


### PR DESCRIPTION
**What problem does this PR solve?**:
e2e failures https://teamcity.mesosphere.io/buildConfiguration/ClosedSource_KonvoyImageBuilder_E2e/3309292?buildTab=log&focusLine=15382&linesState=389

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
