### PR TITLE
build: stop building tags that aren't a part of the current release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -63,10 +63,6 @@ dockers:
   - dockerfile: Dockerfile.devkit
     image_templates:
       - 'mesosphere/konvoy-image-builder:v{{ trimprefix .Version "v" }}-devkit'
-      - "{{ if not .IsSnapshot }}mesosphere/konvoy-image-builder:v{{ .Major }}.{{ .Minor }}-devkit{{ end }}"
-      - "{{ if not .IsSnapshot }}mesosphere/konvoy-image-builder:v{{ .Major }}.{{ .Minor }}-devkit{{ end }}"
-      - "{{ if not .IsSnapshot }}mesosphere/konvoy-image-builder:v{{ .Major }}-devkit{{ end }}"
-      - "{{ if not .IsSnapshot }}mesosphere/konvoy-image-builder:latest-devkit{{ end }}"
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{ .Date }}"
@@ -80,9 +76,6 @@ dockers:
   - dockerfile: Dockerfile
     image_templates:
       - 'mesosphere/konvoy-image-builder:v{{ trimprefix .Version "v" }}'
-      - "{{ if not .IsSnapshot }}mesosphere/konvoy-image-builder:v{{ .Major }}.{{ .Minor }}{{ end }}"
-      - "{{ if not .IsSnapshot }}mesosphere/konvoy-image-builder:v{{ .Major }}{{ end }}"
-      - "{{ if not .IsSnapshot }}mesosphere/konvoy-image-builder:latest{{ end }}"
     ids:
       - konvoy-image
     # NOTE(jkoelker) Exclude `--pull` from the build flags, since the devkit


### PR DESCRIPTION
**What problem does this PR solve?**:
No longer build excess v{major}.{minor} tags and v{major} tags as we push rc to dockerhub as well now.


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
