### PR TITLE
Revert "build(deps): bump alpine from 3.14.2 to 3.15.0"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE=mesosphere/konvoy-image-builder:latest-devkit
 # hadolint ignore=DL3006
 FROM ${BASE} as devkit
 
-FROM alpine:3.15.0
+FROM alpine:3.14.2
 
 ARG ANSIBLE_VERSION=2.10.7
 ENV ANSIBLE_PATH=/usr


### PR DESCRIPTION
Reverts mesosphere/konvoy-image-builder#148 to fix this issue https://githubmemory.com/repo/atmoz/sftp/issues/296

It appears that the keys packer is creating are not compatible with this new version of open-ssh (8.8) that is shipped with alpine. This is a quick measure until we can figure out how to get packer to create different key types that are compatible with open-ssh 8.8