### PR TITLE
only manage a systemd service if it exists

### DIFF
--- a/ansible/roles/sysprep/tasks/redhat.yml
+++ b/ansible/roles/sysprep/tasks/redhat.yml
@@ -19,13 +19,17 @@
 
 - import_tasks: rpm_repos.yml
 
+- name: Populate service facts
+  ansible.builtin.service_facts:
+
 - name: Disable swap service and ensure it is masked
   systemd:
     name: temp-disk-swapfile
     enabled: false
     masked: true
-  when: ansible_memory_mb.swap.total != 0
-
+  when:
+    - ansible_memory_mb.swap.total != 0
+    - "'temp-disk-swapfile' in ansible_facts.services"
 
 - name: Remove yum package caches
   yum:

--- a/ansible/roles/sysprep/tasks/suse.yml
+++ b/ansible/roles/sysprep/tasks/suse.yml
@@ -17,12 +17,17 @@
     last_log_mode: "0664"
     machine_id_mode: "0444"
 
+- name: Populate service facts
+  ansible.builtin.service_facts:
+
 - name: Disable swap service and ensure it is masked
   systemd:
     name: temp-disk-swapfile
     enabled: false
     masked: true
-  when: ansible_memory_mb.swap.total != 0
+  when:
+    - ansible_memory_mb.swap.total != 0
+    - "'temp-disk-swapfile' in ansible_facts.services"
 
 - name: Remove SUSE subscription
   block:


### PR DESCRIPTION
**What problem does this PR solve?**:
fix error when swap is on and the systemd service `temp-disk-swapfile` doesn't exist

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
