### PR TITLE
build(lint): switch from golint to revive

### DIFF
--- a/.github/super-linter.env
+++ b/.github/super-linter.env
@@ -3,3 +3,6 @@ FILTER_REGEX_EXCLUDE=(/.cache/|/work/|/.vscode/|/.devcontainer/|/bin/|/.mypy_cac
 VALIDATE_ANSIBLE=false
 # NOTE(jkoelker) Hadolint covers the dockerfiles
 VALIDATE_DOCKERFILE=false
+# NOTE(joejulian) super-linter tests go files one at a time, breaking packaging
+# https://github.com/github/super-linter/issues/143
+VALIDATE_GOLANG=false

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,22 @@
+---
+name: golangci-lint
+"on":
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+      - main
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2.5.2
+        with:
+          version: v1.43.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,8 +37,6 @@ linters-settings:
     min-complexity: 15
   goimports:
     local-prefixes: github.com/mesosphere/konvoy-image-builder
-  golint:
-    min-confidence: 0
   gomnd:
     settings:
       mnd:
@@ -61,6 +59,9 @@ linters-settings:
     allow-unused: false
     require-explanation: true
     require-specific: true
+  revive:
+    confidence: 0.0
+    errorCode: 1
 
 linters:
   # please, do not use `enable-all`: it's deprecated and will be removed soon.
@@ -85,7 +86,6 @@ linters:
     - gofmt
     - gofumpt
     - goimports
-    - golint
     - gomnd
     - goprintffuncname
     - gosec
@@ -101,6 +101,7 @@ linters:
     - nolintlint
     - prealloc
     - predeclared
+    - revive
     - staticcheck
     - structcheck
     - stylecheck


### PR DESCRIPTION
This also disables golang linting in super-linter due to a design flaw
in super-linter.