### PR TITLE
fix: set the correct KIB version ami tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,11 +351,15 @@ bin/konvoy-image: $(shell find $(REPO_ROOT_DIR)/pkg -type f -name '*'.go)
 bin/konvoy-image: $(shell find $(REPO_ROOT_DIR)/pkg -type f -name '*'.tmpl)
 bin/konvoy-image:
 	$(call print-target)
-	go build -o ./bin/konvoy-image ./cmd/konvoy-image/main.go
+	go build \
+		-ldflags="-X github.com/mesosphere/konvoy-image-builder/pkg/version.version=$(REPO_REV)" \
+		-o ./bin/konvoy-image ./cmd/konvoy-image/main.go
 
 bin/konvoy-image-wrapper:
 	$(call print-target)
-	go build -o ./bin/konvoy-image-wrapper ./cmd/konvoy-image-wrapper/main.go
+	go build \
+		-ldflags="-X github.com/mesosphere/konvoy-image-builder/pkg/version.version=$(REPO_REV)" \
+		-o ./bin/konvoy-image-wrapper ./cmd/konvoy-image-wrapper/main.go
 
 dist/konvoy-image_linux_amd64/konvoy-image: $(REPO_ROOT_DIR)/cmd
 dist/konvoy-image_linux_amd64/konvoy-image: $(shell find $(REPO_ROOT_DIR)/cmd -type f -name '*'.go)

--- a/pkg/app/build.go
+++ b/pkg/app/build.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mesosphere/konvoy-image-builder/pkg/appansible"
 	"github.com/mesosphere/konvoy-image-builder/pkg/packer"
 	"github.com/mesosphere/konvoy-image-builder/pkg/stringutil"
+	"github.com/mesosphere/konvoy-image-builder/pkg/version"
 )
 
 const (
@@ -44,6 +45,7 @@ const (
 	packerBuilderRegionKey     = "aws_region"
 	packerAMIRegionsKey        = "ami_regions"
 	packerInstanceType         = "aws_instance_type"
+	packerKIBVersionKey        = "konvoy_image_builder_version"
 
 	ansibleVarsFilename = "ansible_vars.yaml"
 )
@@ -302,6 +304,7 @@ func genPackerVars(config map[string]interface{}, extraVarsPath string) ([]byte,
 	p[httpProxyKey] = getString(config, httpProxyKey)
 	p[httpsProxyKey] = getString(config, httpsProxyKey)
 	p[noProxyKey] = getString(config, noProxyKey)
+	p[packerKIBVersionKey] = version.Version()
 
 	data, err := json.Marshal(p)
 	if err != nil {


### PR DESCRIPTION
**What problem does this PR solve?**:

Sets the correct KIB version in the ami tag. Previously this was always defaulting to `0.0.1` from the fallback value in `pkg/packer/manifests/aws/packer.json.tmpl`.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note
Fix: The correct Konvoy Image Builder version will be set in the resulting AMI tags.
```
