### PR TITLE
chore: create RHEL 7.9 fips image for airgapped installations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,6 +239,14 @@ rhel79: ## Build RHEL 7.9 image
 	-v ${VERBOSITY} \
 	$(if $(ADDITIONAL_OVERRIDES),--overrides=${ADDITIONAL_OVERRIDES})
 
+.PHONY: rhel79-fips
+rhel79-fips: build
+rhel79-fips: ## Build RHEL 7.9 image
+	./bin/konvoy-image build images/ami/rhel-79.yaml \
+	-v ${VERBOSITY} \
+	--overrides=overrides/fips.yaml \
+	$(if $(ADDITIONAL_OVERRIDES),--overrides=${ADDITIONAL_OVERRIDES})
+
 .PHONY: rhel79-nvidia
 rhel79-nvidia: build
 rhel79-nvidia: ## Build RHEL 7.9 image with GPU support
@@ -511,7 +519,6 @@ endif
 # Output is interleaved when run in parallel. Use --output-sync=recurse to serialize output.
 ci.e2e.build.all: ci.e2e.build.centos-7
 ci.e2e.build.all: e2e.build.centos-7-offline
-ci.e2e.build.all: e2e.build.centos-7-offline-fips
 ci.e2e.build.all: ci.e2e.build.centos-8
 ci.e2e.build.all: ci.e2e.build.ubuntu-18
 ci.e2e.build.all: ci.e2e.build.ubuntu-20
@@ -519,6 +526,7 @@ ci.e2e.build.all: ci.e2e.build.sles-15
 ci.e2e.build.all: ci.e2e.build.oracle-7
 ci.e2e.build.all: ci.e2e.build.oracle-8
 ci.e2e.build.all: ci.e2e.build.flatcar
+ci.e2e.build.all: e2e.build.rhel-7.9-offline-fips
 ci.e2e.build.all: ci.e2e.build.rhel-8-fips
 ci.e2e.build.all: ci.e2e.build.centos-7-nvidia
 ci.e2e.build.all: ci.e2e.build.centos-8-nvidia
@@ -537,10 +545,10 @@ e2e.build.centos-7-offline:
 	$(MAKE) devkit.run WHAT="make centos7 ADDITIONAL_OVERRIDES=overrides/offline.yaml"
 	$(MAKE) docker.clean-latest-ami
 
-e2e.build.centos-7-offline-fips:
+e2e.build.rhel-7.9-offline-fips:
 	$(MAKE) os-packages-artifacts pip-packages-artifacts
 	$(MAKE) devkit.run WHAT="make save-images"
-	$(MAKE) devkit.run WHAT="make centos7 ADDITIONAL_OVERRIDES=overrides/offline-fips.yaml"
+	$(MAKE) devkit.run WHAT="make rhel79-fips ADDITIONAL_OVERRIDES=overrides/offline-fips.yaml"
 	$(MAKE) docker.clean-latest-ami
 
 e2e.build.centos-8: centos8 docker.clean-latest-ami

--- a/Makefile
+++ b/Makefile
@@ -329,6 +329,7 @@ ci: ## CI build
 ci: dev diff
 
 .PHONY: clean
+clean: clean-artifacts
 clean: ## remove files created during build
 	$(call print-target)
 	rm -rf bin
@@ -336,7 +337,6 @@ clean: ## remove files created during build
 	rm -rf "$(REPO_ROOT_DIR)/cmd/konvoy-image-wrapper/image/konvoy-image-builder.tar.gz"
 	rm -f flatcar-version.yaml
 	rm -f $(COVERAGE)*
-	rm -rf artifacts
 	docker image rm $(DOCKER_DEVKIT_IMG) || echo "image already removed"
 
 .PHONY: generate

--- a/Makefile
+++ b/Makefile
@@ -511,6 +511,7 @@ endif
 # Output is interleaved when run in parallel. Use --output-sync=recurse to serialize output.
 ci.e2e.build.all: ci.e2e.build.centos-7
 ci.e2e.build.all: e2e.build.centos-7-offline
+ci.e2e.build.all: e2e.build.centos-7-offline-fips
 ci.e2e.build.all: ci.e2e.build.centos-8
 ci.e2e.build.all: ci.e2e.build.ubuntu-18
 ci.e2e.build.all: ci.e2e.build.ubuntu-20
@@ -534,6 +535,12 @@ e2e.build.centos-7-offline:
 	$(MAKE) os-packages-artifacts pip-packages-artifacts
 	$(MAKE) devkit.run WHAT="make save-images"
 	$(MAKE) devkit.run WHAT="make centos7 ADDITIONAL_OVERRIDES=overrides/offline.yaml"
+	$(MAKE) docker.clean-latest-ami
+
+e2e.build.centos-7-offline-fips:
+	$(MAKE) os-packages-artifacts pip-packages-artifacts
+	$(MAKE) devkit.run WHAT="make save-images"
+	$(MAKE) devkit.run WHAT="make centos7 ADDITIONAL_OVERRIDES=overrides/offline-fips.yaml"
 	$(MAKE) docker.clean-latest-ami
 
 e2e.build.centos-8: centos8 docker.clean-latest-ami

--- a/ansible/roles/packages/tasks/install-redhat.yaml
+++ b/ansible/roles/packages/tasks/install-redhat.yaml
@@ -74,6 +74,7 @@
   when:
     - ansible_distribution == 'RedHat'
     - ansible_distribution_major_version|int == 7
+    - not offline_mode_enabled
 
 - name: install container-selinux rpm package
   yum:

--- a/hack/os-packages/Makefile
+++ b/hack/os-packages/Makefile
@@ -1,5 +1,4 @@
 RPM_PACKAGES_GETTER_IMAGE = mesosphere/rpm-artifacts-getter
-CENTOS_BASE_IMAGE=mesosphere/centos:7.9.2009.minimal
 KUBERNETES_RPM_PATCH = 0
 
 .PHONY: os-packages-artifacts
@@ -45,13 +44,12 @@ endif
 
 .PHONY: rpm-artifacts-getter.check
 rpm-artifacts-getter.check:
-	docker image inspect $(rpm_getter_image) > /dev/null || $(MAKE) build_args='--build-arg BASE_IMAGE=$(CENTOS_BASE_IMAGE)' rpm-artifacts-getter
+	docker image inspect $(rpm_getter_image) > /dev/null || $(MAKE) rpm-artifacts-getter
 
 .PHONY: rpm-artifacts-getter
 rpm-artifacts-getter:
 	@docker build \
 	  -f hack/os-packages/$(getter_target)/Dockerfile \
-	  $(build_args) \
 	  -t $(rpm_getter_image) ./hack/os-packages/$(getter_target)
 
 $(artifacts_dir):

--- a/hack/os-packages/Makefile
+++ b/hack/os-packages/Makefile
@@ -1,17 +1,20 @@
 RPM_PACKAGES_GETTER_IMAGE = mesosphere/rpm-artifacts-getter
-RPM_FIPS_PACKAGES_GETTER_IMAGE = mesosphere/rpm-artifacts-getter-fips
-
+CENTOS_BASE_IMAGE=mesosphere/centos:7.9.2009.minimal
 KUBERNETES_RPM_PATCH = 0
 
 .PHONY: os-packages-artifacts
-os-packages-artifacts: download-all-rpms artifacts/os-packages_$(DEFAULT_KUBERNETES_VERSION_SEMVER)_x86_64_rpms.tar.gz
+os-packages-artifacts: download-all-rpms artifacts/os-packages_$(DEFAULT_KUBERNETES_VERSION_SEMVER)_x86_64_rpms.tar.gz artifacts/os-packages_$(DEFAULT_KUBERNETES_VERSION_SEMVER)_x86_64_fips_rpms.tar.gz
 
 artifacts/os-packages_$(DEFAULT_KUBERNETES_VERSION_SEMVER)_x86_64_rpms.tar.gz:
 	cd artifacts/os-packages_$(DEFAULT_KUBERNETES_VERSION_SEMVER)_el7_x86_64_rpms && tar -czf ../os-packages_$(DEFAULT_KUBERNETES_VERSION_SEMVER)_x86_64_rpms.tar.gz *
 
+artifacts/os-packages_$(DEFAULT_KUBERNETES_VERSION_SEMVER)_x86_64_fips_rpms.tar.gz:
+	cd artifacts/os-packages_$(DEFAULT_KUBERNETES_VERSION_SEMVER)_el7_x86_64_fips_rpms && tar -czf ../os-packages_$(DEFAULT_KUBERNETES_VERSION_SEMVER)_x86_64_fips_rpms.tar.gz *
+
 .PHONY: download-all-rpms
 download-all-rpms:
-	$(MAKE) rhel_major_version=7 fips=0 bastion=0  download-rpms
+	$(MAKE) rhel_major_version=7 fips=0 download-rpms
+	$(MAKE) rhel_major_version=7 fips=1 download-rpms
 #	$(MAKE) rhel_major_version=8 fips=0 bastion=0  download-rpms
 #	$(MAKE) rhel_major_version=7 fips=0 bastion=1  download-rpms
 #	$(MAKE) rhel_major_version=8 fips=0 bastion=1  download-rpms
@@ -22,7 +25,7 @@ download-all-rpms:
 download-rpms:
 	$(MAKE) rhel_major_version=$(rhel_major_version) fips=$(fips) rpm-artifacts-getter.check
 	$(MAKE) rhel_major_version=$(rhel_major_version) fips=$(fips) packages="audit ca-certificates conntrack-tools chrony curl ebtables open-vm-tools python3-pip python-netifaces python-requests socat sysstat yum-utils yum-plugin-versionlock nfs-utils NetworkManager" download-rpm
-	# packages that are not in CentOS-7 Minimal
+# packages that are not in CentOS-7 Minimal
 	$(MAKE) rhel_major_version=$(rhel_major_version) fips=$(fips) packages="tzdata nspr nss python-chardet yum-utils nss-softokn-freebl nss-util nss-softokn nss nss-tools  NetworkManager-libnm libdrm libpciaccess libxml2-python python-kitchen yum-plugin-ovl" download-rpm
 	$(MAKE) rhel_major_version=$(rhel_major_version) fips=$(fips) packages="container-selinux containerd.io-$(CONTAINERD_VERSION) container-selinux" download-rpm
 	$(MAKE) rhel_major_version=$(rhel_major_version) fips=$(fips) packages="kubectl-$(DEFAULT_KUBERNETES_VERSION_SEMVER)-$(KUBERNETES_RPM_PATCH) kubelet-$(DEFAULT_KUBERNETES_VERSION_SEMVER)-$(KUBERNETES_RPM_PATCH) conntrack ebtables ethtool iproute iptables kubernetes-cni libnetfilter_cthelper libnetfilter_cttimeout libnetfilter_queue libblkid libmount libsmartcols libuuid socat util-linux kubeadm-$(DEFAULT_KUBERNETES_VERSION_SEMVER)-$(KUBERNETES_RPM_PATCH) kubernetes-cni cri-tools" download-rpm
@@ -31,34 +34,40 @@ download-rpms:
 
 ifeq ($(fips), 1)
 artifacts_dir = $(shell pwd)/artifacts/os-packages_$(DEFAULT_KUBERNETES_VERSION_SEMVER)_el$(rhel_major_version)_x86_64_fips_rpms
-rpm_getter_image = $(RPM_PACKAGES_GETTER_IMAGE)-fips-$(rhel_major_version)
-getter_target = rpm-fips-artifacts-getter
+rpm_getter_image = $(RPM_PACKAGES_GETTER_IMAGE)-fips-centos:$(rhel_major_version)
+getter_target = rpm-fips-artifacts-getter/centos/$(rhel_major_version)
 endif
 ifeq ($(fips), 0)
 artifacts_dir = $(shell pwd)/artifacts/os-packages_$(DEFAULT_KUBERNETES_VERSION_SEMVER)_el$(rhel_major_version)_x86_64_rpms
-rpm_getter_image = $(RPM_PACKAGES_GETTER_IMAGE)-$(rhel_major_version)
-getter_target = rpm-artifacts-getter
+rpm_getter_image = $(RPM_PACKAGES_GETTER_IMAGE)-centos:$(rhel_major_version)
+getter_target = rpm-artifacts-getter/centos/$(rhel_major_version)
 endif
 
 .PHONY: rpm-artifacts-getter.check
 rpm-artifacts-getter.check:
-	docker image inspect $(rpm_getter_image):$(DEFAULT_KUBERNETES_VERSION_SEMVER) > /dev/null || $(MAKE) fips=$(fips) rhel_major_version=$(rhel_major_version) rpm-artifacts-getter
+	docker image inspect $(rpm_getter_image) > /dev/null || $(MAKE) build_args='--build-arg BASE_IMAGE=$(CENTOS_BASE_IMAGE)' rpm-artifacts-getter
 
 .PHONY: rpm-artifacts-getter
 rpm-artifacts-getter:
 	@docker build \
-	  -f hack/os-packages/$(getter_target)-$(rhel_major_version)/Dockerfile \
-	  -t $(rpm_getter_image):$(DEFAULT_KUBERNETES_VERSION_SEMVER) ./hack/os-packages/$(getter_target)-$(rhel_major_version)/
+	  -f hack/os-packages/$(getter_target)/Dockerfile \
+	  $(build_args) \
+	  -t $(rpm_getter_image) ./hack/os-packages/$(getter_target)
 
 $(artifacts_dir):
 	mkdir -p $(artifacts_dir)
 
 .PHONY: download-rpm
-download-rpm: $(artifact_dir)
-	docker run --rm -v "$(artifacts_dir):/opt/dkp/rpms/" -v /tmp/dnfcache:/var/cache/dnf -w /opt/dkp/rpms $(rpm_getter_image):$(DEFAULT_KUBERNETES_VERSION_SEMVER) \
-		/bin/sh -c 'yumdownloader -y --setopt=skip_missing_names_on_install=False --destdir=. -x \*i686 --archlist=x86_64,noarch --resolve $(packages) && chown -R $(shell id -u):$(shell id -g) .'
+download-rpm: $(artifacts_dir)
+	docker run --rm -v "$(artifacts_dir):/opt/dkp/rpms/" -v /tmp/dnfcache:/var/cache/dnf -w /opt/dkp/rpms $(rpm_getter_image) \
+	/bin/sh -c 'yumdownloader -y --setopt=skip_missing_names_on_install=False --destdir=. -x \*i686 --archlist=x86_64,noarch --resolve $(packages) && chown -R $(shell id -u):$(shell id -g) .'
 
 .PHONY: createrepo
 createrepo:
-	docker run --rm -v "$(artifacts_dir):/opt/dkp/rpms/" -v /tmp/dnfcache:/var/cache/dnf -w /opt/dkp/rpms $(rpm_getter_image):$(DEFAULT_KUBERNETES_VERSION_SEMVER) \
+	docker run --rm -v "$(artifacts_dir):/opt/dkp/rpms/" -v /tmp/dnfcache:/var/cache/dnf -w /opt/dkp/rpms $(rpm_getter_image) \
 		/bin/sh -c 'createrepo -v . && chown -R $(shell id -u):$(shell id -g) repodata/'
+
+.PHONY: clean-artifacts
+clean-artifacts:
+	rm -rf $(shell pwd)/artifacts
+	docker images | grep $(RPM_PACKAGES_GETTER_IMAGE) | awk '{ print $$1":"$$2}' | xargs docker image rm

--- a/hack/os-packages/rpm-artifacts-getter-7/Dockerfile
+++ b/hack/os-packages/rpm-artifacts-getter-7/Dockerfile
@@ -1,8 +1,0 @@
-FROM mesosphere/centos:7.9.2009.minimal
-
-COPY *.repo /etc/yum.repos.d/
-
-# hadolint ignore=DL3033
-RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
-    yum -y install yum-utils createrepo && \
-    yum clean all

--- a/hack/os-packages/rpm-artifacts-getter/centos/7/Dockerfile
+++ b/hack/os-packages/rpm-artifacts-getter/centos/7/Dockerfile
@@ -1,0 +1,8 @@
+ARG BASE_IMAGE=mesosphere/centos:7.9.2009.minimal
+FROM $BASE_IMAGE
+
+COPY *.repo /etc/yum.repos.d/
+
+# hadolint ignore=DL3033
+RUN yum -y install epel-release yum-utils createrepo && \
+    yum clean all

--- a/hack/os-packages/rpm-artifacts-getter/centos/7/Dockerfile
+++ b/hack/os-packages/rpm-artifacts-getter/centos/7/Dockerfile
@@ -1,4 +1,5 @@
 ARG BASE_IMAGE=mesosphere/centos:7.9.2009.minimal
+# hadolint ignore=DL3006
 FROM $BASE_IMAGE
 
 COPY *.repo /etc/yum.repos.d/

--- a/hack/os-packages/rpm-artifacts-getter/centos/7/Dockerfile
+++ b/hack/os-packages/rpm-artifacts-getter/centos/7/Dockerfile
@@ -1,6 +1,4 @@
-ARG BASE_IMAGE=mesosphere/centos:7.9.2009.minimal
-# hadolint ignore=DL3006
-FROM $BASE_IMAGE
+FROM mesosphere/centos:7.9.2009.minimal
 
 COPY *.repo /etc/yum.repos.d/
 

--- a/hack/os-packages/rpm-artifacts-getter/centos/7/containerd.repo
+++ b/hack/os-packages/rpm-artifacts-getter/centos/7/containerd.repo
@@ -1,5 +1,5 @@
 [konvoy-packages]
 baseurl = https://packages.d2iq.com/konvoy/stable/linux/centos/7/x86_64
-gpgcheck = 1
-gpgkey = https://packages.d2iq.com/konvoy/stable/linux/centos/7/x86_64/gpg.asc
+gpgcheck = 0
+gpgkey = ""
 name = Konvoy Containerd package repository

--- a/hack/os-packages/rpm-artifacts-getter/centos/7/containerd.repo
+++ b/hack/os-packages/rpm-artifacts-getter/centos/7/containerd.repo
@@ -1,5 +1,5 @@
 [konvoy-packages]
-baseurl = https://packages.d2iq.com/konvoy/stable/linux/centos/7/x86_64
-gpgcheck = 0
-gpgkey = ""
 name = Konvoy Containerd package repository
+baseurl = https://packages.d2iq.com/konvoy/stable/linux/centos/7/x86_64
+gpgcheck = 1
+gpgkey = https://packages.d2iq.com/konvoy/stable/linux/centos/7/x86_64/gpg.asc

--- a/hack/os-packages/rpm-artifacts-getter/centos/7/kubernetes.repo
+++ b/hack/os-packages/rpm-artifacts-getter/centos/7/kubernetes.repo
@@ -1,5 +1,5 @@
 [kubernetes]
 name=Konvoy Kubernetes package repository
-baseurl=https://kubernetes-fips.s3.us-east-2.amazonaws.com/7/x86_64
+baseurl=https://packages.d2iq.com/konvoy/rpm/stable/centos/7/x86_64
 gpgcheck=1
 gpgkey=https://packages.d2iq.com/konvoy/rpm-gpg-pub-key

--- a/hack/os-packages/rpm-artifacts-getter/centos/7/kubernetes.repo
+++ b/hack/os-packages/rpm-artifacts-getter/centos/7/kubernetes.repo
@@ -1,5 +1,5 @@
 [kubernetes]
 name=Konvoy Kubernetes package repository
-baseurl=https://packages.d2iq.com/konvoy/rpm/stable/centos/7/x86_64
+baseurl=https://kubernetes-fips.s3.us-east-2.amazonaws.com/7/x86_64
 gpgcheck=1
 gpgkey=https://packages.d2iq.com/konvoy/rpm-gpg-pub-key

--- a/hack/os-packages/rpm-fips-artifacts-getter/centos/7/Dockerfile
+++ b/hack/os-packages/rpm-fips-artifacts-getter/centos/7/Dockerfile
@@ -1,0 +1,8 @@
+ARG BASE_IMAGE=mesosphere/centos:7.9.2009.minimal
+FROM $BASE_IMAGE
+
+COPY *.repo /etc/yum.repos.d/
+
+# hadolint ignore=DL3033
+RUN yum -y install epel-release yum-utils createrepo && \
+    yum clean all

--- a/hack/os-packages/rpm-fips-artifacts-getter/centos/7/Dockerfile
+++ b/hack/os-packages/rpm-fips-artifacts-getter/centos/7/Dockerfile
@@ -1,4 +1,5 @@
 ARG BASE_IMAGE=mesosphere/centos:7.9.2009.minimal
+# hadolint ignore=DL3006
 FROM $BASE_IMAGE
 
 COPY *.repo /etc/yum.repos.d/

--- a/hack/os-packages/rpm-fips-artifacts-getter/centos/7/Dockerfile
+++ b/hack/os-packages/rpm-fips-artifacts-getter/centos/7/Dockerfile
@@ -1,6 +1,4 @@
-ARG BASE_IMAGE=mesosphere/centos:7.9.2009.minimal
-# hadolint ignore=DL3006
-FROM $BASE_IMAGE
+FROM mesosphere/centos:7.9.2009.minimal
 
 COPY *.repo /etc/yum.repos.d/
 

--- a/hack/os-packages/rpm-fips-artifacts-getter/centos/7/containerd.fips.repo
+++ b/hack/os-packages/rpm-fips-artifacts-getter/centos/7/containerd.fips.repo
@@ -1,0 +1,5 @@
+[containerd-fips]
+baseurl = https://containerd-fips.s3.us-east-2.amazonaws.com/7/x86_64
+gpgcheck = 0
+gpgkey = ""
+name = FIPS enabled containerd package repository

--- a/hack/os-packages/rpm-fips-artifacts-getter/centos/7/containerd.fips.repo
+++ b/hack/os-packages/rpm-fips-artifacts-getter/centos/7/containerd.fips.repo
@@ -1,5 +1,5 @@
 [containerd-fips]
 baseurl = https://containerd-fips.s3.us-east-2.amazonaws.com/7/x86_64
-gpgcheck = 0
-gpgkey = ""
+gpgcheck = 1
+gpgkey = https://containerd-fips.s3.us-east-2.amazonaws.com/7/x86_64/gpg.asc
 name = FIPS enabled containerd package repository

--- a/hack/os-packages/rpm-fips-artifacts-getter/centos/7/kubernetes.fips.repo
+++ b/hack/os-packages/rpm-fips-artifacts-getter/centos/7/kubernetes.fips.repo
@@ -1,0 +1,5 @@
+[kubernetes-fips]
+name=FIPS enabled Konvoy Kubernetes package repository
+baseurl=https://kubernetes-fips.s3.us-east-2.amazonaws.com/7/x86_64
+gpgcheck=1
+gpgkey=https://kubernetes-fips.s3.us-east-2.amazonaws.com/7/rpm-gpg-pub-key

--- a/overrides/offline-fips.yaml
+++ b/overrides/offline-fips.yaml
@@ -1,15 +1,4 @@
-k8s_image_registry: docker.io/mesosphere
-
-fips:
-  enabled: true
-
-build_name_extra: -fips
-kubernetes_build_metadata: fips.0
-default_image_repo: hub.docker.io/mesosphere
-
 # fips os-packages
 os_packages_local_bundle_file: "{{ playbook_dir }}/../artifacts/os-packages_{{ kubernetes_version }}_x86_64_fips_rpms.tar.gz"
 pip_packages_local_bundle_file: "{{ playbook_dir }}/../artifacts/pip-packages.tar.gz"
 images_local_bundle_dir: "{{ playbook_dir}}/../artifacts/images"
-
-

--- a/overrides/offline-fips.yaml
+++ b/overrides/offline-fips.yaml
@@ -6,18 +6,6 @@ fips:
 build_name_extra: -fips
 kubernetes_build_metadata: fips.0
 default_image_repo: hub.docker.io/mesosphere
-kubernetes_rpm_repository_url: "\
-  https://kubernetes-fips.s3.us-east-2.amazonaws.com\
-  /{{ ansible_distribution_major_version|int }}\
-  /x86_64"
-kubernetes_rpm_gpg_key_url: "\
-  https://kubernetes-fips.s3.us-east-2.amazonaws.com\
-  /{{ ansible_distribution_major_version|int }}\
-  /rpm-gpg-pub-key"
-docker_rpm_repository_url: "\
-  https://containerd-fips.s3.us-east-2.amazonaws.com\
-  /{{ ansible_distribution_major_version|int }}\
-  /x86_64"
 
 # fips os-packages
 os_packages_local_bundle_file: "{{ playbook_dir }}/../artifacts/os-packages_{{ kubernetes_version }}_x86_64_fips_rpms.tar.gz"

--- a/overrides/offline-fips.yaml
+++ b/overrides/offline-fips.yaml
@@ -1,0 +1,27 @@
+k8s_image_registry: docker.io/mesosphere
+
+fips:
+  enabled: true
+
+build_name_extra: -fips
+kubernetes_build_metadata: fips.0
+default_image_repo: hub.docker.io/mesosphere
+kubernetes_rpm_repository_url: "\
+  https://kubernetes-fips.s3.us-east-2.amazonaws.com\
+  /{{ ansible_distribution_major_version|int }}\
+  /x86_64"
+kubernetes_rpm_gpg_key_url: "\
+  https://kubernetes-fips.s3.us-east-2.amazonaws.com\
+  /{{ ansible_distribution_major_version|int }}\
+  /rpm-gpg-pub-key"
+docker_rpm_repository_url: "\
+  https://containerd-fips.s3.us-east-2.amazonaws.com\
+  /{{ ansible_distribution_major_version|int }}\
+  /x86_64"
+
+# fips os-packages
+os_packages_local_bundle_file: "{{ playbook_dir }}/../artifacts/os-packages_{{ kubernetes_version }}_x86_64_fips_rpms.tar.gz"
+pip_packages_local_bundle_file: "{{ playbook_dir }}/../artifacts/pip-packages.tar.gz"
+images_local_bundle_dir: "{{ playbook_dir}}/../artifacts/images"
+
+


### PR DESCRIPTION
**What problem does this PR solve?**:
- build rhel 7.9 AMI for FIPS and airgapped mode
- refactor `os-package` building code to support multiple OS distros/versions/FIPS combinations

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
- https://jira.d2iq.com/browse/D2IQ-83344

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
