### PR TITLE
fix: Allow user to provide a subset of registry configuration fields

### DIFF
--- a/ansible/roles/config/templates/config.toml.tmpl
+++ b/ansible/roles/config/templates/config.toml.tmpl
@@ -120,10 +120,18 @@ imports = ["/etc/containerd/conf.d/*.toml"]
       [plugins."io.containerd.grpc.v1.cri".registry.configs]
 {% for registry in image_registries_with_auth %}
         [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ registry.host }}".auth]
+        {% if registry.username is defined %}
             username = "{{ registry.username }}"
+        {% endif %}
+        {% if registry.password is defined %}
             password = "{{ registry.password }}"
+        {% endif %}
+        {% if registry.auth is defined %}
             auth = "{{ registry.auth }}"
+        {% endif %}
+        {% if registry.identityToken is defined %}
             identitytoken = "{{ registry.identityToken }}"
+        {% endif %}
 {% endfor %}
 {% endif %}
     [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]


### PR DESCRIPTION
**What problem does this PR solve?**:
Allows user to provide a subset of registry configuration fields.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-83441


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
Any suggestions on where to test this?

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note
The user can omit unused fields from their registry credentials override.
```
