### PR TITLE
feat: adds an upload artifacts command to konvoy image builder

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,8 +35,6 @@ linters-settings:
       - style
   gocyclo:
     min-complexity: 15
-  goimports:
-    local-prefixes: github.com/mesosphere/konvoy-image-builder
   gomnd:
     settings:
       mnd:

--- a/ansible/upload-artifacts.yaml
+++ b/ansible/upload-artifacts.yaml
@@ -1,0 +1,26 @@
+---
+- hosts: all
+  name: Prepare Ansible - Flatcar Python setup
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Flatcar no update
+      changed_when: false
+      script: ../packer/files/no-update-flatcar.sh
+    - name: exec bootstrap python
+      changed_when: false
+      script: ../packer/files/bootstrap-flatcar.sh
+    - name: check for flatcar python
+      raw: stat /opt/bin/.bootstrapped
+      changed_when: false
+      failed_when: false
+      register: flatcar_bootstrapped
+    - name: change python if bootstrapped
+      set_fact:
+        ansible_python_interpreter: /opt/bin/python
+      when: flatcar_bootstrapped.rc == 0
+- hosts: all
+  name: Upload Artifacts 
+  become: true
+  roles:
+    - role: offline

--- a/cmd/konvoy-image/cmd/artifacts.go
+++ b/cmd/konvoy-image/cmd/artifacts.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mesosphere/konvoy-image-builder/pkg/app"
+)
+
+var artifactsFlags app.ArtifactsCmdFlags
+
+var artifactsCmd = &cobra.Command{
+	Use:   "artifacts",
+	Short: "upload artifacts to hosts defined in inventory-file",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := app.UploadArtifacts(artifactsFlags)
+		if err != nil {
+			return fmt.Errorf("failed to upload artifacts %w", err)
+		}
+		return nil
+	},
+}
+
+func init() {
+	fs := artifactsCmd.Flags()
+	fs.StringVar(&artifactsFlags.Inventory, "inventory-file", "inventory.yaml", "an ansible inventory defining your infrastructure")
+	fs.StringVar(&artifactsFlags.OSPackagesBundleFile, "os-packages-bundle", "", "path to os-packages tar file for install on remote hosts.")
+	fs.StringVar(&artifactsFlags.PIPPackagesBundleFile, "pip-packages-bundle", "", "path to pip-packages tar file"+
+		"for install on remote hosts.")
+	fs.StringVar(&artifactsFlags.ContainerImagesBundleDir, "container-images-dir", "", "path to container images for install on remote hosts.")
+}

--- a/cmd/konvoy-image/cmd/artifacts.go
+++ b/cmd/konvoy-image/cmd/artifacts.go
@@ -28,6 +28,6 @@ func init() {
 	fs.StringVar(&artifactsFlags.Inventory, "inventory-file", "inventory.yaml", "an ansible inventory defining your infrastructure")
 	fs.StringVar(&artifactsFlags.OSPackagesBundleFile, "os-packages-bundle", "", "path to os-packages tar file for install on remote hosts.")
 	fs.StringVar(&artifactsFlags.PIPPackagesBundleFile, "pip-packages-bundle", "", "path to pip-packages tar file"+
-		"for install on remote hosts.")
+		" for install on remote hosts.")
 	fs.StringVar(&artifactsFlags.ContainerImagesBundleDir, "container-images-dir", "", "path to container images for install on remote hosts.")
 }

--- a/cmd/konvoy-image/cmd/root.go
+++ b/cmd/konvoy-image/cmd/root.go
@@ -83,6 +83,7 @@ func init() {
 	rootCmd.AddCommand(generateCmd)
 	rootCmd.AddCommand(generateDocsCmd)
 	rootCmd.AddCommand(provisionCmd)
+	rootCmd.AddCommand(uploadCmd)
 	rootCmd.DisableAutoGenTag = true
 
 	fs := rootCmd.PersistentFlags()

--- a/cmd/konvoy-image/cmd/upload.go
+++ b/cmd/konvoy-image/cmd/upload.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var uploadCmd = &cobra.Command{
+	Use:   "upload",
+	Short: "Upload one of [artifacts]",
+	Args:  cobra.NoArgs,
+}
+
+func init() {
+	uploadCmd.AddCommand(artifactsCmd)
+}

--- a/cmd/konvoy-image/cmd/validate.go
+++ b/cmd/konvoy-image/cmd/validate.go
@@ -1,7 +1,8 @@
 package cmd
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/mesosphere/konvoy-image-builder/pkg/app"
@@ -11,14 +12,13 @@ var validateFlags app.ValidateFlags
 
 // validateCmd runs validations against nodes to provision.
 var validateCmd = &cobra.Command{
-	SilenceUsage:  true,
-	SilenceErrors: true,
-	Use:           "validate",
-	Short:         "validate existing infrastructure",
-	Args:          cobra.ExactArgs(0),
+	SilenceUsage: true, SilenceErrors: true,
+	Use:   "validate",
+	Short: "validate existing infrastructure",
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := app.Validate(validateFlags); err != nil {
-			return errors.Wrap(err, "error running validate")
+			return fmt.Errorf("failed running validate %w", err)
 		}
 
 		return nil

--- a/docs/cli/konvoy-image.md
+++ b/docs/cli/konvoy-image.md
@@ -18,6 +18,7 @@ Create, provision, and customize images for running Konvoy
 * [konvoy-image generate](konvoy-image_generate.md)	 - generate files relating to building images
 * [konvoy-image generate-docs](konvoy-image_generate-docs.md)	 - generate docs in path
 * [konvoy-image provision](konvoy-image_provision.md)	 - provision to an inventory.yaml or hostname, note the comma at the end of the hostname
+* [konvoy-image upload](konvoy-image_upload.md)	 - Upload one of [artifacts]
 * [konvoy-image validate](konvoy-image_validate.md)	 - validate existing infrastructure
 * [konvoy-image version](konvoy-image_version.md)	 - Version for konvoy-image
 

--- a/docs/cli/konvoy-image_upload.md
+++ b/docs/cli/konvoy-image_upload.md
@@ -1,0 +1,23 @@
+## konvoy-image upload
+
+Upload one of [artifacts]
+
+### Options
+
+```
+  -h, --help   help for upload
+```
+
+### Options inherited from parent commands
+
+```
+      --color     enable color output (default true)
+  -v, --v int     select verbosity level, should be between 0 and 6
+      --verbose   enable debug level logging (same as --v 5)
+```
+
+### SEE ALSO
+
+* [konvoy-image](konvoy-image.md)	 - Create, provision, and customize images for running Konvoy
+* [konvoy-image upload artifacts](konvoy-image_upload_artifacts.md)	 - upload artifacts to hosts defined in inventory-file
+

--- a/docs/cli/konvoy-image_upload_artifacts.md
+++ b/docs/cli/konvoy-image_upload_artifacts.md
@@ -13,7 +13,7 @@ konvoy-image upload artifacts [flags]
   -h, --help                          help for artifacts
       --inventory-file string         an ansible inventory defining your infrastructure (default "inventory.yaml")
       --os-packages-bundle string     path to os-packages tar file for install on remote hosts.
-      --pip-packages-bundle string    path to pip-packages tar filefor install on remote hosts.
+      --pip-packages-bundle string    path to pip-packages tar file for install on remote hosts.
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/konvoy-image_upload_artifacts.md
+++ b/docs/cli/konvoy-image_upload_artifacts.md
@@ -1,0 +1,30 @@
+## konvoy-image upload artifacts
+
+upload artifacts to hosts defined in inventory-file
+
+```
+konvoy-image upload artifacts [flags]
+```
+
+### Options
+
+```
+      --container-images-dir string   path to container images for install on remote hosts.
+  -h, --help                          help for artifacts
+      --inventory-file string         an ansible inventory defining your infrastructure (default "inventory.yaml")
+      --os-packages-bundle string     path to os-packages tar file for install on remote hosts.
+      --pip-packages-bundle string    path to pip-packages tar filefor install on remote hosts.
+```
+
+### Options inherited from parent commands
+
+```
+      --color     enable color output (default true)
+  -v, --v int     select verbosity level, should be between 0 and 6
+      --verbose   enable debug level logging (same as --v 5)
+```
+
+### SEE ALSO
+
+* [konvoy-image upload](konvoy-image_upload.md)	 - Upload one of [artifacts]
+

--- a/pkg/app/artifacts.go
+++ b/pkg/app/artifacts.go
@@ -1,0 +1,49 @@
+package app
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/mesosphere/konvoy-image-builder/pkg/ansible"
+	"github.com/mesosphere/konvoy-image-builder/pkg/appansible"
+)
+
+type ArtifactsCmdFlags struct {
+	OSPackagesBundleFile     string
+	PIPPackagesBundleFile    string
+	ContainerImagesBundleDir string
+	Inventory                string
+	RootFlags
+}
+
+func UploadArtifacts(artifactFlags ArtifactsCmdFlags) error {
+	playbookOptions, err := playbookOptionsFromFlag(artifactFlags)
+	if err != nil {
+		return err
+	}
+	playbook := appansible.NewPlaybook("upload-artifacts", artifactFlags.Inventory, playbookOptions)
+	return playbook.Run(NewRunOptions(artifactFlags.RootFlags))
+}
+
+func playbookOptionsFromFlag(artifactFlags ArtifactsCmdFlags) (*ansible.PlaybookOptions, error) {
+	osPackagesBundleFile, err := filepath.Abs(artifactFlags.OSPackagesBundleFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find absolute path for --os-packages-bundle %w", err)
+	}
+	pipPackagesBundleFile, err := filepath.Abs(artifactFlags.PIPPackagesBundleFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find absolute path for --pip-packages-bundle %w", err)
+	}
+	containerImagesDir, err := filepath.Abs(artifactFlags.ContainerImagesBundleDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find absolute path for --container-images-dir %w", err)
+	}
+	playbookOptions := &ansible.PlaybookOptions{
+		ExtraVars: []string{
+			fmt.Sprintf(extraVarsTemplate, "os_packages_local_bundle_file", osPackagesBundleFile),
+			fmt.Sprintf(extraVarsTemplate, "pip_packages_local_bundle_file", pipPackagesBundleFile),
+			fmt.Sprintf(extraVarsTemplate, "images_local_bundle_dir", containerImagesDir),
+		},
+	}
+	return playbookOptions, nil
+}


### PR DESCRIPTION
**What problem does this PR solve?**:
Creates an `upload artifacts` command to upload artifacts to hosts specified in an inventory file.


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
https://jira.d2iq.com/browse/D2IQ-83933


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->

I ran the command like so:

```
$ bin/konvoy-image-wrapper upload artifacts --inventory-file=ansible-inventory.yaml --container-images-dir=./artifacts/image-bundles/ --os-packages-bundle=./artifacts/os-packages_1.21.6_x86_64_rpms.tar.gz --pip-packages-bundle=./artifacts/pip-packages.tar.gz 
```

I used previous existing terraform scripts to bring up centos7 hosts. 

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some https://jira.d2iq.com/browse/D2IQ-83933bug fix. (COPS-xxxx)"
-->
```release-note
feat: adds a upload artifacts command for hosts that will be used in offline mode.
```
