### PR TITLE
fix: wires extra vars correctly 

### DIFF
--- a/cmd/konvoy-image/cmd/args.go
+++ b/cmd/konvoy-image/cmd/args.go
@@ -10,6 +10,10 @@ func addOverridesArg(fs *pflag.FlagSet, overrides *[]string) {
 	fs.StringSliceVar(overrides, "overrides", []string{}, "a comma separated list of override YAML files")
 }
 
+func addExtraVarsArg(fs *pflag.FlagSet, extraVars *[]string) {
+	fs.StringSliceVar(extraVars, "extra-vars", []string{}, "flag passed Ansible's extra-vars")
+}
+
 func addClusterArgs(fs *pflag.FlagSet, kubernetesVersion, containerdVersion *string) {
 	fs.StringVar(kubernetesVersion, "kubernetes-version", "", "The version of kubernetes to install. Example: 1.21.6")
 	fs.StringVar(containerdVersion, "containerd-version", "", "the version of containerd to install")

--- a/cmd/konvoy-image/cmd/generate.go
+++ b/cmd/konvoy-image/cmd/generate.go
@@ -50,4 +50,5 @@ func initGenerateFlags(fs *flag.FlagSet, gFlags *generateCLIFlags) {
 		&gFlags.userArgs.ClusterArgs.ContainerdVersion,
 	)
 	addAWSUserArgs(fs, &gFlags.userArgs)
+	addExtraVarsArg(fs, &gFlags.userArgs.ExtraVars)
 }

--- a/cmd/konvoy-image/cmd/provision.go
+++ b/cmd/konvoy-image/cmd/provision.go
@@ -27,6 +27,7 @@ var provisionCmd = &cobra.Command{
 				Overrides:        provisionFlags.Overrides,
 				UserArgs: app.UserArgs{
 					ClusterArgs: provisionFlags.ClusterArgs,
+					ExtraVars:   provisionFlags.ExtraVars,
 				},
 			})
 			if err != nil {
@@ -48,7 +49,7 @@ func init() {
 		&provisionFlags.ClusterArgs.KubernetesVersion,
 		&provisionFlags.ClusterArgs.ContainerdVersion,
 	)
-	fs.StringArrayVar(&provisionFlags.ExtraVars, "extra-vars", []string{}, "flag passed Ansible's extra-vars")
+	addExtraVarsArg(fs, &provisionFlags.ExtraVars)
 	fs.StringVar(&provisionFlags.Provider, "provider", "", "specify a provider if you wish to install provider specific utilities")
 	fs.StringVar(&provisionFlags.Inventory, "inventory-file", "", "an ansible inventory defining your infrastructure")
 	addOverridesArg(fs, &provisionFlags.Overrides)

--- a/docs/cli/konvoy-image_build.md
+++ b/docs/cli/konvoy-image_build.md
@@ -20,6 +20,7 @@ build --region us-west-2 --source-ami=ami-12345abcdef images/ami/centos-7.yaml
       --ami-users stringArray            a list AWS user accounts which are allowed use the image
       --aws-instance-type string         instance type used to build the AMI; the type must be present in the region in which the AMI is built
       --containerd-version string        the version of containerd to install
+      --extra-vars stringArray           flag passed Ansible's extra-vars
   -h, --help                             help for build
       --kubernetes-version string        The version of kubernetes to install. Example: 1.21.6
       --overrides strings                a comma separated list of override YAML files

--- a/docs/cli/konvoy-image_build.md
+++ b/docs/cli/konvoy-image_build.md
@@ -20,7 +20,7 @@ build --region us-west-2 --source-ami=ami-12345abcdef images/ami/centos-7.yaml
       --ami-users stringArray            a list AWS user accounts which are allowed use the image
       --aws-instance-type string         instance type used to build the AMI; the type must be present in the region in which the AMI is built
       --containerd-version string        the version of containerd to install
-      --extra-vars stringArray           flag passed Ansible's extra-vars
+      --extra-vars strings               flag passed Ansible's extra-vars
   -h, --help                             help for build
       --kubernetes-version string        The version of kubernetes to install. Example: 1.21.6
       --overrides strings                a comma separated list of override YAML files

--- a/docs/cli/konvoy-image_generate.md
+++ b/docs/cli/konvoy-image_generate.md
@@ -20,6 +20,7 @@ generate --region us-west-2 --source-ami=ami-12345abcdef images/ami/centos-7.yam
       --ami-users stringArray            a list AWS user accounts which are allowed use the image
       --aws-instance-type string         instance type used to build the AMI; the type must be present in the region in which the AMI is built
       --containerd-version string        the version of containerd to install
+      --extra-vars stringArray           flag passed Ansible's extra-vars
   -h, --help                             help for generate
       --kubernetes-version string        The version of kubernetes to install. Example: 1.21.6
       --overrides strings                a comma separated list of override YAML files

--- a/docs/cli/konvoy-image_generate.md
+++ b/docs/cli/konvoy-image_generate.md
@@ -20,7 +20,7 @@ generate --region us-west-2 --source-ami=ami-12345abcdef images/ami/centos-7.yam
       --ami-users stringArray            a list AWS user accounts which are allowed use the image
       --aws-instance-type string         instance type used to build the AMI; the type must be present in the region in which the AMI is built
       --containerd-version string        the version of containerd to install
-      --extra-vars stringArray           flag passed Ansible's extra-vars
+      --extra-vars strings               flag passed Ansible's extra-vars
   -h, --help                             help for generate
       --kubernetes-version string        The version of kubernetes to install. Example: 1.21.6
       --overrides strings                a comma separated list of override YAML files

--- a/docs/cli/konvoy-image_provision.md
+++ b/docs/cli/konvoy-image_provision.md
@@ -16,7 +16,7 @@ provision --inventory-file inventory.yaml
 
 ```
       --containerd-version string   the version of containerd to install
-      --extra-vars stringArray      flag passed Ansible's extra-vars
+      --extra-vars strings          flag passed Ansible's extra-vars
   -h, --help                        help for provision
       --inventory-file string       an ansible inventory defining your infrastructure
       --kubernetes-version string   The version of kubernetes to install. Example: 1.21.6

--- a/pkg/app/build.go
+++ b/pkg/app/build.go
@@ -72,6 +72,8 @@ type BuildOptions struct {
 
 type UserArgs struct {
 	ClusterArgs
+	// ExtraVars provided to ansible
+	ExtraVars []string
 	// AMI options
 	SourceAMI        string   `json:"source_ami"`
 	AMIFilterName    string   `json:"ami_filter_name"`
@@ -138,6 +140,23 @@ func (b *Builder) InitConfig(initOptions InitOptions) (string, error) {
 	extraVarsPath, err := filepath.Abs(filepath.Join(workDir, ansibleVarsFilename))
 	if err != nil {
 		return "", InitConfigError("failed to get ansible variables path", err)
+	}
+
+	// merge extraVars passed through args into config -- which will
+	// show up in extraVarsPath
+	extraVarSet := make(map[string]interface{})
+	for _, extraVars := range initOptions.UserArgs.ExtraVars {
+		set := strings.Split(extraVars, "=")
+		//nolint:gomnd // the code is splitting on the equal
+		if len(set) == 2 {
+			k := set[0]
+			v := set[1]
+			extraVarSet[k] = v
+		}
+	}
+
+	if err = mergeMapsOverwrite(config, extraVarSet); err != nil {
+		return "", fmt.Errorf("error merging overrides: %w", err)
 	}
 
 	if err = initAnsibleConfig(extraVarsPath, config); err != nil {

--- a/pkg/app/build.go
+++ b/pkg/app/build.go
@@ -91,6 +91,7 @@ type ClusterArgs struct {
 	ContainerdVersion string `json:"containerd_version" yaml:"containerd_version"`
 }
 
+//nolint:gocyclo // this will be refactored
 func (b *Builder) InitConfig(initOptions InitOptions) (string, error) {
 	config, err := loadYAML(initOptions.CommonConfigPath)
 	if err != nil {


### PR DESCRIPTION
**What problem does this PR solve?**:
Wires the values of `extra-vars` flag to the `builder` which is used for provisioning.
Also adds `extra-vars` flag to `build` and `generate` commands

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-84265 


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note
fix: wires extra vars correctly 
feat: add extra-vars to build and generate commands
```
