### PR TITLE
chore: Retry more SLES tasks to work around connectivity issues

### DIFF
--- a/ansible/roles/gpu/tasks/nvidia-gpu-SLES15.yaml
+++ b/ansible/roles/gpu/tasks/nvidia-gpu-SLES15.yaml
@@ -3,12 +3,16 @@
   command: SUSEConnect --status
   register: suseconnect_status
   changed_when: false
+  retries: 15
+  delay: 60
 
 - name: Activate PackageHub {{ ansible_distribution_version }} {{ ansible_architecture }}
   command: SUSEConnect -p {{ suse_packagehub_product }}
   register: connect_register
   changed_when: "'Successfully registered' in connect_register.stdout"
   when: not 'PackageHub' in suseconnect_status.stdout
+  retries: 15
+  delay: 60
 
 - name: Import CUDA rpm repository key
   rpm_key:


### PR DESCRIPTION
**What problem does this PR solve?**:
Works around connectivity issues we see in e2e tests. Per @jkoelker:

> the issue is SLES on aws uses an aws local mirror, and yea that get rate limited. IIRC its on a per tenant (vpc egress ip is what its actually tracking), so it would limit the number of concurrent builds we have ;(. Is there a way we can serialize it in TC, so that at most there are X SLES based builds running at any given time period?

Example failure from https://teamcity.mesosphere.io/buildConfiguration/ClosedSource_KonvoyImageBuilder_E2eSles15nvidia/3344885?showLog=3344885_1757_478.1757&logFilter=debug:
```
sles-15-nvidia: TASK [gpu : Activate PackageHub 15.3 x86_64] ***********************************
sles-15-nvidia: fatal: [default]: FAILED! => {
    "changed": false,
    "cmd": [
        "SUSEConnect",
        "-p",
        "PackageHub/15.3/x86_64"
    ],
    "delta": "0:01:06.997011",
    "end": "2022-02-04 02:10:24.091867",
    "msg": "non-zero return code",
    "rc": 104,
    "start": "2022-02-04 02:09:17.094856",
    "stderr": "",
    "stderr_lines": [],
    "stdout": "Registering system to registration proxy https://smt-ec2.susecloud.net

Updating system details on https://smt-ec2.susecloud.net ...

Activating PackageHub 15.3 x86_64 ...
-> Adding service to system ...
-> Installing release package ...
command 'zypper --no-refresh --non-interactive install --no-recommends --auto-agree-with-product-licenses -t product PackageHub' failed
Error: zypper returned (104) with 'Error building the cache:
[SUSE_Package_Hub_x86_64:SUSE-PackageHub-15-SP3-Backports-Pool|plugin:/susecloud?credentials=SUSE_Package_Hub_x86_64&path=/repo/SUSE/Backports/SLE-15-SP3_x86_64/standard/] Valid metadata not found at specified URL
History:
 - Signature verification failed for repomd.xml
 - Can't provide /repodata/repomd.xml

Error building the cache:
[SUSE_Package_Hub_x86_64:SUSE-PackageHub-15-SP3-Pool|plugin:/susecloud?credentials=SUSE_Package_Hub_x86_64&path=/repo/SUSE/Backports/SLE-15-SP3_x86_64/product/] Valid metadata not found at specified URL
History:
 - Unknown error reading from 'plugin:/susecloud?credentials=SUSE_Package_Hub_x86_64&path=/repo/SUSE/Backports/SLE-15-SP3_x86_64/product/'
 - Not ready to read within timeout.

Some of the repositories have not been refreshed because of an error.
No provider of 'PackageHub' found.'",
    "stdout_lines": [
        "Registering system to registration proxy https://smt-ec2.susecloud.net",
        "",
        "Updating system details on https://smt-ec2.susecloud.net ...",
        "",
        "Activating PackageHub 15.3 x86_64 ...",
        "-> Adding service to system ...",
        "-> Installing release package ...",
        "command 'zypper --no-refresh --non-interactive install --no-recommends --auto-agree-with-product-licenses -t product PackageHub' failed",
        "Error: zypper returned (104) with 'Error building the cache:",
        "[SUSE_Package_Hub_x86_64:SUSE-PackageHub-15-SP3-Backports-Pool|plugin:/susecloud?credentials=SUSE_Package_Hub_x86_64&path=/repo/SUSE/Backports/SLE-15-SP3_x86_64/standard/] Valid metadata not found at specified URL",
        "History:",
        " - Signature verification failed for repomd.xml",
        " - Can't provide /repodata/repomd.xml",
        "",
        "Error building the cache:",
        "[SUSE_Package_Hub_x86_64:SUSE-PackageHub-15-SP3-Pool|plugin:/susecloud?credentials=SUSE_Package_Hub_x86_64&path=/repo/SUSE/Backports/SLE-15-SP3_x86_64/product/] Valid metadata not found at specified URL",
        "History:",
        " - Unknown error reading from 'plugin:/susecloud?credentials=SUSE_Package_Hub_x86_64&path=/repo/SUSE/Backports/SLE-15-SP3_x86_64/product/'",
        " - Not ready to read within timeout.",
        "",
        "Some of the repositories have not been refreshed because of an error.",
        "No provider of 'PackageHub' found.'"
    ]
}
```

A different failure from https://teamcity.mesosphere.io/buildConfiguration/ClosedSource_KonvoyImageBuilder_E2eSles15nvidia/3344641?showLog=3344641_1494_475.1494&logFilter=debug
```
      sles-15-nvidia: TASK [packages : install common packages] **************************************
14:08:40
      sles-15-nvidia: FAILED - RETRYING: install common packages (15 retries left).
14:09:41
      sles-15-nvidia: FAILED - RETRYING: install common packages (14 retries left).
14:10:42
      sles-15-nvidia: FAILED - RETRYING: install common packages (13 retries left).
14:11:43
      sles-15-nvidia: FAILED - RETRYING: install common packages (12 retries left).
14:12:45
      sles-15-nvidia: FAILED - RETRYING: install common packages (11 retries left).
14:13:46
      sles-15-nvidia: FAILED - RETRYING: install common packages (10 retries left).
14:14:47
      sles-15-nvidia: FAILED - RETRYING: install common packages (9 retries left).
14:15:48
      sles-15-nvidia: FAILED - RETRYING: install common packages (8 retries left).
14:16:49
      sles-15-nvidia: FAILED - RETRYING: install common packages (7 retries left).
14:17:50
      sles-15-nvidia: FAILED - RETRYING: install common packages (6 retries left).
14:18:59
      sles-15-nvidia: FAILED - RETRYING: install common packages (5 retries left).
14:20:00
      sles-15-nvidia: FAILED - RETRYING: install common packages (4 retries left).
14:21:01
      sles-15-nvidia: FAILED - RETRYING: install common packages (3 retries left).
14:22:02
      sles-15-nvidia: FAILED - RETRYING: install common packages (2 retries left).
14:23:03
      sles-15-nvidia: FAILED - RETRYING: install common packages (1 retries left).
      sles-15-nvidia: fatal: [default]: FAILED! => {
    "attempts": 15,
    "changed": false,
    "cmd": [
        "/usr/bin/zypper",
        "--quiet",
        "--non-interactive",
        "--xmlout",
        "install",
        "--type",
        "package",
        "--auto-agree-with-licenses",
        "--no-recommends",
        "--",
        "+audit",
        "+conntrack-tools",
        "+open-vm-tools",
        "+python3-pip",
        "+python3-netifaces",
        "+socat",
        "+sysstat",
        "+nfs-utils"
    ],
    "msg": "No provider of '+conntrack-tools' found.",
    "rc": 104,
    "stderr": "",
    "stderr_lines": [],
    "stdout": "<?xml version='1.0'?>
<stream>
<message type=\"error\">Package ';+python3-netifaces'; not found.</message>
<message type=\"error\">Package ';+python3-pip'; not found.</message>
<message type=\"error\">No provider of ';+audit'; found.</message>
<message type=\"error\">No provider of ';+open-vm-tools'; found.</message>
<message type=\"error\">No provider of ';+sysstat'; found.</message>
<message type=\"error\">No provider of ';+socat'; found.</message>
<message type=\"error\">No provider of ';+conntrack-tools'; found.</message>
</stream>
",
    "stdout_lines": [
        "<?xml version='1.0'?>",
        "<stream>",
        "<message type=\"error\">Package ';+python3-netifaces'; not found.</message>",
        "<message type=\"error\">Package ';+python3-pip'; not found.</message>",
        "<message type=\"error\">No provider of ';+audit'; found.</message>",
        "<message type=\"error\">No provider of ';+open-vm-tools'; found.</message>",
        "<message type=\"error\">No provider of ';+sysstat'; found.</message>",
        "<message type=\"error\">No provider of ';+socat'; found.</message>",
        "<message type=\"error\">No provider of ';+conntrack-tools'; found.</message>",
        "</stream>"
    ]
}
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
