### PR TITLE
fix: use crictl to pull images and supports mirrors

### DIFF
--- a/ansible/roles/images/tasks/check-or-pull-images.yaml
+++ b/ansible/roles/images/tasks/check-or-pull-images.yaml
@@ -14,7 +14,7 @@
   changed_when: false
 
 - name: pull image  # noqa no-changed-when
-  command: ctr --address {{ containerd_cri_socket }} --namespace k8s.io images pull {{ image_name }}
+  command: crictl pull {{ image_name }}
   when: image_name not in ctr_images_check.stdout
   register: ctr_images_pull
   failed_when: ctr_images_pull.rc != 0


### PR DESCRIPTION
**What problem does this PR solve?**:
Reported in Slack https://mesosphere.slack.com/archives/C01MPKVBB5E/p1646197247844029

`ctr` does not use the same Containerd mirror configuration, lets go back to using `crictl` to pull the images which will use Containerd mirrors.

This is basically the command we had before https://github.com/mesosphere/konvoy-image-builder/pull/162/files#diff-14c84fc26cc68826bdd8c9ee2ba0b29f31537fc6fec4f03028d38b024d7b9d6cL12

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
