### PR TITLE
chore: remove pulling kfips image

### DIFF
--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -8,7 +8,6 @@ kubernetes_version: "1.21.6"
 containerd_version: "1.4.11"
 kubernetes_cni_version: "0.9.1"
 crictl_version: "1.22.0"
-kfips_version: "0.1.0"
 kubernetes_semver: "v{{ kubernetes_version }}"
 
 # Adding kubernetes_full_version for mitogen runs. This variable is always overridden
@@ -27,8 +26,7 @@ package_versions:
 # variable used for seeding images
 k8s_image_registry: "k8s.gcr.io"
 coredns_image_registry_repository: "k8s.gcr.io/coredns/coredns"
-control_plane_images:
-  - "docker.io/mesosphere/kfips:v{{ kfips_version }}"
+control_plane_images: []
 
 aws_images: []
 


### PR DESCRIPTION
**What problem does this PR solve?**:
The kfips image used in `dkp check cluster fips` is the responsibility of konvoy not KIB, removing it from here and I will open a PR in Konvoy to add it there. 

PR in Konvoy https://github.com/mesosphere/konvoy2/pull/1104

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
