### PR TITLE
Revert "chore: bump alpine to 3.15"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ ARG BASE=mesosphere/konvoy-image-builder:latest-devkit
 # hadolint ignore=DL3006
 FROM ${BASE} as devkit
 
-FROM alpine:3.15.0
+# DO NOT BUMP TO 3.15.0 https://githubmemory.com/repo/atmoz/sftp/issues/296
+FROM alpine:3.14.2
 
 ARG ANSIBLE_VERSION=2.10.7
 ENV ANSIBLE_PATH=/usr

--- a/pkg/packer/manifests/aws/packer.json.tmpl
+++ b/pkg/packer/manifests/aws/packer.json.tmpl
@@ -77,7 +77,6 @@
       "iam_instance_profile": "{{user `iam_instance_profile`}}",
       "skip_profile_validation": "{{user `skip_profile_validation`}}",
       "ssh_username": "{{user `ssh_username`}}",
-      "ssh_key_exchange_algorithms": ["curve25519-sha256@libssh.org", "ecdh-sha2-nistp256", "ecdh-sha2-nistp384", "ecdh-sha2-nistp521", "diffie-hellman-group14-sha1","diffie-hellman-group1-sha1"],
       "vpc_id": "{{ user `vpc_id` }}",
       "ssh_bastion_host": "{{ user `ssh_bastion_host` }}",
       "ssh_bastion_username": "{{ user  `ssh_bastion_username` }}",
@@ -194,7 +193,7 @@
       "playbook_file": "./ansible/provision.yaml",
       "user": "{{user `ssh_username`}}",
       "ansible_env_vars": [
-        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes -o HostkeyAlgorithms=+ssh-rsa'",
+        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'",
         "ANSIBLE_REMOTE_TEMP='/tmp/.ansible/'"
       ],
       "extra_arguments": [

--- a/pkg/packer/manifests/vsphere/packer.json.tmpl
+++ b/pkg/packer/manifests/vsphere/packer.json.tmpl
@@ -54,7 +54,6 @@
         "ssh_password": "{{user `ssh_password`}}",
         "ssh_timeout": "4h",
         "ssh_username": "{{user `ssh_username`}}",
-        "ssh_key_exchange_algorithms": ["curve25519-sha256@libssh.org", "ecdh-sha2-nistp256", "ecdh-sha2-nistp384", "ecdh-sha2-nistp521", "diffie-hellman-group14-sha1","diffie-hellman-group1-sha1"],
         "template": "{{user `template`}}",
         "username": "{{user `username`}}",
         "vcenter_server": "{{user `vcenter_server`}}",


### PR DESCRIPTION
Reverts mesosphere/konvoy-image-builder#250 and goes back to a working version

@jkoelker reported the issue in https://github.com/mesosphere/konvoy-image-builder/pull/271