### PR TITLE
fix: cleanup vsphere VM when building vSphere template in dry run

### DIFF
--- a/Dockerfile.devkit
+++ b/Dockerfile.devkit
@@ -3,6 +3,7 @@ FROM hashicorp/packer:1.8.0 as packer
 FROM golangci/golangci-lint:v1.44.2-alpine as golangci-lint
 FROM goreleaser/goreleaser:v1.7.0 as goreleaser
 FROM docker:20.10 as docker
+FROM vmware/govc:v0.27.4 as govc
 
 FROM golang:1.17.8-alpine3.15 as builder
 
@@ -53,22 +54,6 @@ RUN wget \
     && sha256sum -c "/tmp/${GOCOVER_COBERTURA_FILE}.sha256" \
     && 7z e -o/tools "/tmp/${GOCOVER_COBERTURA_FILE}" \
     && chmod +x /tools/gocover-cobertura
-
-ARG GOVC_VERSION=v0.27.4
-ARG GOVC_FILE="govc_Linux_x86_64.tar.gz"
-ARG GOVC_SHA256=529d357cc504df17199971fa0586af5e381f1c15482dc0eda60ff5c9b17d8d5e
-ARG GOVC_URL=https://github.com/vmware/govmomi/releases/download/${GOVC_VERSION}/${GOVC_FILE}
-RUN wget \
-        --no-verbose \
-        --output-document="/tmp/${GOVC_FILE}" \
-        "${GOVC_URL}" \
-    && echo "${GOVC_SHA256}  /tmp/${GOVC_FILE}" \
-        > "/tmp/${GOVC_FILE}.sha256" \
-    && sha256sum -c "/tmp/${GOVC_FILE}.sha256" \
-    && tar --extract \
-        --file "/tmp/${GOVC_FILE}" \
-        --directory /tools
-
 
 # NOTE(jkoelker) From here we care about layers
 FROM golang:1.17.8-alpine3.15
@@ -123,7 +108,9 @@ COPY --from=packer /bin/packer /usr/local/bin/
 COPY --from=golangci-lint /usr/bin/golangci-lint /usr/local/bin/
 COPY --from=goreleaser /usr/bin/goreleaser /usr/local/bin/
 COPY --from=docker /usr/local/bin/docker /usr/local/bin/
+COPY --from=govc /govc /usr/local/bin/
 COPY --from=builder /tools /usr/local/bin
+
 
 RUN getent group "${GROUP_ID}" > /dev/null 2>&1 \
     || addgroup -S -g "${GROUP_ID}" "${GROUP_NAME}"

--- a/Dockerfile.devkit
+++ b/Dockerfile.devkit
@@ -54,6 +54,22 @@ RUN wget \
     && 7z e -o/tools "/tmp/${GOCOVER_COBERTURA_FILE}" \
     && chmod +x /tools/gocover-cobertura
 
+ARG GOVC_VERSION=v0.27.4
+ARG GOVC_FILE="govc_Linux_x86_64.tar.gz"
+ARG GOVC_SHA256=529d357cc504df17199971fa0586af5e381f1c15482dc0eda60ff5c9b17d8d5e
+ARG GOVC_URL=https://github.com/vmware/govmomi/releases/download/${GOVC_VERSION}/${GOVC_FILE}
+RUN wget \
+        --no-verbose \
+        --output-document="/tmp/${GOVC_FILE}" \
+        "${GOVC_URL}" \
+    && echo "${GOVC_SHA256}  /tmp/${GOVC_FILE}" \
+        > "/tmp/${GOVC_FILE}.sha256" \
+    && sha256sum -c "/tmp/${GOVC_FILE}.sha256" \
+    && tar --extract \
+        --file "/tmp/${GOVC_FILE}" \
+        --directory /tools
+
+
 # NOTE(jkoelker) From here we care about layers
 FROM golang:1.17.8-alpine3.15
 

--- a/pkg/packer/manifests/vsphere/packer.json.tmpl
+++ b/pkg/packer/manifests/vsphere/packer.json.tmpl
@@ -2,7 +2,7 @@
     "variables": {
         "ansible_extra_vars": "",
         "build_timestamp": "{{timestamp}}",
-        "build_version": "konvoy-ova-{{user `build_name`}}{{user `build_name_extra`}}-{{user `kubernetes_full_version` }}-{{user `build_timestamp`}}",
+        "vm_name": "konvoy-ova-{{user `build_name`}}{{user `build_name_extra`}}-{{user `kubernetes_full_version` }}-{{user `build_timestamp`}}",
         "cluster": "",
         "datastore": "",
         "folder": "",
@@ -18,8 +18,8 @@
         "export_manifest": "none",
         "guest_os_type": null,
         "ib_version": "{{env `IB_VERSION`}}",
-        "username": "{{env `VSPHERE_USERNAME`}}",
-        "password": "{{env `VSPHERE_PASSWORD`}}",
+        "vsphere_username": "{{env `VSPHERE_USERNAME`}}",
+        "vsphere_password": "{{env `VSPHERE_PASSWORD`}}",
         "vcenter_server": "{{env `VSPHERE_SERVER`}}",
         "vsphere_guest_os_type": null,
         "insecure_connection": "false",
@@ -50,7 +50,7 @@
         "insecure_connection": "{{user `insecure_connection`}}",
         "linked_clone": "{{user `linked_clone`}}",
         "network": "{{user `network`}}",
-        "password": "{{user `password`}}",
+        "password": "{{user `vsphere_password`}}",
         "ssh_password": "{{user `ssh_password`}}",
         "ssh_timeout": "4h",
         "ssh_username": "{{user `ssh_username`}}",
@@ -63,7 +63,7 @@
           "diffie-hellman-group1-sha1"
         ],
         "template": "{{user `template`}}",
-        "username": "{{user `username`}}",
+        "username": "{{user `vsphere_username`}}",
         "vcenter_server": "{{user `vcenter_server`}}",
         ((- if not .DryRun ))
         "create_snapshot": "true",
@@ -73,7 +73,7 @@
         "ssh_bastion_username": "{{ user  `ssh_bastion_username` }}",
         "ssh_bastion_password": "{{ user `ssh_bastion_password` }}",
         "ssh_bastion_private_key_file": "{{ user `ssh_bastion_private_key_file` }}",
-        "vm_name": "{{user `build_version`}}"
+        "vm_name": "{{user `vm_name`}}"
       }
     ],
     "post-processors": [
@@ -104,9 +104,22 @@
         "output": "{{user `manifest_output`}}",
         "strip_path": true
       }
+      ((- if .DryRun ))
+      ,{
+        "type": "shell-local",
+        "environment_vars":[
+          "GOVC_URL={{user `vcenter_server`}}",
+          "GOVC_USERNAME={{user `vsphere_username`}}",
+          "GOVC_PASSWORD={{user `vsphere_password`}}"
+        ],
+        "inline": [
+          "echo 'destroying VM {{user `vm_name`}}' && govc vm.destroy {{user `vm_name`}}"
+        ]
+      }
+      ((- end ))
     ],
     "provisioners":[
-      {
+    {
         "type": "ansible",
         "playbook_file": "./ansible/provision.yaml",
         "user": "{{user `ssh_username`}}",
@@ -169,4 +182,4 @@
         ]
       }
     ]
-  }
+}


### PR DESCRIPTION
**What problem does this PR solve?**:
- If `--dry-run` option is provided, destroys vsphere VM that was created during image building 
- This will automatically cleanup the VMS when a PR builds are run with `--dry-run` mode.
- After this PR, only `released` vsphere templates should remain in our vSphere cluster

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->

Once the PR is merged I will destroy all the left over VMs that were created so far.