### PR TITLE
chore(make): reorg build targets and add Azure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ ifneq ($(shell command -v docker),)
 	endif
 endif
 
+include make/ci.mk
 include make/images.mk
 include hack/pip-packages/Makefile
 include test/infra/aws/Makefile
@@ -362,76 +363,6 @@ help:
 define print-target
     @printf "Executing target: \033[36m$@\033[0m\n"
 endef
-
-# requires ANSIBLE_PATH, otherwise run `make ci.e2e.ansible`
-e2e.ansible:
-	make -C test/e2e/ansible e2e
-
-ifeq ($(CI), true)
-export DOCKER_DEVKIT_AWS_ARGS := --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY
-endif
-
-# Run every E2E test in its own devkit container.
-# All tests run in parallel. Adjust parallelism with --jobs.
-# Output is interleaved when run in parallel. Use --output-sync=recurse to serialize output.
-ci.e2e.build.all: ci.e2e.build.centos-7
-ci.e2e.build.all: ci.e2e.build.ubuntu-18
-ci.e2e.build.all: ci.e2e.build.ubuntu-20
-ci.e2e.build.all: ci.e2e.build.sles-15
-ci.e2e.build.all: ci.e2e.build.oracle-7
-ci.e2e.build.all: ci.e2e.build.oracle-8
-ci.e2e.build.all: ci.e2e.build.flatcar
-ci.e2e.build.all: e2e.build.centos-7-offline
-ci.e2e.build.all: e2e.build.rhel-7.9-offline-fips
-ci.e2e.build.all: e2e.build.rhel-8.2-offline-fips
-ci.e2e.build.all: e2e.build.rhel-8.4-offline-fips
-ci.e2e.build.all: ci.e2e.build.rhel-8-fips
-ci.e2e.build.all: ci.e2e.build.centos-7-nvidia
-ci.e2e.build.all: ci.e2e.build.sles-15-nvidia
-ci.e2e.build.all: ci.e2e.build.rhel-8.4-ova
-ci.e2e.build.all: ci.e2e.build.rhel-7.9-ova
-
-# Run an E2E test in its own devkit container.
-ci.e2e.build.%:
-	make devkit.run WHAT="make e2e.build.$*"
-
-e2e.build.centos-7: centos7
-
-e2e.build.centos-7-offline: centos7-offline infra.aws.destroy
-
-e2e.build.rhel-7.9-offline-fips: rhel79-fips-offline infra.aws.destroy
-
-e2e.build.rhel-8.2-offline-fips: rhel82-fips-offline infra.aws.destroy
-
-e2e.build.rhel-8.4-offline-fips: rhel84-fips-offline infra.aws.destroy
-
-e2e.build.ubuntu-18: ubuntu18
-
-e2e.build.ubuntu-20: ubuntu20
-
-e2e.build.sles-15: sles15
-
-e2e.build.oracle-7: oracle7
-
-e2e.build.oracle-8: oracle8
-
-e2e.build.flatcar: flatcar
-
-e2e.build.rhel-8-fips: rhel82-fips
-
-e2e.build.rhel-8.4-ova: rhel84-ova
-
-e2e.build.rhel-7.9-ova: rhel79-ova
-
-e2e.build.centos-7-nvidia: centos7-nvidia
-
-e2e.build.sles-15-nvidia: sles15-nvidia
-
-# use sibling containers to handle dependencies and avoid DinD
-ci.e2e.ansible:
-	make -C test/e2e/ansible e2e.setup
-	WHAT="make -C test/e2e/ansible e2e.run" DOCKER_DEVKIT_DEFAULT_ARGS="--rm --net=host" make devkit.run
-	make -C test/e2e/ansible e2e.clean
 
 release-bundle-GOOS:
 	GOOS=$(GOOS) go build -tags EMBED_DOCKER_IMAGE \

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,6 @@ OS := $(shell uname -s)
 
 INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 
-# BUILD_DRY_RUN determines the value of the --dry-run flag of the build command. Should be 'true' or 'false'.
-BUILD_DRY_RUN ?= true
-ifeq ($(BUILD_DRY_RUN),true)
-$(warning Warning: BUILD_DRY_RUN is true)
-endif
-
 root_mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 export REPO_ROOT_DIR := $(dir $(root_mkfile_path))
 export REPO_REV := $(shell cd $(REPO_ROOT_DIR) && git describe --abbrev=12 --tags --match='v*' HEAD)
@@ -75,6 +69,11 @@ export DOCKER_DEVKIT_VSPHERE_ARGS ?= \
 	--env RHSM_USER \
 	--env RHSM_PASS
 
+export DOCKER_DEVKIT_BASTION_ARGS ?= \
+	--env SSH_BASTION_USERNAME \
+	--env SSH_BASTION_HOST \
+	--env SSH_BASTION_KEY_CONTENTS
+
 ifneq ($(wildcard $(DOCKER_SOCKET)),)
 	export DOCKER_SOCKET_ARGS ?= \
 		--volume "$(DOCKER_SOCKET)":/var/run/docker.sock
@@ -113,11 +112,11 @@ export DOCKER_DEVKIT_ARGS ?= \
 	$(DOCKER_SOCKET_ARGS) \
 	$(DOCKER_DEVKIT_AWS_ARGS) \
 	$(DOCKER_DEVKIT_AZURE_ARGS) \
+	$(DOCKER_DEVKIT_BASTION_ARGS) \
 	$(DOCKER_DEVKIT_VSPHERE_ARGS) \
 	$(DOCKER_DEVKIT_PUSH_ARGS) \
 	$(DOCKER_DEVKIT_ENV_ARGS) \
 	$(DOCKER_DEVKIT_SSH_ARGS)
-
 
 export DOCKER_DEVKIT_DEFAULT_ARGS ?= \
 	--rm \
@@ -141,6 +140,7 @@ ifneq ($(shell command -v docker),)
 	endif
 endif
 
+include make/images.mk
 include hack/pip-packages/Makefile
 include test/infra/aws/Makefile
 include test/infra/vsphere/Makefile
@@ -171,11 +171,6 @@ devkit: $(DOCKER_DEVKIT_PHONY_FILE)
 
 WHAT ?= bash
 
-export DEFAULT_KUBERNETES_VERSION_SEMVER ?= $(shell grep -E -e "kubernetes_version:" ansible/group_vars/all/defaults.yaml | cut -d\" -f2)
-export DEFAULT_KUBERNETES_VERSION ?= v${DEFAULT_KUBERNETES_VERSION_SEMVER}
-export CONTAINERD_VERSION ?= $(shell grep -E -e "containerd_version:" ansible/group_vars/all/defaults.yaml | cut -d\" -f2)
-
-
 .PHONY: devkit.run
 devkit.run: ## run $(WHAT) in devkit
 devkit.run: devkit
@@ -184,268 +179,6 @@ devkit.run: devkit
 		$(DOCKER_DEVKIT_ARGS) \
 		"$(DOCKER_DEVKIT_IMG)" \
 		$(WHAT)
-
-.PHONY: centos7
-centos7: build
-centos7: ## Build Centos 7 image
-	./bin/konvoy-image build images/ami/centos-7.yaml \
-	--dry-run=$(BUILD_DRY_RUN) \
-	-v ${VERBOSITY} \
-	$(if $(ADDITIONAL_OVERRIDES),--overrides=${ADDITIONAL_OVERRIDES})
-
-.PHONY: centos7-fips
-centos7-fips: ## Build CENTOS 7.9 FIPS image
-	$(MAKE) centos7 ADDITIONAL_OVERRIDES=overrides/fips.yaml$(if $(ADDITIONAL_OVERRIDES),$(COMMA)${ADDITIONAL_OVERRIDES})
-
-.PHONY: centos7-offline
-centos7-offline: ## Build Centos 7 image
-	$(MAKE) os_distribution=centos os_distribution_major_version=7 os_distribution_arch=x86_64 bundle_suffix= download-os-packages-bundle
-	$(MAKE) pip-packages-artifacts
-	$(MAKE) bundle_suffix= download-images-bundle
-	$(MAKE) devkit.run WHAT="make packer-custom-vpc-override.yaml"
-	$(MAKE) devkit.run WHAT="make centos7 BUILD_DRY_RUN=${BUILD_DRY_RUN} \
-	ADDITIONAL_OVERRIDES=overrides/offline.yaml,packer-custom-vpc-override.yaml$(if $(ADDITIONAL_OVERRIDES),$(COMMA)${ADDITIONAL_OVERRIDES})"
-
-.PHONY: centos7-nvidia
-centos7-nvidia: build
-centos7-nvidia: ## Build Centos 7 image with GPU support
-	./bin/konvoy-image build images/ami/centos-7.yaml \
-	--dry-run=$(BUILD_DRY_RUN) \
-	-v ${VERBOSITY} \
-	--overrides=overrides/nvidia.yaml \
-	--aws-instance-type p2.xlarge \
-	$(if $(ADDITIONAL_OVERRIDES),--overrides=${ADDITIONAL_OVERRIDES})
-
-
-.PHONY: rhel82
-rhel82: build
-rhel82: ## Build RHEL 8.2 image
-	./bin/konvoy-image build images/ami/rhel-82.yaml \
-	--dry-run=$(BUILD_DRY_RUN) \
-	-v ${VERBOSITY} \
-	$(if $(ADDITIONAL_OVERRIDES),--overrides=${ADDITIONAL_OVERRIDES})
-
-.PHONY: rhel82-nvidia
-rhel82-nvidia: build
-rhel82-nvidia: ## Build RHEL 8.2 image with GPU support
-	./bin/konvoy-image build images/ami/rhel-82.yaml \
-	--dry-run=$(BUILD_DRY_RUN) \
-	-v ${VERBOSITY} \
-	--overrides=overrides/nvidia.yaml \
-	--aws-instance-type p2.xlarge \
-	$(if $(ADDITIONAL_OVERRIDES),--overrides=${ADDITIONAL_OVERRIDES})
-
-
-.PHONY: rhel82-fips
-rhel82-fips: ## Build RHEL 8.2 FIPS image
-	$(MAKE) rhel82 ADDITIONAL_OVERRIDES=overrides/fips.yaml$(if $(ADDITIONAL_OVERRIDES),$(COMMA)${ADDITIONAL_OVERRIDES})
-
-.PHONY: rhel82-fips-offline
-rhel82-fips-offline:
-	$(MAKE) os_distribution=redhat os_distribution_major_version=8 os_distribution_arch=x86_64 bundle_suffix=_fips download-os-packages-bundle
-	$(MAKE) pip-packages-artifacts
-	$(MAKE) bundle_suffix=_fips download-images-bundle
-	$(MAKE) devkit.run WHAT="make packer-custom-vpc-override.yaml"
-	$(MAKE) devkit.run WHAT="make rhel82-fips BUILD_DRY_RUN=${BUILD_DRY_RUN} \
-	ADDITIONAL_OVERRIDES=overrides/offline-fips.yaml,packer-custom-vpc-override.yaml$(if $(ADDITIONAL_OVERRIDES),$(COMMA)${ADDITIONAL_OVERRIDES})"
-
-.PHONY: rhel84
-rhel84: build
-rhel84: ## Build RHEL 8.4 image
-	./bin/konvoy-image build images/ami/rhel-84.yaml \
-	--dry-run=$(BUILD_DRY_RUN) \
-	-v ${VERBOSITY} \
-	$(if $(ADDITIONAL_OVERRIDES),--overrides=${ADDITIONAL_OVERRIDES})
-
-.PHONY: rhel84-fips
-rhel84-fips: ## Build RHEL 8.4 FIPS image
-	$(MAKE) rhel84 ADDITIONAL_OVERRIDES=overrides/fips.yaml$(if $(ADDITIONAL_OVERRIDES),$(COMMA)${ADDITIONAL_OVERRIDES})
-
-.PHONY: rhel84-fips-offline
-rhel84-fips-offline:
-	$(MAKE) os_distribution=redhat os_distribution_major_version=8 os_distribution_arch=x86_64 bundle_suffix=_fips download-os-packages-bundle
-	$(MAKE) pip-packages-artifacts
-	$(MAKE) bundle_suffix=_fips download-images-bundle
-	$(MAKE) devkit.run WHAT="make packer-custom-vpc-override.yaml"
-	$(MAKE) devkit.run WHAT="make rhel84-fips BUILD_DRY_RUN=${BUILD_DRY_RUN} \
-	ADDITIONAL_OVERRIDES=overrides/offline-fips.yaml,packer-custom-vpc-override.yaml$(if $(ADDITIONAL_OVERRIDES),$(COMMA)${ADDITIONAL_OVERRIDES})"
-
-.PHONY: rhel84-nvidia
-rhel84-nvidia: build
-rhel84-nvidia: ## Build RHEL 8.4 image with GPU support
-	./bin/konvoy-image build images/ami/rhel-84.yaml \
-	--dry-run=$(BUILD_DRY_RUN) \
-	--overrides=overrides/nvidia.yaml \
-	--aws-instance-type p2.xlarge \
-	$(if $(ADDITIONAL_OVERRIDES),--overrides=${ADDITIONAL_OVERRIDES})
-
-
-.PHONY: rhel84-ova
-rhel84-ova: build
-rhel84-ova: ## Build RHEL 8.4 image
-	./bin/konvoy-image build images/ova/rhel-84.yaml \
-	--dry-run=$(BUILD_DRY_RUN) \
-	-v ${VERBOSITY} \
-	$(if $(ADDITIONAL_OVERRIDES),--overrides=${ADDITIONAL_OVERRIDES})
-
-.PHONY: rhel84-ova-offline
-rhel84-ova-offline: packer-vsphere-airgap.yaml
-	$(MAKE) os_distribution=redhat os_distribution_major_version=8 os_distribution_arch=x86_64 bundle_suffix= download-os-packages-bundle
-	$(MAKE) pip-packages-artifacts
-	$(MAKE) bundle_suffix= download-images-bundle
-	$(MAKE) devkit.run WHAT="make rhel84-ova BUILD_DRY_RUN=${BUILD_DRY_RUN} \
-	ADDITIONAL_OVERRIDES=overrides/offline.yaml,packer-vsphere-airgap.yaml$(if $(ADDITIONAL_OVERRIDES),$(COMMA)${ADDITIONAL_OVERRIDES})"
-
-.PHONY: rhel84-ova-fips
-rhel84-ova-fips: ## Build RHEL 7.9 FIPS image
-	$(MAKE) rhel84-ova ADDITIONAL_OVERRIDES=overrides/fips.yaml$(if $(ADDITIONAL_OVERRIDES),$(COMMA)${ADDITIONAL_OVERRIDES})
-
-.PHONY: rhel84-ova-fips-offline
-rhel84-ova-fips-offline: packer-vsphere-airgap.yaml
-	$(MAKE) os_distribution=redhat os_distribution_major_version=8 os_distribution_arch=x86_64 bundle_suffix=_fips download-os-packages-bundle
-	$(MAKE) pip-packages-artifacts
-	$(MAKE) bundle_suffix=_fips download-images-bundle
-	$(MAKE) devkit.run WHAT="make rhel84-ova-fips BUILD_DRY_RUN=${BUILD_DRY_RUN} \
-	ADDITIONAL_OVERRIDES=overrides/offline-fips.yaml,packer-vsphere-airgap.yaml$(if $(ADDITIONAL_OVERRIDES),$(COMMA)${ADDITIONAL_OVERRIDES})"
-
-.PHONY: rhel79
-rhel79: build
-rhel79: ## Build RHEL 7.9 image
-	./bin/konvoy-image build images/ami/rhel-79.yaml \
-	--dry-run=$(BUILD_DRY_RUN) \
-	-v ${VERBOSITY} \
-	$(if $(ADDITIONAL_OVERRIDES),--overrides=${ADDITIONAL_OVERRIDES})
-
-.PHONY: rhel79-fips
-rhel79-fips: ## Build RHEL 7.9 FIPS image
-	$(MAKE) rhel79 ADDITIONAL_OVERRIDES=overrides/fips.yaml$(if $(ADDITIONAL_OVERRIDES),$(COMMA)${ADDITIONAL_OVERRIDES})
-
-.PHONY: rhel79-fips-offline
-rhel79-fips-offline: ## Build RHEL 7.9 FIPS image
-	$(MAKE) os_distribution=redhat os_distribution_major_version=7 os_distribution_arch=x86_64 bundle_suffix=_fips download-os-packages-bundle
-	$(MAKE) pip-packages-artifacts
-	$(MAKE) bundle_suffix=_fips download-images-bundle
-	$(MAKE) devkit.run WHAT="make packer-custom-vpc-override.yaml"
-	$(MAKE) devkit.run WHAT="make rhel79-fips BUILD_DRY_RUN=${BUILD_DRY_RUN} \
-	ADDITIONAL_OVERRIDES=overrides/offline-fips.yaml,packer-custom-vpc-override.yaml$(if $(ADDITIONAL_OVERRIDES),$(COMMA)${ADDITIONAL_OVERRIDES})"
-
-.PHONY: rhel79-nvidia
-rhel79-nvidia: build
-rhel79-nvidia: ## Build RHEL 7.9 image with GPU support
-	./bin/konvoy-image build images/ami/rhel-79.yaml \
-	--dry-run=$(BUILD_DRY_RUN) \
-	--overrides=overrides/nvidia.yaml \
-	--aws-instance-type p2.xlarge \
-	$(if $(ADDITIONAL_OVERRIDES),--overrides=${ADDITIONAL_OVERRIDES})
-
-
-.PHONY: rhel79-ova
-rhel79-ova: build
-rhel79-ova: ## Build RHEL 7.9 image
-	./bin/konvoy-image build images/ova/rhel-79.yaml \
-	--dry-run=$(BUILD_DRY_RUN) \
-	-v ${VERBOSITY} \
-	$(if $(ADDITIONAL_OVERRIDES),--overrides=${ADDITIONAL_OVERRIDES})
-
-.PHONY: rhel79-ova-offline
-rhel79-ova-offline: packer-vsphere-airgap.yaml
-	$(MAKE) os_distribution=redhat os_distribution_major_version=7 os_distribution_arch=x86_64 bundle_suffix= download-os-packages-bundle
-	$(MAKE) pip-packages-artifacts
-	$(MAKE) bundle_suffix= download-images-bundle
-	$(MAKE) devkit.run WHAT="make rhel79-ova BUILD_DRY_RUN=${BUILD_DRY_RUN} \
-	ADDITIONAL_OVERRIDES=overrides/offline.yaml,packer-vsphere-airgap.yaml$(if $(ADDITIONAL_OVERRIDES),$(COMMA)${ADDITIONAL_OVERRIDES})"
-
-.PHONY: rhel79-ova-fips
-rhel79-ova-fips: ## Build RHEL 7.9 FIPS image
-	$(MAKE) rhel79-ova ADDITIONAL_OVERRIDES=overrides/fips.yaml$(if $(ADDITIONAL_OVERRIDES),$(COMMA)${ADDITIONAL_OVERRIDES})
-
-.PHONY: rhel79-ova-fips-offline
-rhel79-ova-fips-offline: packer-vsphere-airgap.yaml
-	$(MAKE) os_distribution=redhat os_distribution_major_version=7 os_distribution_arch=x86_64 bundle_suffix=_fips download-os-packages-bundle
-	$(MAKE) pip-packages-artifacts
-	$(MAKE) bundle_suffix=_fips download-images-bundle
-	$(MAKE) devkit.run WHAT="make rhel79-ova-fips BUILD_DRY_RUN=${BUILD_DRY_RUN} \
-	ADDITIONAL_OVERRIDES=overrides/offline-fips.yaml,packer-vsphere-airgap.yaml$(if $(ADDITIONAL_OVERRIDES),$(COMMA)${ADDITIONAL_OVERRIDES})"
-
-.PHONY: sles15
-sles15: build
-sles15: ## Build SLES 15 image
-	./bin/konvoy-image build images/ami/sles-15.yaml \
-	--dry-run=$(BUILD_DRY_RUN) \
-	-v ${VERBOSITY} \
-	$(if $(ADDITIONAL_OVERRIDES),--overrides=${ADDITIONAL_OVERRIDES})
-
-.PHONY: sles15-nvidia
-sles15-nvidia: build
-sles15-nvidia: ## Build SLES 15 image with GPU support
-	./bin/konvoy-image build images/ami/sles-15.yaml \
-	--dry-run=$(BUILD_DRY_RUN) \
-	-v ${VERBOSITY} \
-	--overrides=overrides/nvidia.yaml \
-	--aws-instance-type p2.xlarge \
-	$(if $(ADDITIONAL_OVERRIDES),--overrides=${ADDITIONAL_OVERRIDES})
-
-.PHONY: flatcar
-flatcar: build
-flatcar: ## Build flatcar image
-	./bin/konvoy-image build images/ami/flatcar.yaml \
-	--dry-run=$(BUILD_DRY_RUN) \
-	-v ${VERBOSITY} \
-	$(if $(ADDITIONAL_OVERRIDES),--overrides=${ADDITIONAL_OVERRIDES})
-
-.PHONY: flatcar-nvidia
-flatcar-nvidia: build
-flatcar-nvidia: ## Build flatcar image with GPU support
-	./bin/konvoy-image build images/ami/flatcar.yaml \
-	--dry-run=$(BUILD_DRY_RUN) \
-	-v ${VERBOSITY} \
-	--overrides=overrides/nvidia.yaml \
-	--aws-instance-type p2.xlarge \
-	$(if $(ADDITIONAL_OVERRIDES),--overrides=${ADDITIONAL_OVERRIDES})
-
-
-.PHONY: ubuntu18
-ubuntu18: build
-ubuntu18: ## Build Ubuntu 20 image
-	./bin/konvoy-image build images/ami/ubuntu-18.yaml \
-	--dry-run=$(BUILD_DRY_RUN) \
-	-v ${VERBOSITY} \
-	$(if $(ADDITIONAL_OVERRIDES),--overrides=${ADDITIONAL_OVERRIDES})
-
-.PHONY: ubuntu20
-ubuntu20: build
-ubuntu20: ## Build Ubuntu 20 image
-	./bin/konvoy-image build images/ami/ubuntu-20.yaml \
-	--dry-run=$(BUILD_DRY_RUN) \
-	-v ${VERBOSITY} \
-	$(if $(ADDITIONAL_OVERRIDES),--overrides=${ADDITIONAL_OVERRIDES})
-
-.PHONY: ubuntu20-nvidia
-ubuntu20-nvidia: build
-ubuntu20-nvidia: ## Build Ubuntu 20 image with GPU support
-	./bin/konvoy-image build images/ami/ubuntu-20.yaml \
-	--dry-run=$(BUILD_DRY_RUN) \
-	-v ${VERBOSITY} \
-	--overrides=overrides/nvidia.yaml \
-	--aws-instance-type p2.xlarge \
-	$(if $(ADDITIONAL_OVERRIDES),--overrides=${ADDITIONAL_OVERRIDES})
-
-
-.PHONY: oracle7
-oracle7: build
-oracle7: ## Build Oracle Linux 7 image
-	./bin/konvoy-image build images/ami/oracle-7.yaml \
-	--dry-run=$(BUILD_DRY_RUN) \
-	-v ${VERBOSITY} \
-	$(if $(ADDITIONAL_OVERRIDES),--overrides=${ADDITIONAL_OVERRIDES})
-
-.PHONY: oracle8
-oracle8: build
-oracle8: ## Build Oracle Linux 8 image
-	./bin/konvoy-image build images/ami/oracle-8.yaml \
-	--dry-run=$(BUILD_DRY_RUN) \
-	-v ${VERBOSITY} \
-	$(if $(ADDITIONAL_OVERRIDES),--overrides=${ADDITIONAL_OVERRIDES})
 
 .PHONY: provision
 provision: build
@@ -718,15 +451,3 @@ release-bundle: cmd/konvoy-image-wrapper/image/konvoy-image-builder.tar.gz
 	$(MAKE) GOOS=linux release-bundle-GOOS
 	$(MAKE) GOOS=windows release-bundle-GOOS
 	$(MAKE) GOOS=darwin release-bundle-GOOS
-
-AIRGAPPED_BUNDLE_URL = konvoy-kubernetes-staging.s3.us-west-2.amazonaws.com
-
-.PHONY: download-images-bundle
-download-images-bundle:
-	mkdir -p artifacts/images/
-	curl -o artifacts/images/$(DEFAULT_KUBERNETES_VERSION_SEMVER)_images$(bundle_suffix).tar.gz -fsSL https://$(AIRGAPPED_BUNDLE_URL)/konvoy/airgapped/kubernetes-images/$(DEFAULT_KUBERNETES_VERSION_SEMVER)_images$(bundle_suffix).tar.gz
-
-.PHONY: download-os-packages-bundle
-download-os-packages-bundle:
-	mkdir -p artifacts/
-	curl -o artifacts/$(DEFAULT_KUBERNETES_VERSION_SEMVER)_$(os_distribution)_$(os_distribution_major_version)_$(os_distribution_arch)$(bundle_suffix).tar.gz -fsSL https://$(AIRGAPPED_BUNDLE_URL)/konvoy/airgapped/os-packages/$(DEFAULT_KUBERNETES_VERSION_SEMVER)_$(os_distribution)_$(os_distribution_major_version)_$(os_distribution_arch)$(bundle_suffix).tar.gz

--- a/cmd/konvoy-image/cmd/aws.go
+++ b/cmd/konvoy-image/cmd/aws.go
@@ -92,6 +92,13 @@ func addAmazonArgs(fs *flag.FlagSet, amazonArgs *app.AmazonArgs) {
 		"",
 		"instance type used to build the AMI; the type must be present in the region in which the AMI is built",
 	)
+	_ = fs.MarkDeprecated("aws-instance-type", "please use `--instance-type`.")
+	fs.StringVar(
+		&amazonArgs.AWSInstanceType,
+		"instance-type",
+		"",
+		"instance type used to build the AMI; the type must be present in the region in which the AMI is built",
+	)
 	fs.StringArrayVar(
 		&amazonArgs.AMIUsers,
 		"ami-users",

--- a/cmd/konvoy-image/cmd/azure.go
+++ b/cmd/konvoy-image/cmd/azure.go
@@ -132,4 +132,11 @@ func addAzureArgs(fs *flag.FlagSet, azure *app.AzureArgs) {
 		"",
 		"the tenant id to use for the build",
 	)
+
+	fs.StringVar(
+		&azure.InstanceType,
+		"instance-type",
+		"Standard_D2ds_v5",
+		"the Instance Type to use for the build",
+	)
 }

--- a/docs/cli/konvoy-image_build.md
+++ b/docs/cli/konvoy-image_build.md
@@ -16,11 +16,11 @@ konvoy-image build <image.yaml> [flags]
       --ami-groups stringArray           a list of AWS groups which are allowed use the image, using 'all' result in a public image
       --ami-regions stringArray          a list of regions to publish amis
       --ami-users stringArray            a list AWS user accounts which are allowed use the image
-      --aws-instance-type string         instance type used to build the AMI; the type must be present in the region in which the AMI is built
       --containerd-version string        the version of containerd to install
       --dry-run                          do not create artifacts, or delete them after creating. Recommended for tests.
       --extra-vars strings               flag passed Ansible's extra-vars
   -h, --help                             help for build
+      --instance-type string             instance type used to build the AMI; the type must be present in the region in which the AMI is built
       --kubernetes-version string        The version of kubernetes to install. Example: 1.21.6
       --overrides strings                a comma separated list of override YAML files
       --packer-manifest string           provide the path to a custom packer manifest

--- a/docs/cli/konvoy-image_build_aws.md
+++ b/docs/cli/konvoy-image_build_aws.md
@@ -18,11 +18,11 @@ aws --region us-west-2 --source-ami=ami-12345abcdef images/ami/centos-7.yaml
       --ami-groups stringArray           a list of AWS groups which are allowed use the image, using 'all' result in a public image
       --ami-regions stringArray          a list of regions to publish amis
       --ami-users stringArray            a list AWS user accounts which are allowed use the image
-      --aws-instance-type string         instance type used to build the AMI; the type must be present in the region in which the AMI is built
       --containerd-version string        the version of containerd to install
       --dry-run                          do not create artifacts, or delete them after creating. Recommended for tests.
       --extra-vars strings               flag passed Ansible's extra-vars
   -h, --help                             help for aws
+      --instance-type string             instance type used to build the AMI; the type must be present in the region in which the AMI is built
       --kubernetes-version string        The version of kubernetes to install. Example: 1.21.6
       --overrides strings                a comma separated list of override YAML files
       --packer-manifest string           provide the path to a custom packer manifest

--- a/docs/cli/konvoy-image_build_azure.md
+++ b/docs/cli/konvoy-image_build_azure.md
@@ -26,6 +26,7 @@ azure --location westus2 --subscription-id <sub_id> images/azure/centos-7.yaml
       --gallery-image-sku string           the gallery image sku to set
       --gallery-name string                the gallery name to publish the image in (default "dkp")
   -h, --help                               help for azure
+      --instance-type string               the Instance Type to use for the build (default "Standard_D2ds_v5")
       --kubernetes-version string          The version of kubernetes to install. Example: 1.21.6
       --location string                    the location in which to build the image (default "westus2")
       --overrides strings                  a comma separated list of override YAML files

--- a/docs/cli/konvoy-image_generate.md
+++ b/docs/cli/konvoy-image_generate.md
@@ -16,10 +16,10 @@ konvoy-image generate <image.yaml> [flags]
       --ami-groups stringArray           a list of AWS groups which are allowed use the image, using 'all' result in a public image
       --ami-regions stringArray          a list of regions to publish amis
       --ami-users stringArray            a list AWS user accounts which are allowed use the image
-      --aws-instance-type string         instance type used to build the AMI; the type must be present in the region in which the AMI is built
       --containerd-version string        the version of containerd to install
       --extra-vars strings               flag passed Ansible's extra-vars
   -h, --help                             help for generate
+      --instance-type string             instance type used to build the AMI; the type must be present in the region in which the AMI is built
       --kubernetes-version string        The version of kubernetes to install. Example: 1.21.6
       --overrides strings                a comma separated list of override YAML files
       --region string                    the region in which to build the AMI

--- a/docs/cli/konvoy-image_generate_aws.md
+++ b/docs/cli/konvoy-image_generate_aws.md
@@ -18,10 +18,10 @@ aws --region us-west-2 --source-ami=ami-12345abcdef images/ami/centos-7.yaml
       --ami-groups stringArray           a list of AWS groups which are allowed use the image, using 'all' result in a public image
       --ami-regions stringArray          a list of regions to publish amis
       --ami-users stringArray            a list AWS user accounts which are allowed use the image
-      --aws-instance-type string         instance type used to build the AMI; the type must be present in the region in which the AMI is built
       --containerd-version string        the version of containerd to install
       --extra-vars strings               flag passed Ansible's extra-vars
   -h, --help                             help for aws
+      --instance-type string             instance type used to build the AMI; the type must be present in the region in which the AMI is built
       --kubernetes-version string        The version of kubernetes to install. Example: 1.21.6
       --overrides strings                a comma separated list of override YAML files
       --region string                    the region in which to build the AMI

--- a/docs/cli/konvoy-image_generate_azure.md
+++ b/docs/cli/konvoy-image_generate_azure.md
@@ -25,6 +25,7 @@ azure --location westus2 --subscription-id <sub_id> images/azure/centos-7.yaml
       --gallery-image-sku string           the gallery image sku to set
       --gallery-name string                the gallery name to publish the image in (default "dkp")
   -h, --help                               help for azure
+      --instance-type string               the Instance Type to use for the build (default "Standard_D2ds_v5")
       --kubernetes-version string          The version of kubernetes to install. Example: 1.21.6
       --location string                    the location in which to build the image (default "westus2")
       --overrides strings                  a comma separated list of override YAML files

--- a/images/azure/rhel-8.yaml
+++ b/images/azure/rhel-8.yaml
@@ -8,6 +8,6 @@ packer:
   image_version: "latest"
   ssh_username: "azureuser"
 
-build_name: "rhel-7"
+build_name: "rhel-8"
 packer_builder_type: "azure"
 python_path: ""

--- a/make/ci.mk
+++ b/make/ci.mk
@@ -34,6 +34,7 @@ ci.e2e.build.all: ci.e2e.build.rhel-7.9-ova
 ci.e2e.build.%:
 	make devkit.run WHAT="make e2e.build.$*"
 
+# AWS
 e2e.build.centos-7: centos7
 
 e2e.build.centos-7-offline: centos7-offline infra.aws.destroy
@@ -56,15 +57,35 @@ e2e.build.oracle-8: oracle8
 
 e2e.build.flatcar: flatcar
 
-e2e.build.rhel-8-fips: rhel82-fips
-
-e2e.build.rhel-8.4-ova: rhel84-ova
-
-e2e.build.rhel-7.9-ova: rhel79-ova
-
 e2e.build.centos-7-nvidia: centos7-nvidia
 
 e2e.build.sles-15-nvidia: sles15-nvidia
+
+e2e.build.rhel-8-fips: rhel82-fips
+
+# Azure
+e2e.build.centos-7-azure: centos7-azure
+
+e2e.build.flatcar-azure: flatcar-azure
+
+e2e.build.oracle-7-azure: oracle7-azure
+
+e2e.build.oracle-8-azure: oracle8-azure
+
+e2e.build.sles-15-azure: sles15-azure
+
+e2e.build.rhel-7-fips-azure: rhel7-fips-azure
+
+e2e.build.rhel-8-fips-azure: rhel8-fips-azure
+
+e2e.build.ubuntu-18-azure: ubuntu18-azure
+
+e2e.build.ubuntu-20-azure: ubuntu20-azure
+
+# vSphere
+e2e.build.rhel-8.4-ova: rhel84-ova
+
+e2e.build.rhel-7.9-ova: rhel79-ova
 
 # use sibling containers to handle dependencies and avoid DinD
 ci.e2e.ansible:

--- a/make/ci.mk
+++ b/make/ci.mk
@@ -1,0 +1,73 @@
+#
+# CI targets
+#
+
+# requires ANSIBLE_PATH, otherwise run `make ci.e2e.ansible`
+e2e.ansible:
+	make -C test/e2e/ansible e2e
+
+ifeq ($(CI), true)
+export DOCKER_DEVKIT_AWS_ARGS := --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY
+endif
+
+# Run every E2E test in its own devkit container.
+# All tests run in parallel. Adjust parallelism with --jobs.
+# Output is interleaved when run in parallel. Use --output-sync=recurse to serialize output.
+ci.e2e.build.all: ci.e2e.build.centos-7
+ci.e2e.build.all: ci.e2e.build.ubuntu-18
+ci.e2e.build.all: ci.e2e.build.ubuntu-20
+ci.e2e.build.all: ci.e2e.build.sles-15
+ci.e2e.build.all: ci.e2e.build.oracle-7
+ci.e2e.build.all: ci.e2e.build.oracle-8
+ci.e2e.build.all: ci.e2e.build.flatcar
+ci.e2e.build.all: e2e.build.centos-7-offline
+ci.e2e.build.all: e2e.build.rhel-7.9-offline-fips
+ci.e2e.build.all: e2e.build.rhel-8.2-offline-fips
+ci.e2e.build.all: e2e.build.rhel-8.4-offline-fips
+ci.e2e.build.all: ci.e2e.build.rhel-8-fips
+ci.e2e.build.all: ci.e2e.build.centos-7-nvidia
+ci.e2e.build.all: ci.e2e.build.sles-15-nvidia
+ci.e2e.build.all: ci.e2e.build.rhel-8.4-ova
+ci.e2e.build.all: ci.e2e.build.rhel-7.9-ova
+
+# Run an E2E test in its own devkit container.
+ci.e2e.build.%:
+	make devkit.run WHAT="make e2e.build.$*"
+
+e2e.build.centos-7: centos7
+
+e2e.build.centos-7-offline: centos7-offline infra.aws.destroy
+
+e2e.build.rhel-7.9-offline-fips: rhel79-fips-offline infra.aws.destroy
+
+e2e.build.rhel-8.2-offline-fips: rhel82-fips-offline infra.aws.destroy
+
+e2e.build.rhel-8.4-offline-fips: rhel84-fips-offline infra.aws.destroy
+
+e2e.build.ubuntu-18: ubuntu18
+
+e2e.build.ubuntu-20: ubuntu20
+
+e2e.build.sles-15: sles15
+
+e2e.build.oracle-7: oracle7
+
+e2e.build.oracle-8: oracle8
+
+e2e.build.flatcar: flatcar
+
+e2e.build.rhel-8-fips: rhel82-fips
+
+e2e.build.rhel-8.4-ova: rhel84-ova
+
+e2e.build.rhel-7.9-ova: rhel79-ova
+
+e2e.build.centos-7-nvidia: centos7-nvidia
+
+e2e.build.sles-15-nvidia: sles15-nvidia
+
+# use sibling containers to handle dependencies and avoid DinD
+ci.e2e.ansible:
+	make -C test/e2e/ansible e2e.setup
+	WHAT="make -C test/e2e/ansible e2e.run" DOCKER_DEVKIT_DEFAULT_ARGS="--rm --net=host" make devkit.run
+	make -C test/e2e/ansible e2e.clean

--- a/make/images.mk
+++ b/make/images.mk
@@ -133,7 +133,7 @@ build-%:
 .PHONY: %_nvidia
 %_nvidia:
 	$(MAKE) build-$* \
-		ADDITIONAL_ARGS="--aws-instance-type p2.xlarge$(if $(ADDITIONAL_ARGS), $(SPACE)$(ADDITIONAL_ARGS))" \
+		ADDITIONAL_ARGS="--instance-type p2.xlarge$(if $(ADDITIONAL_ARGS),$(SPACE)$(ADDITIONAL_ARGS))" \
 		ADDITIONAL_OVERRIDES=overrides/nvidia.yaml$(if $(ADDITIONAL_OVERRIDES),$(COMMA)$(ADDITIONAL_OVERRIDES))
 		VERBOSITY=$(VERBOSITY) \
 		BUILD_DRY_RUN=$(BUILD_DRY_RUN)

--- a/make/images.mk
+++ b/make/images.mk
@@ -157,11 +157,11 @@ centos7-nvidia:
 
 .PHONY: flatcar
 flatcar:
-	$(MAKE) build-aws-flatcar ADDITIONAL_OVERRIDES=flatcar-version.yaml
+	$(MAKE) build-aws-flatcar
 
 .PHONY: flatcar-nvidia
 flatcar-nvidia:
-	$(MAKE) aws-flatcar_nvidia ADDITIONAL_OVERRIDES=flatcar-version.yaml
+	$(MAKE) aws-flatcar_nvidia
 
 # Oracle 7
 .PHONY: oracle7
@@ -188,7 +188,7 @@ rhel79-fips:
 
 .PHONY: rhel79-fips-offline
 rhel79-fips-offline:
-	$(MAKE) aws-rhel7.9_offline-fips
+	$(MAKE) aws-rhel-7.9_offline-fips
 
 .PHONY: rhel79-ova
 rhel79-ova:

--- a/make/images.mk
+++ b/make/images.mk
@@ -1,0 +1,280 @@
+#
+# Image Building targets
+#
+
+# BUILD_DRY_RUN determines the value of the --dry-run flag of the build command. Should be 'true' or 'false'.
+BUILD_DRY_RUN ?= true
+ifeq ($(BUILD_DRY_RUN),true)
+$(warning Warning: BUILD_DRY_RUN is true)
+endif
+
+VERBOSITY ?= 0
+COMMA := ,
+NULL :=
+SPACE := $(NULL) $(NULL)
+
+AIRGAPPED_BUNDLE_URL ?= konvoy-kubernetes-staging.s3.us-west-2.amazonaws.com
+ARTIFACTS_DIR ?= artifacts/
+DEFAULT_KUBERNETES_VERSION_SEMVER ?= $(shell \
+	grep -E -e "kubernetes_version:" ansible/group_vars/all/defaults.yaml | \
+	cut -d\" -f2 \
+)
+
+# NOTE(jkoelker) Extract the provider as the first part (same as `cut -d- -f1`)
+provider = $(firstword $(subst -,$(SPACE),$(1)))
+
+#NOTE(jkoelker) Extract the distro as the second part (same as `cut -d- -f2`)
+distro = $(wordlist 2,2,$(subst -,$(SPACE),$(1)))
+
+#NOTE(jkoelker) Extract the version as the third part (same as `cut -d- -f3`)
+version = $(wordlist 3,3,$(subst -,$(SPACE),$(1)))
+
+#NOTE(jkoelker) Extract the major as the first part (same as `cut -d. -f1`)
+major_version = $(firstword $(subst .,$(SPACE),$(1)))
+
+#NOTE(jkoelker) Convert the distro to the package bundle distro name
+os_distro = $(subst rhel,redhat,$(1))
+
+# NOTE(jkoelker) Convert the provider to an image subdir
+image_dir = $(subst aws,ami,$(call provider, $(1)))
+
+# NOTE(jkoelker) Extract the file from the last part (same as `cut -d- -f2-`)
+#                and squashes major and minor, e.g 7.9 -> 79, 8.2 -> 82
+image_file = $(subst .,,$(subst $(SPACE),-,$(wordlist 2, 3, $(subst -,$(SPACE),$(1)))))
+
+$(ARTIFACTS_DIR):
+	mkdir -p $(ARTIFACTS_DIR)
+
+$(ARTIFACTS_DIR)/images:
+	mkdir -p $(ARTIFACTS_DIR)/images
+
+# TODO(jkoelker) UnPHONYify these targets
+.PHONY: download-images-bundle
+download-images-bundle: $(ARTIFACTS_DIR)/images
+	curl -o $(ARTIFACTS_DIR)/images/$(DEFAULT_KUBERNETES_VERSION_SEMVER)_images$(bundle_suffix).tar.gz -fsSL https://$(AIRGAPPED_BUNDLE_URL)/konvoy/airgapped/kubernetes-images/$(DEFAULT_KUBERNETES_VERSION_SEMVER)_images$(bundle_suffix).tar.gz
+
+.PHONY: download-os-packages-bundle
+download-os-packages-bundle: $(ARTIFACTS_DIR)
+	curl -o $(ARTIFACTS_DIR)/$(DEFAULT_KUBERNETES_VERSION_SEMVER)_$(os_distribution)_$(os_distribution_major_version)_$(os_distribution_arch)$(bundle_suffix).tar.gz -fsSL https://$(AIRGAPPED_BUNDLE_URL)/konvoy/airgapped/os-packages/$(DEFAULT_KUBERNETES_VERSION_SEMVER)_$(os_distribution)_$(os_distribution_major_version)_$(os_distribution_arch)$(bundle_suffix).tar.gz
+
+# NOTE(jkoelker) set no-op cleanup targets for providers that support `DryRun`.
+.PHONY: aws-build-image-cleanup
+aws-build-image-cleanup: ;
+
+.PHONY: ova-build-image-cleanup
+ova-build-image-cleanup: ;
+
+# NOTE(jkoelker) The common build target every other target ends up calling.
+.PHONY: build-image
+build-image: build
+build-image: $(IMAGE)
+build-image: ## Build an image on a provider
+	./bin/konvoy-image build $(subst ova,,$(PROVIDER)) $(IMAGE) \
+	--dry-run=$(BUILD_DRY_RUN) \
+	-v ${VERBOSITY} \
+	$(if $(ADDITIONAL_OVERRIDES),--overrides=$(ADDITIONAL_OVERRIDES)) \
+	$(ADDITIONAL_ARGS)
+	$(MAKE) $(PROVIDER)-build-image-cleanup
+
+# NOTE(jkoelker) Parses the `PROVIDER` and `IMAGE` from the target name. E.g
+#                `build-aws-centos-8.4` will set `PROVIDER=aws` and
+#                `IMAGE=images/ami/centos-84.yaml1.
+.PHONY: build-%
+build-%:
+	$(MAKE) build-image \
+		PROVIDER=$(call provider,$*) \
+		ADDITIONAL_OVERRIDES=$(ADDITIONAL_OVERRIDES) \
+		ADDITIONAL_ARGS="$(ADDITIONAL_ARGS)" \
+		IMAGE=images/$(call image_dir,$*)/$(call image_file,$*).yaml \
+		VERBOSITY=$(VERBOSITY) \
+		BUILD_DRY_RUN=$(BUILD_DRY_RUN)
+
+.PHONY: %_fips
+%_fips:
+	$(MAKE) build-$* \
+		ADDITIONAL_ARGS="$(ADDITIONAL_ARGS)" \
+		ADDITIONAL_OVERRIDES=overrides/fips.yaml$(if $(ADDITIONAL_OVERRIDES),$(COMMA)$(ADDITIONAL_OVERRIDES)) \
+		VERBOSITY=$(VERBOSITY) \
+		BUILD_DRY_RUN=$(BUILD_DRY_RUN)
+
+.PHONY: %_offline
+%_offline:
+	# NOTE(jkoelker) Fail fast if offline is not supported for provider
+	$(MAKE) devkit.run WHAT="make packer-$(call provider,$*)-offline-override.yaml"
+	$(MAKE) os_distribution=$(call os_distro,$(call distro,$*)) \
+		os_distribution_major_version=$(call major_version,$(call version,$*)) \
+		os_distribution_arch=x86_64 \
+		bundle_suffix= \
+		download-os-packages-bundle
+	$(MAKE) pip-packages-artifacts
+	$(MAKE) bundle_suffix= download-images-bundle
+	$(MAKE) devkit.run WHAT="make build-$* \
+		BUILD_DRY_RUN=$(BUILD_DRY_RUN) \
+		VERBOSITY=$(VERBOSITY) \
+		ADDITIONAL_ARGS=\"$(ADDITIONAL_ARGS)\" \
+		ADDITIONAL_OVERRIDES=overrides/offline.yaml,packer-$(call provider, $*)-offline-override.yaml$(if $(ADDITIONAL_OVERRIDES),$(COMMA)$(ADDITIONAL_OVERRIDES))"
+
+.PHONY: %_offline-fips
+%_offline-fips:
+	$(MAKE) devkit.run WHAT="make packer-$(call provider,$*)-offline-override.yaml"
+	$(MAKE) os_distribution=$(call os_distro,$(call distro,$*)) \
+		os_distribution_major_version=$(call major_version,$(call version,$*)) \
+		os_distribution_arch=x86_64 \
+		bundle_suffix=_fips \
+		download-os-packages-bundle
+	$(MAKE) pip-packages-artifacts
+	$(MAKE) bundle_suffix=_fips download-images-bundle
+	$(MAKE) devkit.run WHAT="make $*_fips \
+		BUILD_DRY_RUN=${BUILD_DRY_RUN} \
+		VERBOSITY=$(VERBOSITY) \
+		ADDITIONAL_ARGS=\"$(ADDITIONAL_ARGS)\" \
+		ADDITIONAL_OVERRIDES=overrides/offline-fips.yaml,packer-$(call provider,$*)-offline-override.yaml$(if $(ADDITIONAL_OVERRIDES),$(COMMA)${ADDITIONAL_OVERRIDES})"
+
+.PHONY: %_nvidia
+%_nvidia:
+	$(MAKE) build-$* \
+		ADDITIONAL_ARGS="--aws-instance-type p2.xlarge$(if $(ADDITIONAL_ARGS), $(SPACE)$(ADDITIONAL_ARGS))" \
+		ADDITIONAL_OVERRIDES=overrides/nvidia.yaml$(if $(ADDITIONAL_OVERRIDES),$(COMMA)$(ADDITIONAL_OVERRIDES))
+		VERBOSITY=$(VERBOSITY) \
+		BUILD_DRY_RUN=$(BUILD_DRY_RUN)
+
+# Centos 7
+.PHONY: centos7
+centos7:
+	$(MAKE) build-aws-centos-7
+
+.PHONY: centos7-fips
+centos7-fips:
+	$(MAKE) aws-centos-7_fips
+
+.PHONY: centos7-offline
+centos7-offline:
+	$(MAKE) aws-centos-7_offline
+
+.PHONY: centos7-nvidia
+centos7-nvidia:
+	$(MAKE) aws-centos-7_nvidia
+
+.PHONY: flatcar
+flatcar:
+	$(MAKE) build-aws-flatcar ADDITIONAL_OVERRIDES=flatcar-version.yaml
+
+.PHONY: flatcar-nvidia
+flatcar-nvidia:
+	$(MAKE) aws-flatcar_nvidia ADDITIONAL_OVERRIDES=flatcar-version.yaml
+
+# Oracle 7
+.PHONY: oracle7
+oracle7:
+	$(MAKE) build-aws-oracle-7
+
+# Oracle 8
+.PHONY: oracle8
+oracle8:
+	$(MAKE) build-aws-oracle-8
+
+# RHEL 7.9
+.PHONY: rhel79
+rhel79:
+	$(MAKE) build-aws-rhel-7.9
+
+.PHONY: rhel79-nvidia
+rhel79-nvidia:
+	$(MAKE) aws-rhel-7.9_nvidia
+
+.PHONY: rhel79-fips
+rhel79-fips:
+	$(MAKE) aws-rhel-7.9_fips
+
+.PHONY: rhel79-fips-offline
+rhel79-fips-offline:
+	$(MAKE) aws-rhel7.9_offline-fips
+
+.PHONY: rhel79-ova
+rhel79-ova:
+	$(MAKE) build-ova-rhel-7.9
+
+.PHONY: rhel79-ova-offline
+rhel79-ova-offline:
+	$(MAKE) ova-rhel-7.9_offline
+
+.PHONY: rhel79-ova-fips
+rhel79-ova-fips:
+	$(MAKE) ova-rhel-7.9_fips
+
+.PHONY: rhel79-ova-fips-offline
+rhel79-ova-fips-offline:
+	$(MAKE) ova-rhel-7.9_offline-fips
+
+# RHEL 8.2
+.PHONY: rhel82
+rhel82:
+	$(MAKE) build-aws-rhel-8.2
+
+.PHONY: rhel82-nvidia
+rhel82-nvidia:
+	$(MAKE) aws-rhel-8.2_nvidia
+
+.PHONY: rhel82-fips
+rhel82-fips:
+	$(MAKE) aws-rhel-8.2_fips
+
+.PHONY: rhel82-fips-offline
+rhel82-fips-offline:
+	$(MAKE) aws-rhel-8.2_offline-fips
+
+# RHEL 8.4
+.PHONY: rhel84
+rhel84:
+	$(MAKE) build-aws-rhel-8.4
+
+.PHONY: rhel84-nvidia
+rhel84-nvidia:
+	$(MAKE) aws-rhel-8.4_nvidia
+
+.PHONY: rhel84-fips
+rhel84-fips:
+	$(MAKE) aws-rhel-8.4_fips
+
+.PHONY: rhel84-fips-offline
+rhel84-fips-offline:
+	$(MAKE) aws-rhel-8.4_offline-fips
+
+.PHONY: rhel84-ova
+rhel84-ova:
+	$(MAKE) build-ova-rhel-8.4
+
+.PHONY: rhel84-ova-offline
+rhel84-ova-offline:
+	$(MAKE) ova-rhel-8.4_offline
+
+.PHONY: rhel84-ova-fips
+rhel84-ova-fips:
+	$(MAKE) ova-rhel-8.4_fips
+
+.PHONY: rhel82-ova-fips-offline
+rhel84-ova-fips-offline:
+	$(MAKE) ova-rhel-8.4_offline-fips
+
+# SLES 15
+.PHONY: sles15
+sles15:
+	$(MAKE) build-aws-sles-15
+
+.PHONY: sles15-nvidia
+sles15-nvidia:
+	$(MAKE) aws-sles-15_nvidia
+
+# Ubuntu 18(04)
+.PHONY: ubuntu18
+ubuntu18:
+	$(MAKE) build-aws-ubuntu-18
+
+# Ubuntu 20(04)
+.PHONY: ubuntu20
+ubuntu20:
+	$(MAKE) build-aws-ubuntu-20
+
+.PHONY: ubuntu20-nvidia
+ubuntu20-nvidia:
+	$(MAKE) aws-ubuntu-20_nvidia

--- a/pkg/app/build.go
+++ b/pkg/app/build.go
@@ -62,6 +62,8 @@ type AmazonArgs struct {
 type AzureArgs struct {
 	ClientID string
 
+	InstanceType string
+
 	GalleryImageLocations []string
 	GalleryImageName      string
 	GalleryImageOffer     string

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -438,6 +438,10 @@ func MergeAzureUserArgs(config Config, azureArgs *AzureArgs) error {
 		return fmt.Errorf("failed to set %s: %w", PackerAzureTenantIDPath, err)
 	}
 
+	if err := config.Set(PackerAzureInstanceType, azureArgs.InstanceType); err != nil {
+		return fmt.Errorf("failed to set %s: %w", PackerAzureInstanceType, err)
+	}
+
 	galleryImageLocations := azureArgs.GalleryImageLocations
 	if len(galleryImageLocations) == 0 {
 		galleryImageLocations = []string{azureArgs.Location}

--- a/pkg/app/constants.go
+++ b/pkg/app/constants.go
@@ -30,6 +30,7 @@ const (
 
 	PackerAzureClientIDPath              = "/packer/client_id"
 	PackerAzureDistributionVersionPath   = "/packer/distribution_version"
+	PackerAzureInstanceType              = "/packer/vm_size"
 	PackerAzureGalleryLocations          = "/packer/gallery_image_locations"
 	PackerAzureGalleryImageNamePath      = "/packer/gallery_image_name"
 	PackerAzureGalleryImageOfferPath     = "/packer/gallery_image_offer"

--- a/test/e2e/scripts/clean-last-azure-image.sh
+++ b/test/e2e/scripts/clean-last-azure-image.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+UUID=$(jq -r ".last_run_uuid" manifest.json)
+ARTIFACT=$(jq -r ".builds[] | \
+                    select(.packer_run_uuid == \"${UUID}\") |\
+                    .artifact_id" manifest.json)
+
+# NOTE(jkoelker) extract just the timestamp as the chars after the final `-`
+TS="${ARTIFACT##*-}"
+
+# NOTE(jkoelker) extract the image name as the chars after the final `/`
+IMG="${ARTIFACT##*/}"
+
+# NOTE(jkoelker) further refine the image name by stripping off the timestamp
+IMG="${IMG%-"$TS"}"
+
+az login \
+    --service-principal \
+    --username "${AZURE_CLIENT_ID}" \
+    --password "${AZURE_CLIENT_SECRET}" \
+    --tenant "${AZURE_TENANT_ID}"
+
+az sig image-version delete \
+    --resource-group dkp \
+    --gallery-name dkp \
+    --gallery-image-definition "${IMG}" \
+    --gallery-image-version "0.0.${TS}"

--- a/test/infra/aws/Makefile
+++ b/test/infra/aws/Makefile
@@ -37,9 +37,8 @@ infra.aws.create: install-terraform infra.aws.init
 	TF_LOG=INFO $(TERRAFORM_BIN) -chdir=$(TEST_INFRA_STATE_DIR)/aws plan
 	TF_LOG=INFO $(TERRAFORM_BIN) -chdir=$(TEST_INFRA_STATE_DIR)/aws apply -auto-approve
 
-packer-custom-vpc-override.yaml:
-packer-custom-vpc-override.yaml: infra.aws.create
-	@$(TEST_INFRA_STATE_DIR)/aws/export.sh
+packer-aws-offline-override.yaml: infra.aws.create
+	@$(TEST_INFRA_STATE_DIR)/aws/export.sh $@
 
 .PHONY: infra.aws.destroy
 infra.aws.destroy: ## Destroy infrastructure

--- a/test/infra/aws/export.sh
+++ b/test/infra/aws/export.sh
@@ -9,4 +9,4 @@ export AWS_VPC_ID="$("${TERRAFORM_BIN}" -chdir=.local/infra/aws output -raw vpc_
 export AWS_SECURITY_GROUP_ID="$("${TERRAFORM_BIN}" -chdir=.local/infra/aws output -raw security_group_id)"
 # shellcheck disable=SC2155
 export AWS_SUBNET_ID="$("${TERRAFORM_BIN}" -chdir=.local/infra/aws output -raw public_subnets)"
-envsubst < .local/infra/aws/packer-custom-vpc-override.yaml.tmpl >> packer-custom-vpc-override.yaml
+envsubst < .local/infra/aws/packer-custom-vpc-override.yaml.tmpl >> "$1"

--- a/test/infra/vsphere/Makefile
+++ b/test/infra/vsphere/Makefile
@@ -4,6 +4,5 @@ export SCRIPT_DIR ?= $(CURDIR)/hack
 
 TEST_SCRIPTS_DIR ?= $(CURDIR)/test/infra/vsphere
 
-packer-vsphere-airgap.yaml:
-packer-vsphere-airgap.yaml:
-	@$(TEST_SCRIPTS_DIR)/export.sh
+packer-ova-offline-override.yaml:
+	@$(TEST_SCRIPTS_DIR)/export.sh $@

--- a/test/infra/vsphere/export.sh
+++ b/test/infra/vsphere/export.sh
@@ -2,4 +2,4 @@
 # shellcheck disable=SC2001
 echo "${SSH_BASTION_KEY_CONTENTS}" | sed 's/\\n/\n/g' >> vsphere-tests.pem
 chmod 600 vsphere-tests.pem
-envsubst < test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl >> packer-vsphere-airgap.yaml
+envsubst < test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl >> "$1"


### PR DESCRIPTION
**What problem does this PR solve?**:

DRY up the current build targets by using `pattern` targets.

The basis is a `build-${provider}-${distro}-${version}` pattern target that will parse out the parts from the target name. Other pattern targets end up calling this target setting the various `ADDITIONAL_OVERRIDES` or `ADDITIONAL_ARGS`. They then provide the following pattern targets:

`${provider}-${distro}-${version}_fips`
`${provider}-${distro}-${version}_offline`
`${provider}-${distro}-${version}_offline-fips`
`${provider}-${distro}-${version}_nvidia`

All the existing targets are now just aliases to the dynamic pattern targets. In the future if we stay consistent with the image name pattern we have for aws/azure/vsphere, we won't have to have any alias patterns and can just setup CI to call the pattern targets directly.

I pulled the images targets out into their own makefile as well. The root one is getting kinda gnarly.

Adds Azure build using these this new target pattern.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
*https://jira.d2iq.com/browse/D2IQ-85258


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
