### PR TITLE
chore(devkit): fix python packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ FROM ${BASE} as devkit
 
 FROM alpine:3.15.2
 
-ARG ANSIBLE_VERSION=2.10.7
 ENV ANSIBLE_PATH=/usr
 ENV PYTHON_PATH=/usr
 
+COPY requirements.txt /tmp/
 # NOTE(jkoelker) Ignore "Pin versions in [pip | apk add]"
 # hadolint ignore=DL3013,DL3018
 RUN apk add --no-cache \
@@ -20,9 +20,7 @@ RUN apk add --no-cache \
         py3-cryptography \
         py3-pip \
         py3-wheel \
-    && pip3 install --no-cache-dir \
-        ansible=="${ANSIBLE_VERSION}" \
-        netaddr \
+    && pip3 install --no-cache-dir --requirement /tmp/requirements.txt \
     && rm -rf /root/.cache
 
 COPY --from=devkit /usr/local/bin/goss /usr/local/bin/

--- a/Dockerfile.devkit
+++ b/Dockerfile.devkit
@@ -69,6 +69,8 @@ ARG GROUP_NAME=root
 ARG GROUP_ID=0
 ARG DOCKER_GID=0
 
+COPY requirements.txt /tmp/
+COPY requirements-devkit.txt /tmp/
 # NOTE(jkoelker) Ignore "Pin versions in [pip | apk add]"
 # hadolint ignore=DL3013,DL3018
 RUN apk add --no-cache \
@@ -78,6 +80,7 @@ RUN apk add --no-cache \
         gcc \
         jq \
         libc6-compat \
+        linux-headers \
         musl-dev \
         make \
         openssl \
@@ -85,19 +88,12 @@ RUN apk add --no-cache \
         python3 \
         python3-dev \
         gettext \
-        py3-cffi \
-        py3-cryptography \
         py3-pynacl \
-        py3-pip\
-        py3-psutil \
-        py3-setuptools \
-        py3-wheel \
+        py3-pip \
+    && pip3 install --no-cache-dir --upgrade pip wheel \
     && pip3 install --no-cache-dir \
-        ansible=="${ANSIBLE_VERSION}" \
-        awscli \
-        azure-cli \
-        docker=="${DOCKER_PY_VERSION}" \
-        netaddr \
+        --requirement /tmp/requirements.txt \
+        --requirement /tmp/requirements-devkit.txt \
     && rm -rf \
         /root/.cache
 

--- a/requirements-devkit.txt
+++ b/requirements-devkit.txt
@@ -1,0 +1,3 @@
+awscli==1.23.1
+azure-cli==2.36.0
+docker==5.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+ansible==2.10.7
+netaddr==0.8.0


### PR DESCRIPTION
**What problem does this PR solve?**:

The devkit is currently failing to build due to conflicting versions of `psutil` being installed vs needed (`alpine` has 5.8 and `azure-cli` requires 5.9).

To remedy this, move the requirements and pining of what we actually care about into `requirements.txt` and `requirements-devkit.txt`. This allows pip to satisfy all the requirements as binary wheels currently, and will allow us to use dependabot in the future to manage bumping the versions. 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
