### PR TITLE
fix(azure): append build name to image sku

### DIFF
--- a/pkg/app/build.go
+++ b/pkg/app/build.go
@@ -330,6 +330,10 @@ func azureImageDescription(config Config) (*azure.ImageDescription, error) {
 		}
 	}
 
+	// NOTE(jkoelker) Append the build extra to the sku to prevent conflicts between
+	//                base images and their special flavors (e.g. centos7 and centos7-nvidia)
+	sku = config.AddBuildNameExtra(sku)
+
 	description, err := azure.NewImageDescription(
 		galleryName,
 		galleryImageName,

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -95,6 +95,10 @@ func (config Config) get(path string) (interface{}, error) {
 	return value, nil
 }
 
+func (config Config) AddBuildNameExtra(base string) string {
+	return fmt.Sprintf("%s%s", base, config.Get(BuildNameExtraKey))
+}
+
 func (config Config) GetSliceWithError(path string) ([]string, error) {
 	value, err := config.get(path)
 	if err != nil {
@@ -184,16 +188,11 @@ func (config Config) Delete(path string) error {
 func BuildName(config Config) string {
 	buildName := config.Get(BuildNameKey)
 
-	buildNameExtra := config.Get(BuildNameExtraKey)
 	if buildName == "" {
 		buildName = DefaultBuildName
 	}
 
-	if buildNameExtra != "" {
-		return fmt.Sprintf("%s%s", buildName, buildNameExtra)
-	}
-
-	return buildName
+	return config.AddBuildNameExtra(buildName)
 }
 
 func configFromWorkDir(workDir string, ansibleVarsFilename string) (Config, error) {


### PR DESCRIPTION
Allows sharing a common base image with the `-nvidia` override.

**What problem does this PR solve?**:

When building extra images (gpu, fips, etc) the name of the resulting image should include that build extra to prevent conflicts if an account has, for example, RHEL8 and RHEL8 with GPU. Currently both images will attempt to be stored as RHEL8 and only the first will succeed. 

Broke this commit out from #323 as that is blocked on Azure GPU capacity, and its valid for fips images as well.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
