### PR TITLE
feat(oracle): support installing RHCK kernel 

### DIFF
--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -71,3 +71,6 @@ os_packages_remote_bundle_path: "/opt/dkp/packages/"
 pip_packages_local_bundle_file: ""
 pip_packages_remote_bundle_path: "/opt/dkp/pip-packages/"
 pip_packages_remote_filesystem_repo_path: "/opt/dkp/pip-packages/offline-packages/"
+
+# NOTE(jkoelker) UEK is the default. Set to RHCK to change to RH kernel.
+oracle_kernel: UEK

--- a/ansible/roles/packages/tasks/oracle.yaml
+++ b/ansible/roles/packages/tasks/oracle.yaml
@@ -1,0 +1,76 @@
+---
+
+- name: RHCK kernel
+  when:
+    - oracle_kernel == "RHCK"
+  block:
+    - name: install RHCK kernel
+      yum:
+        name: kernel
+        state: present
+        update_cache: true
+        enablerepo: "{{ 'offline' if offline_mode_enabled else '' }}"
+        disablerepo: "{{ '*' if offline_mode_enabled else '' }}"
+      register: rhck_installation_rpm
+      until: rhck_installation_rpm is success
+      retries: 3
+      delay: 3
+
+    - name: configure grub for oracle 7
+      block:
+        - name: generate grub
+          command: grub2-mkconfig -o /boot/grub2/grub.cfg
+
+        - name: read grub.cfg
+          command: cat /boot/grub2/grub.cfg
+          register: grub_cfg
+
+        - name: read RHCK kernel
+          set_fact:
+            rhck_kernel: "{{
+              grub_cfg.stdout_lines |
+              reject('match', '^.*Unbreakable Enterprise Kernel.*$') |
+              select('match', '^menuentry') |
+              map('regex_replace', \"^menuentry '(.*?)' .*$\", '\\1') |
+              sort |
+              last
+            }}"
+
+        - name: set default kernel
+          command: grub2-set-default "{{ rhck_kernel }}"
+
+      when:
+        - ansible_distribution_major_version == '7'
+
+    - name: configure grub for oracle 8
+      block:
+        - name: install grubby
+          yum:
+            name: grubby
+            state: present
+            update_cache: true
+            enablerepo: "{{ 'offline' if offline_mode_enabled else '' }}"
+            disablerepo: "{{ '*' if offline_mode_enabled else '' }}"
+          register: grubby_installation_rpm
+          until: grubby_installation_rpm is success
+          retries: 3
+          delay: 3
+
+        - name: list kernels
+          shell: ls -1 /boot/vmlinuz*
+          register: boot_vmlinuz
+
+        - name: read RHCK kernel
+          set_fact:
+            rhck_kernel: "{{
+              boot_vmlinuz.stdout_lines |
+              reject('match', '^.*uek.*$') |
+              sort |
+              last
+            }}"
+
+        - name: set default kernel
+          command: grubby --set-default "{{ rhck_kernel }}"
+
+      when:
+        - ansible_distribution_major_version == '8'

--- a/ansible/roles/packages/tasks/redhat.yaml
+++ b/ansible/roles/packages/tasks/redhat.yaml
@@ -19,7 +19,7 @@
     state: present
     enablerepo: "{{ 'offline' if offline_mode_enabled else '' }}"
     disablerepo: "{{ '*' if offline_mode_enabled else '' }}"
-    update_cache: yes
+    update_cache: true
   register: result
   until: result is success
   retries: 5
@@ -47,9 +47,10 @@
     - kubectl
   args:
     warn: false
-  ignore_errors: True
+  ignore_errors: true
   register: command_result
-  changed_when: 'command_result.stdout is regex(".*versionlock deleted: [1-9]+.*")'
+  changed_when: >
+    'command_result.stdout is regex(".*versionlock deleted: [1-9]+.*")'
   when:
     - versionlock_plugin_enabled
     - item in exportedversionlocklist.stdout
@@ -58,7 +59,7 @@
   yum:
     name: "{{ 'kubectl-' + package_versions.kubernetes_rpm }}"
     state: present
-    update_cache: yes
+    update_cache: true
     enablerepo: "{{ 'offline' if offline_mode_enabled else '' }}"
     disablerepo: "{{ '*' if offline_mode_enabled else '' }}"
   register: result
@@ -70,7 +71,7 @@
   yum:
     name: "{{ 'kubelet-' + package_versions.kubernetes_rpm }}"
     state: present
-    update_cache: yes
+    update_cache: true
     enablerepo: "{{ 'offline' if offline_mode_enabled else '' }}"
     disablerepo: "{{ '*' if offline_mode_enabled else '' }}"
   register: kubelet_installation_rpm
@@ -86,6 +87,7 @@
   args:
     warn: false
   register: command_result
-  changed_when: 'command_result.stdout is regex(".*versionlock added: [1-9]+.*")'
+  changed_when: >
+    'command_result.stdout is regex(".*versionlock added: [1-9]+.*")'
   when:
     - versionlock_plugin_enabled

--- a/ansible/roles/packages/tasks/redhat.yaml
+++ b/ansible/roles/packages/tasks/redhat.yaml
@@ -91,3 +91,6 @@
     'command_result.stdout is regex(".*versionlock added: [1-9]+.*")'
   when:
     - versionlock_plugin_enabled
+
+- include: oracle.yaml
+  when: ansible_distribution == "OracleLinux"

--- a/overrides/rhck.yaml
+++ b/overrides/rhck.yaml
@@ -1,0 +1,2 @@
+---
+oracle_kernel: RHCK


### PR DESCRIPTION
**What problem does this PR solve?**:

Adds the `oracle_kernel` varaible for ansible. When set to the string `RHCK` it will install the RHCK kernel and set it as the default for the next boot.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-88561)
-->
* https://jira.d2iq.com/browse/D2IQ-88561


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
