### PR TITLE
fix: adds a v1 to copy path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,7 +332,7 @@ build.snapshot:
 	#                copying the dist folder into the temporary folder
 	#                that it uses as its docker build context ;(.
 	mkdir -p bin
-	cp dist/konvoy-image_linux_amd64/konvoy-image bin/konvoy-image
+	cp dist/konvoy-image_linux_amd64_v1/konvoy-image bin/konvoy-image
 	goreleaser --parallelism=1 --skip-publish --snapshot --rm-dist
 
 .PHONY: diff


### PR DESCRIPTION
**What problem does this PR solve?**:
Adds a v1 that now get appended during tagged builds which goreleaser runs. The normal builds seem to not use goreleaser so tests should not be affected.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
