### PR TITLE
fix: remove extra "release"  keyword from vsphere template name

### DIFF
--- a/images/ova/rhel-79.yaml
+++ b/images/ova/rhel-79.yaml
@@ -1,6 +1,6 @@
 ---
 download_images: true
-build_name: "vsphere-rhel-79"
+build_name: "rhel-79"
 packer_builder_type: "vsphere"
 guestinfo_datasource_slug: "https://raw.githubusercontent.com/vmware/cloud-init-vmware-guestinfo"
 guestinfo_datasource_ref: "v1.4.0"

--- a/images/ova/rhel-84.yaml
+++ b/images/ova/rhel-84.yaml
@@ -1,6 +1,6 @@
 ---
 download_images: true
-build_name: "vsphere-rhel-84"
+build_name: "rhel-84"
 packer_builder_type: "vsphere" 
 guestinfo_datasource_slug: "https://raw.githubusercontent.com/vmware/cloud-init-vmware-guestinfo"
 guestinfo_datasource_ref: "v1.4.0"

--- a/pkg/packer/manifests/vsphere/packer.json.tmpl
+++ b/pkg/packer/manifests/vsphere/packer.json.tmpl
@@ -2,7 +2,7 @@
     "variables": {
         "ansible_extra_vars": "",
         "build_timestamp": "{{timestamp}}",
-        "vm_name": "konvoy-ova-{{user `build_name`}}{{user `build_name_extra`}}-{{user `kubernetes_full_version` }}-{{user `build_timestamp`}}",
+        "vm_name": "konvoy-{{user `build_name`}}-{{user `kubernetes_full_version` }}-{{user `build_timestamp`}}",
         "cluster": "",
         "datastore": "",
         "folder": "",


### PR DESCRIPTION
**What problem does this PR solve?**:
This is one of the first PR to help cleanup vSphere environment and automate it.
- Removes extra release keyword from the name of the template: `konvoy-ova-vsphere-rhel-79-release-release-1.22.8+fips.0-1652280664`
- Removes `ova-vsphere` keyword to allow more room in the VM name. The VM name length is limited. 
  We are planning to add KIB version in the name of the release template so that we can automate "lookup" functionality when running e2e tests. This will help make image lookup similar as we do in AWS AMI lookup and avoid creating a PR to change the template name.
- The TC job to create template will add KIB version in the template name. ex. `buildname_extra: release-v1.13.2`

I will file another PR that will cleanup old released template from vSphere. 
