### PR TITLE
chore: Update vscode-go settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
     // gopls with gofumpt and import ordering
     "go.useLanguageServer": true,
     "gopls": {
-        "gofumpt": true,
+        "formatting.gofumpt": true,
     },
     "[go]": {
         "editor.formatOnSave": true,


### PR DESCRIPTION
**What problem does this PR solve?**:
With this change, vscode-go no longer shows a "duplicate configuration" warning if you happen to use the (up-to-date) `formatting.gofumpt` field in workspace or globally-scoped settings.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
