### PR TITLE
fix: disable packer initiated shutdown when building vsphere images with dry run

### DIFF
--- a/pkg/packer/manifests/vsphere/packer.json.tmpl
+++ b/pkg/packer/manifests/vsphere/packer.json.tmpl
@@ -35,6 +35,7 @@
     "vsphere_username": "{{env `VSPHERE_USERNAME`}}",
     "vsphere_password": "{{env `VSPHERE_PASSWORD`}}",
     "vcenter_server": "{{env `VSPHERE_SERVER`}}",
+    "disable_shutdown": "true",
     "vsphere_guest_os_type": null
   },
   "builders": [
@@ -76,6 +77,7 @@
       "ssh_bastion_username": "{{ user  `ssh_bastion_username` }}",
       "ssh_bastion_password": "{{ user `ssh_bastion_password` }}",
       "ssh_bastion_private_key_file": "{{ user `ssh_bastion_private_key_file` }}",
+      "disable_shutdown": "{{user `disable_shutdown`}}",
       "vm_name": "{{user `vm_name`}}"
     }
   ],


### PR DESCRIPTION
**What problem does this PR solve?**:
- The PR builds for centos and RHEL 7.9 fails intermittently because the last step of packer initiated shutdown of the VM times out. Packer waits 5 minutes before throwing the error and still going ahead and destroying the VM. There seems to be race condition as with packer and vmware tools where the shutdown succeeds sometimes within 5 mintues

Success run: https://teamcity.mesosphere.io/buildConfiguration/ClosedSource_KonvoyImageBuilder_Bui/3447781
Failed run: https://teamcity.mesosphere.io/buildConfiguration/ClosedSource_KonvoyImageBuilder_Bui/3456783

Since we will be destroying the VM immediately after shutdown anyways during `--dry-run` (PR builds) , failing successful KIB provision because of flaky shutdown race condition is not a good failure signal. 
This PR introduces `disable_shutdown` option during `--dry-run` which will wait for 5 minutes for shutdown but will not fail the build if shutdown times out. Then let packer proceed to destroy the VM. 
more detail: https://www.packer.io/plugins/builders/vsphere/vsphere-clone#disable_shutdown

PS: We convert the VM to template in `--dry-run false` so no shutdown needed when `--dry-run` is disable. 