### PR TITLE
fix: correctly set default pause image

### DIFF
--- a/ansible/roles/containerd/tasks/install.yaml
+++ b/ansible/roles/containerd/tasks/install.yaml
@@ -43,3 +43,4 @@
     force: yes
   loop:
     - ctr
+    - containerd

--- a/ansible/roles/containerd/tasks/install.yaml
+++ b/ansible/roles/containerd/tasks/install.yaml
@@ -31,9 +31,9 @@
     extra_opts:
       - --no-overwrite-dir
 
-# We run ctr. When we do, it must be in the PATH of the ansible process. On some distributions, /usr/local/bin is not in
-# the PATH. The symlink makes ctr available in /usr/bin, which is in the PATH across all distributions where we install
-# ctr. We do not install ctr on flatcar, but there it is already in the PATH.
+# Some ansible tasks run ctr and containerd. For these tasks, the executable must be in the PATH of the ansible process.
+# On some distributions, /usr/local/bin is not in the PATH. The symlink makes the executables available in /usr/bin,
+# which is in the PATH across all supported distributions. On flatcar, the executables are already in the PATH.
 - name: symlink ctr to /usr/local/bin
   file:
     src: "/usr/local/bin/{{ item }}"


### PR DESCRIPTION
**What problem does this PR solve?**:
The default `pause` from Containerd was not getting pulled, causing air-gapped tests to fail.
This is because the task to run get the image relies on `containerd` but it was not in the PATH 

See this example where the output is empty https://teamcity.mesosphere.io/buildConfiguration/ClosedSource_KonvoyImageBuilder_E2eCentOS7/3471607?buildTab=log&focusLine=1183&linesState=491

With the fix - https://teamcity.mesosphere.io/buildConfiguration/ClosedSource_KonvoyImageBuilder_E2eCentOS7/3471618?buildTab=log&focusLine=1188&linesState=495

---

Alternatively maybe we should just add the binaries to `/usr/bin` instead of `/usr/local/bin`?

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
