### PR TITLE
ci: remove invalid working directory param

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -83,7 +83,6 @@ jobs:
       - if: ${{ needs.release-please.outputs.release_created }}
         name: Create Pull Request for KIB bump in CAPPP
         uses: peter-evans/create-pull-request@v4
-        working-directory: cluster-api-provider-preprovisioned
         with:
           token: ${{ secrets.MESOSPHERECI_USER_TOKEN }}
           add-paths: preprovisioned/kib


### PR DESCRIPTION
**What problem does this PR solve?**:
removes invalid working directory param.

this worked with my local tool https://github.com/nektos/act but didn't work with actions where it's not supported according to many people on the actions forums https://github.community/t/unable-to-use-working-directory-with-docker-based-actions/16419/3

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
