### PR TITLE
chore: skip gcp image creation with --dry-run=true

### DIFF
--- a/docs/dev/gcp.md
+++ b/docs/dev/gcp.md
@@ -1,0 +1,62 @@
+# Create OS images for GCP
+
+
+## Prerequisites
+- Install gcloud CLI: (Instructions](https://cloud.google.com/sdk/docs/install)
+- Authentication:
+    Packer plugin for google compute requires authenticate with GCP using service account credentails. Instructions to create service account and credentials file can be found [here](https://www.packer.io/plugins/builders/googlecompute#running-outside-of-google-cloud)
+    **Using CLI:**
+    ```shell
+    export USER=<SERVICE_ACCOUNT_USER>
+    export GCP_PROJECT=<GCP_PROJECT_NAME>
+    export GOOGLE_APPLICATION_CREDENTIALS=</PATH/TO/credentials.json>
+    gcloud iam service-accounts create "$USER"
+    gcloud projects add-iam-policy-binding $GCP_PROJECT --member="serviceAccount:$USER@$GCP_PROJECT.iam.gserviceaccount.com" --role=roles/compute.instanceAdmin.v1
+    gcloud projects add-iam-policy-binding $GCP_PROJECT --member="serviceAccount:$USER@$GCP_PROJECT.iam.gserviceaccount.com" --role=roles/iam.serviceAccountUser
+    gcloud iam service-accounts keys create $GOOGLE_APPLICATION_CREDENTIALS --iam-account="$USER@$GCP_PROJECT.iam.gserviceaccount.com"
+    ```
+- Network
+    A network with firewall rule set to allow SSH traffic must be created to allow packer communicate to the VM provisioning image.
+    **Using CLI:**
+    ```shell
+    export NETWORK_NAME=<NAME_OF_NETWORK>
+    gcloud compute networks create "${NETWORK_NAME}" --project="$GCP_PROJECT" --subnet-mode=auto --mtu=1460 --bgp-routing-mode=regional
+
+    gcloud compute firewall-rules create "${NETWORK_NAME}-allow-ssh" --project="$GCP_PROJECT" --network="projects/$GCP_PROJECT/global/networks/${CLUSTER_NAME}" --description=Allows\ TCP\ connections\ from\ any\ source\ to\ any\ instance\ on\ the\ network\ using\ port\ 22. --direction=INGRESS --priority=65534 --source-ranges=0.0.0.0/0 --action=ALLOW --rules=tcp:22
+    ```
+- Environment variables
+Make sure to create file with credentials for the service account using instructions above.
+export GOOGLE_APPLICATION_CREDENTIALS=</PATH/TO/credentials.json>
+
+**Packer variables for GCP:**
+Add following configuration in the `image.yaml`
+Substitue following variables needed for building images in GCP
+- PROJECT_NAME
+- ZONE
+- NETWORK_NAME
+
+```yaml
+packer:
+  # The source image to use to create the new image from. source_image = `distribution`-`distribution_version`
+  distribution: "centos"
+  distribution_version: "7-9-v20220519"
+  source_image: "centos-7-v20220519" # GCP maintained public base image
+  distribution_family: "centos-7"
+  # The username to connect to SSH with. Required if using SSH.
+  ssh_username: "centos"
+  project_id: "<PROJECT_NAME>"
+  zone: "<GCP_ZONE>" # List all zones using  gcloud compute zones list
+  network: "<NETWORK>" # name of the network
+
+build_name: "centos-7"
+packer_builder_type: "googlecompute"
+python_path: ""
+```
+
+## Create template image on vSphere
+
+```bash
+konvoy-image build gcp path/to/image.yaml
+```
+
+Checkout example image configuration at: [`<project_root>/images/gcp/`](../../images/gcp) directory.

--- a/pkg/packer/manifests/gcp/packer.json.tmpl
+++ b/pkg/packer/manifests/gcp/packer.json.tmpl
@@ -13,7 +13,9 @@
     "manifest_output": "manifest.json",
     "network": "",
     "project_id": "",
-    "zone": ""
+    "zone": "",
+    "disk_size": "80",
+    "disk_type": "pd-standard"
   },
   "builders": [
     {
@@ -25,6 +27,8 @@
        "source_image_family": "{{ user `distribution_family` }}",
        "zone": "{{ user `zone` }}",
        "ssh_username": "packer",
+       "disk_size": "{{ user `disk_size` }}",
+       "disk_type": "{{ user `disk_type` }}",
        "ssh_key_exchange_algorithms": [
          "curve25519-sha256@libssh.org",
          "ecdh-sha2-nistp256",
@@ -45,9 +49,9 @@
          "kubernetes_cni_version": "{{ user `kubernetes_cni_version` }}",
          "kubernetes_version": "{{ user `kubernetes_full_version` | clean_resource_name }}"
        },
-       "metadata": {
-
-       },
+        ((- if .DryRun ))
+       "skip_create_image": true,
+       ((- end ))
        "network": "{{ user `network` }}"
     }
   ],


### PR DESCRIPTION
**What problem does this PR solve?**:
- adds default disk size to 80 GB to match with other providers
- skip image creation with dry-run is true
- add dev doc for GCP

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
