### PR TITLE
fix: use the same instance-type as konvoy

### DIFF
--- a/cmd/konvoy-image/cmd/azure.go
+++ b/cmd/konvoy-image/cmd/azure.go
@@ -136,7 +136,7 @@ func addAzureArgs(fs *flag.FlagSet, azure *app.AzureArgs) {
 	fs.StringVar(
 		&azure.InstanceType,
 		"instance-type",
-		"Standard_D2ds_v5",
+		"Standard_D2s_v3",
 		"the Instance Type to use for the build",
 	)
 }

--- a/docs/cli/konvoy-image_build_azure.md
+++ b/docs/cli/konvoy-image_build_azure.md
@@ -26,7 +26,7 @@ azure --location westus2 --subscription-id <sub_id> images/azure/centos-79.yaml
       --gallery-image-sku string           the gallery image sku to set
       --gallery-name string                the gallery name to publish the image in (default "dkp")
   -h, --help                               help for azure
-      --instance-type string               the Instance Type to use for the build (default "Standard_D2ds_v5")
+      --instance-type string               the Instance Type to use for the build (default "Standard_D2s_v3")
       --kubernetes-version string          The version of kubernetes to install. Example: 1.21.6
       --location string                    the location in which to build the image (default "westus2")
       --overrides strings                  a comma separated list of override YAML files

--- a/docs/cli/konvoy-image_generate_azure.md
+++ b/docs/cli/konvoy-image_generate_azure.md
@@ -25,7 +25,7 @@ azure --location westus2 --subscription-id <sub_id> images/azure/centos-79.yaml
       --gallery-image-sku string           the gallery image sku to set
       --gallery-name string                the gallery name to publish the image in (default "dkp")
   -h, --help                               help for azure
-      --instance-type string               the Instance Type to use for the build (default "Standard_D2ds_v5")
+      --instance-type string               the Instance Type to use for the build (default "Standard_D2s_v3")
       --kubernetes-version string          The version of kubernetes to install. Example: 1.21.6
       --location string                    the location in which to build the image (default "westus2")
       --overrides strings                  a comma separated list of override YAML files

--- a/pkg/packer/manifests/azure/packer.json.tmpl
+++ b/pkg/packer/manifests/azure/packer.json.tmpl
@@ -31,7 +31,7 @@
     "shared_image_gallery_image_version": "0.0.{{timestamp}}",
     "subscription_id": "{{env `AZURE_SUBSCRIPTION_ID`}}",
     "tenant_id": "{{env `AZURE_TENANT_ID`}}",
-    "vm_size": "Standard_D2ds_v5"
+    "vm_size": "Standard_D2s_v3"
   },
   "builders": [
     {


### PR DESCRIPTION
**What problem does this PR solve?**:
Our Azure dev account does not allow creating `Standard_D2ds_v5`. 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-90419)
-->
* https://jira.d2iq.com/browse/D2IQ-90419


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
