### PR TITLE
feat: set a GCP image-family that can be used in dkp

### DIFF
--- a/pkg/packer/manifests/gcp/packer.json.tmpl
+++ b/pkg/packer/manifests/gcp/packer.json.tmpl
@@ -22,7 +22,7 @@
     {
        "name": "{{(user `distribution`) | lower}}-{{user `distribution_version`}}{{user `build_name_extra`}}",
        "image_name": "konvoy-{{user `build_name`}}-{{user `kubernetes_full_version` | clean_resource_name}}-{{user `build_timestamp`}}",
-       "image_family": "{{ user `distribution_family` }}",
+       "image_family": "konvoy-{{user `build_name`}}-{{user `kubernetes_full_version` | clean_resource_name}}",
        "type": "googlecompute",
        "project_id": "{{ user `project_id` }}",
        "source_image": "{{ user `source_image` }}",


### PR DESCRIPTION
**What problem does this PR solve?**:
Set the `image_family` to something that can be usable in `dkp`.

See companion PR: https://github.com/mesosphere/konvoy2/pull/1411

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-90596)
-->
* https://jira.d2iq.com/browse/D2IQ-90596


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
