### PR TITLE
fix: install cloud-init packages for vsphere in offline mode

### DIFF
--- a/ansible/roles/providers/tasks/vmware.yml
+++ b/ansible/roles/providers/tasks/vmware.yml
@@ -29,6 +29,8 @@
   yum:
     name: "{{ packages }}"
     state: present
+    enablerepo: "{{ 'offline' if offline_mode_enabled else '' }}"
+    disablerepo: "{{ '*' if offline_mode_enabled else '' }}"
   vars:
     packages:
       - cloud-init


### PR DESCRIPTION
**What problem does this PR solve?**:
- install cloud-init packages for vsphere in offline mode

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
The vsphere airgapped test appear to be false positive. This package was pre-installed in the base-os template so the ansible playbooks always skipped them without searching for them in the `offline` repo.

Currently we are still have not added such fix for other OS than Redhat and centos, GPU etc. 
As we add more code to support offline image building in future, we can unintentionally setting `offline` repo. We will need to think about globally enable offline repo for airgapped mode.
