### PR TITLE
ci: use production bucket to download air-gapped artifacts

### DIFF
--- a/make/images.mk
+++ b/make/images.mk
@@ -12,7 +12,7 @@ COMMA := ,
 NULL :=
 SPACE := $(NULL) $(NULL)
 
-AIRGAPPED_BUNDLE_URL ?= konvoy-kubernetes-staging.s3.us-west-2.amazonaws.com
+AIRGAPPED_BUNDLE_URL_PREFIX ?= downloads.mesosphere.io/dkp
 CONTAINERD_URL ?= https://packages.d2iq.com/dkp/containerd
 ARTIFACTS_DIR ?= artifacts/
 DEFAULT_KUBERNETES_VERSION_SEMVER ?= $(shell \
@@ -64,12 +64,12 @@ $(ARTIFACTS_DIR)/images:
 # TODO(jkoelker) UnPHONYify these targets
 .PHONY: download-images-bundle
 download-images-bundle: $(ARTIFACTS_DIR)/images
-	curl -o $(ARTIFACTS_DIR)/images/$(DEFAULT_KUBERNETES_VERSION_SEMVER)_images$(bundle_suffix).tar.gz -fsSL https://$(AIRGAPPED_BUNDLE_URL)/konvoy/airgapped/kubernetes-images/$(DEFAULT_KUBERNETES_VERSION_SEMVER)_images$(bundle_suffix).tar.gz
+	curl -o $(ARTIFACTS_DIR)/images/$(DEFAULT_KUBERNETES_VERSION_SEMVER)_images$(bundle_suffix).tar.gz -fsSL https://$(AIRGAPPED_BUNDLE_URL_PREFIX)/airgapped/kubernetes-images/$(DEFAULT_KUBERNETES_VERSION_SEMVER)_images$(bundle_suffix).tar.gz
 
 .PHONY: download-os-packages-bundle
 download-os-packages-bundle: $(ARTIFACTS_DIR)
 	curl -o $(ARTIFACTS_DIR)/containerd-$(DEFAULT_CONTAINERD_VERSION)-d2iq.1-$(os_distribution_os_release)-$(os_distribution_major_minor_version)-$(os_distribution_arch)$(bundle_suffix).tar.gz -fsSL $(CONTAINERD_URL)/containerd-$(DEFAULT_CONTAINERD_VERSION)-d2iq.1-$(os_distribution_os_release)-$(os_distribution_major_minor_version)-$(os_distribution_arch)$(bundle_suffix).tar.gz
-	curl -o $(ARTIFACTS_DIR)/$(DEFAULT_KUBERNETES_VERSION_SEMVER)_$(os_distribution)_$(os_distribution_major_version)_$(os_distribution_arch)$(bundle_suffix).tar.gz -fsSL https://$(AIRGAPPED_BUNDLE_URL)/konvoy/airgapped/os-packages/$(DEFAULT_KUBERNETES_VERSION_SEMVER)_$(os_distribution)_$(os_distribution_major_version)_$(os_distribution_arch)$(bundle_suffix).tar.gz
+	curl -o $(ARTIFACTS_DIR)/$(DEFAULT_KUBERNETES_VERSION_SEMVER)_$(os_distribution)_$(os_distribution_major_version)_$(os_distribution_arch)$(bundle_suffix).tar.gz -fsSL https://$(AIRGAPPED_BUNDLE_URL_PREFIX)/airgapped/os-packages/$(DEFAULT_KUBERNETES_VERSION_SEMVER)_$(os_distribution)_$(os_distribution_major_version)_$(os_distribution_arch)$(bundle_suffix).tar.gz
 
 # NOTE(jkoelker) set no-op cleanup targets for providers that support `DryRun`.
 .PHONY: aws-build-image-cleanup


### PR DESCRIPTION
**What problem does this PR solve?**:
We've had a few discussions now with SRE about how we are pushing different artifacts to S3 buckets.

We started by pushing the image and os-packages tars to a staging bucket `konvoy-kubernetes-staging.s3.us-west-2.amazonaws.com` then [a different sync job](https://github.com/mesosphere/docker-repo-sync/blob/d8958f1b25df35ffd863a7f5a4aa20792afe8ef9/sync.sh#L20-L30) is supposed to sync these artifacts to the production `downloads.mesosphere.io` bucket.

There are issues with this approach:
1. The sync job fails pushing the OS packages and image bundles, [see this conversation](https://mesosphere.slack.com/archives/C01MPKVBB5E/p1655830029095139)
2. There is no verification step anyways before the automated sync, so there is little value having it there. It also may lead to subtle bugs, where what is returned by CloudFront is out fo date from what is actually in the bucket and requires either waiting 24 hours or invalidating the cache.

This change along with the changes in [image TC job](https://teamcity.mesosphere.io/project/MesosphereOnly_ClosedSource_DkpReleases_KubernetesImagesBundles?mode=builds) and [OS packages TC job](https://teamcity.mesosphere.io/project/MesosphereOnly_ClosedSource_DkpReleases_OsPackagesBundles?branch=v1.24.3&mode=builds) to push directly to the production buckets simplifies the process.

The TC jobs already pushed new Kubernetes `1.23.8`, `1.23.9` and `1.24.3` artifacts and going forward would push all future versions
```
➜  ~ aws s3 ls s3://downloads.mesosphere.io/dkp/airgapped/kubernetes-images/
2022-04-04 12:58:39  205642603 1.21.6_images.tar.gz
2022-04-04 13:00:22  208045884 1.21.6_images_fips.tar.gz
2022-04-04 13:02:33  307082981 1.22.8_images.tar.gz
2022-04-04 13:08:25  210569962 1.22.8_images_fips.tar.gz
2022-06-22 12:16:40  310625172 1.23.7_images.tar.gz
2022-06-22 12:18:15  215036987 1.23.7_images_fips.tar.gz
2022-07-14 08:58:27  310603626 1.23.8_images.tar.gz
2022-07-14 08:57:02  215058305 1.23.8_images_fips.tar.gz
2022-07-14 08:58:38  310615279 1.23.9_images.tar.gz
2022-07-14 08:56:52  215054490 1.23.9_images_fips.tar.gz
2022-07-14 08:58:12  314624252 1.24.3_images.tar.gz
2022-07-14 08:57:48  216644595 1.24.3_images_fips.tar.gz
```
```
➜  ~ aws s3 ls s3://downloads.mesosphere.io/dkp/airgapped/os-packages/
2022-04-07 06:34:33  170858223 1.22.8_centos_7_x86_64.tar.gz
2022-04-07 06:33:30  176613116 1.22.8_centos_7_x86_64_fips.tar.gz
2022-04-07 06:36:50  184646046 1.22.8_redhat_7_x86_64.tar.gz
2022-04-07 06:35:39  190391946 1.22.8_redhat_7_x86_64_fips.tar.gz
2022-04-07 06:39:40  223411454 1.22.8_redhat_8_x86_64.tar.gz
2022-04-07 06:38:09  229168475 1.22.8_redhat_8_x86_64_fips.tar.gz
2022-06-22 12:04:28  170590001 1.23.7_centos_7_x86_64.tar.gz
2022-06-22 12:05:47  176352534 1.23.7_centos_7_x86_64_fips.tar.gz
2022-06-22 12:06:47  184370899 1.23.7_redhat_7_x86_64.tar.gz
2022-06-22 12:07:49  190135216 1.23.7_redhat_7_x86_64_fips.tar.gz
2022-06-22 12:09:03  232602675 1.23.7_redhat_8_x86_64.tar.gz
2022-06-22 12:10:19  238369034 1.23.7_redhat_8_x86_64_fips.tar.gz
2022-07-14 09:37:52  169707095 1.23.8_centos_7_x86_64.tar.gz
2022-07-14 09:37:16  217152651 1.23.8_centos_7_x86_64_fips.tar.gz
2022-07-14 09:37:37  183487965 1.23.8_redhat_7_x86_64.tar.gz
2022-07-14 09:37:28  189258549 1.23.8_redhat_7_x86_64_fips.tar.gz
2022-07-14 09:38:29  231723186 1.23.8_redhat_8_x86_64.tar.gz
2022-07-14 09:38:26  237502978 1.23.8_redhat_8_x86_64_fips.tar.gz
2022-07-14 09:25:17  169656532 1.23.9_centos_7_x86_64.tar.gz
2022-07-14 09:12:01  175419602 1.23.9_centos_7_x86_64_fips.tar.gz
2022-07-14 09:34:03  183439376 1.23.9_redhat_7_x86_64.tar.gz
2022-07-14 09:34:06  189205744 1.23.9_redhat_7_x86_64_fips.tar.gz
2022-07-14 09:35:26  231675569 1.23.9_redhat_8_x86_64.tar.gz
2022-07-14 09:35:27  237443323 1.23.9_redhat_8_x86_64_fips.tar.gz
2022-07-14 09:44:06  170449861 1.24.3_centos_7_x86_64.tar.gz
2022-07-14 09:44:27  176219560 1.24.3_centos_7_x86_64_fips.tar.gz
2022-07-14 09:43:53  184233328 1.24.3_redhat_7_x86_64.tar.gz
2022-07-14 09:43:39  231735098 1.24.3_redhat_7_x86_64_fips.tar.gz
2022-07-14 09:44:36  273411265 1.24.3_redhat_8_x86_64.tar.gz
2022-07-14 09:43:53  238244423 1.24.3_redhat_8_x86_64_fips.tar.gz
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
