### PR TITLE
fix: flags not being set correctly

### DIFF
--- a/cmd/konvoy-image/cmd/aws.go
+++ b/cmd/konvoy-image/cmd/aws.go
@@ -14,48 +14,56 @@ var (
 	awsUse     = "aws <image.yaml>"
 )
 
-var awsBuildCmd = &cobra.Command{
-	Use:     awsUse,
-	Short:   "build and provision aws images",
-	Example: awsExample,
-	Args:    cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		runBuild(args[0])
-	},
+func NewAWSBuildCmd() *cobra.Command {
+	flags := &buildCLIFlags{}
+	cmd := &cobra.Command{
+		Use:     awsUse,
+		Short:   "build and provision aws images",
+		Example: awsExample,
+		Args:    cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			runBuild(args[0], flags)
+		},
+	}
+
+	initBuildAWSFlags(cmd.Flags(), flags)
+	return cmd
 }
 
-var awsGenerateCmd = &cobra.Command{
-	Use:     awsUse,
-	Short:   "generate files relating to building aws images",
-	Example: awsExample,
-	Args:    cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		runGenerate(args[0])
-	},
+func NewAWSGenerateCmd() *cobra.Command {
+	flags := &generateCLIFlags{}
+	cmd := &cobra.Command{
+		Use:     awsUse,
+		Short:   "generate files relating to building aws images",
+		Example: awsExample,
+		Args:    cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			runGenerate(args[0], flags)
+		},
+	}
+
+	initGenerateAWSFlags(cmd.Flags(), flags)
+	return cmd
 }
 
-func initBuildAws() {
-	fs := awsBuildCmd.Flags()
+func initBuildAWSFlags(fs *flag.FlagSet, buildFlags *buildCLIFlags) {
+	initGenerateArgs(fs, &buildFlags.generateCLIFlags)
+	initAWSArgs(fs, &buildFlags.generateCLIFlags)
 
-	initGenerateFlags(fs, &buildFlags.generateCLIFlags)
-	initAmazonFlags(fs, &buildFlags.generateCLIFlags)
-
-	addBuildArgs(fs, &buildFlags)
+	addBuildArgs(fs, buildFlags)
 }
 
-func initGenerateAws() {
-	fs := awsGenerateCmd.Flags()
-
-	initGenerateFlags(fs, &generateFlags)
-	initAmazonFlags(fs, &generateFlags)
+func initGenerateAWSFlags(fs *flag.FlagSet, generateFlags *generateCLIFlags) {
+	initGenerateArgs(fs, generateFlags)
+	initAWSArgs(fs, generateFlags)
 }
 
-func initAmazonFlags(fs *flag.FlagSet, gFlags *generateCLIFlags) {
+func initAWSArgs(fs *flag.FlagSet, gFlags *generateCLIFlags) {
 	gFlags.userArgs.Amazon = &app.AmazonArgs{}
-	addAmazonArgs(fs, gFlags.userArgs.Amazon)
+	addAWSArgs(fs, gFlags.userArgs.Amazon)
 }
 
-func addAmazonArgs(fs *flag.FlagSet, amazonArgs *app.AmazonArgs) {
+func addAWSArgs(fs *flag.FlagSet, amazonArgs *app.AmazonArgs) {
 	fs.StringVar(
 		&amazonArgs.AWSBuilderRegion,
 		"region",

--- a/cmd/konvoy-image/cmd/azure.go
+++ b/cmd/konvoy-image/cmd/azure.go
@@ -14,43 +14,51 @@ var (
 	azureUse     = "azure <image.yaml>"
 )
 
-var azureBuildCmd = &cobra.Command{
-	Use:     azureUse,
-	Short:   "build and provision azure images",
-	Example: azureExample,
-	Args:    cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		runBuild(args[0])
-	},
+func NewAzureBuildCmd() *cobra.Command {
+	flags := &buildCLIFlags{}
+	cmd := &cobra.Command{
+		Use:     azureUse,
+		Short:   "build and provision azure images",
+		Example: azureExample,
+		Args:    cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			runBuild(args[0], flags)
+		},
+	}
+
+	initBuildAzureFlags(cmd.Flags(), flags)
+	return cmd
 }
 
-var azureGenerateCmd = &cobra.Command{
-	Use:     azureUse,
-	Short:   "generate files relating to building azure images",
-	Example: azureExample,
-	Args:    cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		runGenerate(args[0])
-	},
+func NewAzureGenerateCmd() *cobra.Command {
+	flags := &generateCLIFlags{}
+	cmd := &cobra.Command{
+		Use:     azureUse,
+		Short:   "generate files relating to building azure images",
+		Example: azureExample,
+		Args:    cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			runGenerate(args[0], flags)
+		},
+	}
+
+	initGenerateAzureFlags(cmd.Flags(), flags)
+	return cmd
 }
 
-func initBuildAzure() {
-	fs := azureBuildCmd.Flags()
+func initBuildAzureFlags(fs *flag.FlagSet, buildFlags *buildCLIFlags) {
+	initGenerateArgs(fs, &buildFlags.generateCLIFlags)
+	initAzurergs(fs, &buildFlags.generateCLIFlags)
 
-	initGenerateFlags(fs, &buildFlags.generateCLIFlags)
-	initAzureFlags(fs, &buildFlags.generateCLIFlags)
-
-	addBuildArgs(fs, &buildFlags)
+	addBuildArgs(fs, buildFlags)
 }
 
-func initGenerateAzure() {
-	fs := azureGenerateCmd.Flags()
-
-	initGenerateFlags(fs, &generateFlags)
-	initAzureFlags(fs, &generateFlags)
+func initGenerateAzureFlags(fs *flag.FlagSet, generateFlags *generateCLIFlags) {
+	initGenerateArgs(fs, generateFlags)
+	initAzurergs(fs, generateFlags)
 }
 
-func initAzureFlags(fs *flag.FlagSet, gFlags *generateCLIFlags) {
+func initAzurergs(fs *flag.FlagSet, gFlags *generateCLIFlags) {
 	gFlags.userArgs.Azure = &app.AzureArgs{}
 	addAzureArgs(fs, gFlags.userArgs.Azure)
 }

--- a/cmd/konvoy-image/cmd/gcp.go
+++ b/cmd/konvoy-image/cmd/gcp.go
@@ -12,26 +12,30 @@ var (
 	gcpUse     = "gcp <image.yaml>"
 )
 
-var gcpBuildCmd = &cobra.Command{
-	Use:     gcpUse,
-	Short:   "build and provision gcp images",
-	Example: gcpExample,
-	Args:    cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		runBuild(args[0])
-	},
+func NewGCPBuildCmd() *cobra.Command {
+	flags := &buildCLIFlags{}
+	cmd := &cobra.Command{
+		Use:     gcpUse,
+		Short:   "build and provision gcp images",
+		Example: gcpExample,
+		Args:    cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			runBuild(args[0], flags)
+		},
+	}
+
+	initBuildGCPFlags(cmd.Flags(), flags)
+	return cmd
 }
 
-func initBuildGCP() {
-	fs := gcpBuildCmd.Flags()
+func initBuildGCPFlags(fs *flag.FlagSet, buildFlags *buildCLIFlags) {
+	initGenerateArgs(fs, &buildFlags.generateCLIFlags)
+	initGCPArgs(fs, &buildFlags.generateCLIFlags)
 
-	initGenerateFlags(fs, &buildFlags.generateCLIFlags)
-	initGCPFlags(fs, &buildFlags.generateCLIFlags)
-
-	addBuildArgs(fs, &buildFlags)
+	addBuildArgs(fs, buildFlags)
 }
 
-func initGCPFlags(fs *flag.FlagSet, gFlags *generateCLIFlags) {
+func initGCPArgs(fs *flag.FlagSet, gFlags *generateCLIFlags) {
 	gFlags.userArgs.GCP = &app.GCPArgs{}
 	addGCPArgs(fs, gFlags.userArgs.GCP)
 }

--- a/cmd/konvoy-image/cmd/root.go
+++ b/cmd/konvoy-image/cmd/root.go
@@ -79,8 +79,8 @@ func bail(message string, err error, code int) {
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
-	rootCmd.AddCommand(buildCmd)
-	rootCmd.AddCommand(generateCmd)
+	rootCmd.AddCommand(NewBuildCmd())
+	rootCmd.AddCommand(NewGenereateCmd())
 	rootCmd.AddCommand(generateDocsCmd)
 	rootCmd.AddCommand(provisionCmd)
 	rootCmd.AddCommand(uploadCmd)

--- a/make/ci.mk
+++ b/make/ci.mk
@@ -24,6 +24,7 @@ ci.e2e.build.all: e2e.build.centos-7-offline
 ci.e2e.build.all: e2e.build.rhel-7.9-offline-fips
 ci.e2e.build.all: e2e.build.rhel-8.2-offline-fips
 ci.e2e.build.all: e2e.build.rhel-8.4-offline-fips
+ci.e2e.build.all: ci.e2e.build.rhel-8.4-nvidia
 ci.e2e.build.all: ci.e2e.build.rhel-8-fips
 ci.e2e.build.all: ci.e2e.build.centos-7-nvidia
 ci.e2e.build.all: ci.e2e.build.sles-15-nvidia
@@ -62,6 +63,8 @@ e2e.build.centos-7-nvidia: centos7-nvidia
 e2e.build.sles-15-nvidia: sles15-nvidia
 
 e2e.build.rhel-8-fips: rhel82-fips
+
+e2e.build.rhel-8.4-nvidia: rhel84-nvidia
 
 # Azure
 e2e.build.centos-7-azure: centos7-azure


### PR DESCRIPTION
**What problem does this PR solve?**:
When we added provider specific subcommands, we introduced a bug for how flags are set by Ginkgo.
Using global `buildFlags` and `generateFlags` does not work. This `init()` function calls `initBuildAws()` :
https://github.com/mesosphere/konvoy-image-builder/blob/0bb8778d319c20d7f1bd6813d0cd7251ebef5e2c/cmd/konvoy-image/cmd/build.go#L77-L78

Which internally calls `initBuildAws()`
https://github.com/mesosphere/konvoy-image-builder/blob/0bb8778d319c20d7f1bd6813d0cd7251ebef5e2c/cmd/konvoy-image/cmd/aws.go#L38-L43

But then the `init()` function calls the same `initGenerateFlags` and `initAmazonFlags` with `buildCmd.Flags()` https://github.com/mesosphere/konvoy-image-builder/blob/0bb8778d319c20d7f1bd6813d0cd7251ebef5e2c/cmd/konvoy-image/cmd/build.go#L82-L87

Resulting in any flags set in `konvoy-image build aws` not actually getting propagated since its now only looking at the flags from `konvoy-image build` (and those will be empty).

**Removed the use of global vars and moved all the flag initialization out of an `init()` function and into individual command functions that can use local variables for `buildFlags` and `generateFlags`.**

**Also added a new unit test for RHEL 8.4 NVIDIA.**

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-91591)
-->
* https://jira.d2iq.com/browse/D2IQ-91591


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
