### PR TITLE
fix: install cloud-init packages for vsphere in offline mode

### DIFF
--- a/ansible/roles/providers/tasks/vmware.yml
+++ b/ansible/roles/providers/tasks/vmware.yml
@@ -29,6 +29,8 @@
   yum:
     name: "{{ packages }}"
     state: present
+    enablerepo: "{{ 'offline' if offline_mode_enabled else '' }}"
+    disablerepo: "{{ '*' if offline_mode_enabled else '' }}"
   vars:
     packages:
       - cloud-init


### PR DESCRIPTION
**What problem does this PR solve?**:
Backport https://github.com/mesosphere/konvoy-image-builder/pull/406 to `release-1.17`, version `v1.17.2` is used by Konvoy v2.2.2, we can release `v1.17.3` with this fix.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->

I do wonder how `release-please` is going to handle this PR.

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
