### PR TITLE
feat: bump Ansible to 4.10.0

### DIFF
--- a/Dockerfile.devkit
+++ b/Dockerfile.devkit
@@ -58,7 +58,7 @@ RUN wget \
 # NOTE(jkoelker) From here we care about layers
 FROM golang:1.18.3-alpine3.15
 
-ARG ANSIBLE_VERSION=2.10.7
+ARG ANSIBLE_VERSION=4.10.0
 ARG DOCKER_PY_VERSION=5.0.3
 ENV ANSIBLE_PATH=/usr
 ENV PYTHON_PATH=/usr

--- a/ansible/requirements.txt
+++ b/ansible/requirements.txt
@@ -3,6 +3,6 @@ molecule-ec2
 ansible-lint
 boto
 boto3
-ansible==2.10.7
+ansible==4.10.0
 yamllint
 pytest-testinfra

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ansible==2.10.7
+ansible==4.10.0
 netaddr==0.8.0


### PR DESCRIPTION
**What problem does this PR solve?**:
Bumping Ansible to `4.10.0` which adds support for Rocky Linux https://github.com/ansible/ansible/pull/74530
After Ansible version `v2.10.x` Ansible changed the way the versioning and distribution works, version `v4.x.x` is the first major version that uses ansible-core `v2.11.x`.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
