### PR TITLE
fix: use other user token that can run actions

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: google-github-actions/release-please-action@v3
         id: release-please
         with:
+          token: ${{ secrets.MESOSPHERECI_USER_TOKEN }}
           release-type: go
           package-name: konvoy-image-builder
           changelog-types: >-

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -62,6 +62,7 @@ jobs:
           title: "fix: bump kib to ${{ github.ref }}"
 
   sign-binary:
+    runs-on: macos-latest
     env:
       KEYCHAIN: job-${{ github.job }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     steps:


### PR DESCRIPTION
**What problem does this PR solve?**:
This user should have permissions to run actions. According to the docs the default one will not create an action run https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
