### PR TITLE
fix: various cleanups for release-tag action

### DIFF
--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ github.ref_name }}
+          ref: ${{ github.ref}}
 
       - name: Docker Login
         uses: docker/login-action@v2

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ github.ref}}
+          ref: ${{ github.ref }}
 
       - name: Docker Login
         uses: docker/login-action@v2

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ github.ref }}
+          ref: ${{ github.ref_name }}
 
       - name: Docker Login
         uses: docker/login-action@v2
@@ -57,11 +57,12 @@ jobs:
           token: ${{ secrets.MESOSPHERECI_USER_TOKEN }}
           add-paths: preprovisioned/kib
           body: bumps KIB to latest version
-          commit-message: "fix: bump kib to ${{ github.ref }}"
+          commit-message: "fix: bump kib to ${{ github.ref_name }}"
           path: cluster-api-provider-preprovisioned
-          title: "fix: bump kib to ${{ github.ref }}"
+          title: "fix: bump kib to ${{ github.ref_name }}"
 
   sign-binary:
+    needs: release-artifacts
     runs-on: macos-latest
     env:
       KEYCHAIN: job-${{ github.job }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
@@ -74,17 +75,17 @@ jobs:
 
       - uses: dsaltares/fetch-gh-release-asset@1.0.0
         with:
-          version: "tags/${{ github.ref }}"
-          file: "konvoy-image-bundle-${{ github.ref }}_darwin_amd64.tar.gz"
+          version: "tags/${{ github.ref_name }}"
+          file: "konvoy-image-bundle-${{ github.ref_name }}_darwin_amd64.tar.gz"
 
       - name: Create directory to extract the pulled file into
         run: mkdir "konvoy-image-bundle_darwin_amd64"
 
       - name: Extract the pulled file
-        run: tar -xvzf "konvoy-image-bundle-${{ github.ref }}_darwin_amd64.tar.gz" -C "konvoy-image-bundle_darwin_amd64"
+        run: tar -xvzf "konvoy-image-bundle-${{ github.ref_name }}_darwin_amd64.tar.gz" -C "konvoy-image-bundle_darwin_amd64"
 
       - name: Remove original downloaded file
-        run: rm "konvoy-image-bundle-${{ github.ref }}_darwin_amd64.tar.gz"
+        run: rm "konvoy-image-bundle-${{ github.ref_name }}_darwin_amd64.tar.gz"
 
       - name: Import Code-Signing Certificates
         uses: Apple-Actions/import-codesign-certs@v1
@@ -113,8 +114,8 @@ jobs:
         run: |
           unzip -o konvoy-image.zip
           mv konvoy-image konvoy-image-bundle_darwin_amd64
-          mv konvoy-image-bundle_darwin_amd64 konvoy-image-bundle-${{ github.ref }}_darwin_amd64
-          tar czf konvoy-image-bundle-${{ github.ref }}_darwin_amd64.tar.gz konvoy-image-bundle_darwin_amd64 konvoy-image-bundle-${{ github.ref }}_darwin_amd64
+          mv konvoy-image-bundle_darwin_amd64 konvoy-image-bundle-${{ github.ref_name }}_darwin_amd64
+          tar czf konvoy-image-bundle-${{ github.ref_name }}_darwin_amd64.tar.gz konvoy-image-bundle_darwin_amd64 konvoy-image-bundle-${{ github.ref_name }}_darwin_amd64
 
       - name: Delete keychain
         if: always()
@@ -124,23 +125,21 @@ jobs:
       - name: Get checksum file
         uses: dsaltares/fetch-gh-release-asset@1.0.0
         with:
-          version: "tags/${{ github.ref }}"
-          file: "checksums"
-          regex: true
-          target: checksum_${{ github.ref }}.txt
+          version: "tags/${{ github.ref_name }}"
+          file: "konvoy-image-builder_${{ github.ref_name }}_checksums.txt"
 
       - name: Calculate checksum
         run: |
-          cat checksum_${{ github.ref }}.txt | grep darwin | xargs -I{} sed -i'.bak' s/{}//g checksum_${{ github.ref }}.txt
-          sed -i'.bak' '/^[[:space:]]*$/d' checksum_${{ github.ref }}.txt
-          sha256sum konvoy-image-bundle-${{ github.ref}}_darwin_amd64.tar.gz >> checksum_${{ github.ref }}.txt
+          cat konvoy-image-builder_${{ github.ref_name }}_checksums.txt | grep darwin | xargs -I{} sed -i'.bak' s/{}//g konvoy-image-builder_${{ github.ref_name }}_checksums.txt
+          sed -i'.bak' '/^[[:space:]]*$/d' konvoy-image-builder_${{ github.ref_name }}_checksums.txt
+          sha256sum konvoy-image-bundle-${{ github.ref_name}}_darwin_amd64.tar.gz >> konvoy-image-builder_${{ github.ref_name }}_checksums.txt
 
 
       - name: Replace release artifact
         uses: ncipollo/release-action@v1
         with:
-          tag: "${{ github.ref }}"
-          artifacts: konvoy-image-bundle-${{ github.ref }}_darwin_amd64.tar.gz,checksum_${{ github.ref }}.txt
+          tag: "${{ github.ref_name }}"
+          artifacts: konvoy-image-bundle-${{ github.ref_name }}_darwin_amd64.tar.gz,konvoy-image-builder_${{ github.ref_name }}_checksums.txt
           replacesArtifacts: true
           token: ${{ secrets.MESOSPHERECI_USER_TOKEN }}
           artifactErrorsFailBuild: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -120,6 +120,10 @@ archives:
       - LICENSE
       - README.md
 
+checksum:
+  # override the name template to include the "v" prefix
+  name_template: '{{ .ProjectName }}_v{{trimprefix .Version "v"}}_checksums.txt'
+
 release:
   github:
   prerelease: auto


### PR DESCRIPTION
**What problem does this PR solve?**:
A couple of changes here

1. Just use the tag name -> https://github.community/t/how-to-get-just-the-tag-name/16241/35
2. Have the checksum file include the `v` in the file name
3. Add a `needs` for the notarizing pipeline 
4. uses new checksumfile 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
