### PR TITLE
fix: use new rhel7 template

### DIFF
--- a/images/ova/rhel-79.yaml
+++ b/images/ova/rhel-79.yaml
@@ -13,7 +13,6 @@ packer:
   insecure_connection: "false"
   network: ""
   resource_pool: ""
-  template: "base-rhel-7"
   vsphere_guest_os_type: "rhel7_64Guest"
   guest_os_type: "rhel7-64"
   # goss params

--- a/images/ova/rhel-79.yaml
+++ b/images/ova/rhel-79.yaml
@@ -13,6 +13,7 @@ packer:
   insecure_connection: "false"
   network: ""
   resource_pool: ""
+  template: "base-rhel-7-sortega" 
   vsphere_guest_os_type: "rhel7_64Guest"
   guest_os_type: "rhel7-64"
   # goss params

--- a/test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl
+++ b/test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl
@@ -12,5 +12,5 @@ packer:
   datacenter: "dc1"
   datastore: "esxi-05-disk2"
   folder: "cluster-api"
-  network: "Airgapped"
+  network: "Public"
   resource_pool: "Users"

--- a/test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl
+++ b/test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl
@@ -10,7 +10,8 @@ packer:
   ssh_bastion_private_key_file: /kib/vsphere-tests.pem
   cluster: "zone1"
   datacenter: "dc1"
-  datastore: "esxi-05-disk2"
+  template: "base-rhel-7-sortega"
+  datastore: "esxi-06-disk1"
   folder: "cluster-api"
-  network: "Public"
+  network: "Airgapped"
   resource_pool: "Users"

--- a/test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl
+++ b/test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl
@@ -10,7 +10,7 @@ packer:
   ssh_bastion_private_key_file: /kib/vsphere-tests.pem
   cluster: "zone1"
   datacenter: "dc1"
-  datastore: "esxi-06-disk1"
+  datastore: "esxi-05-disk2"
   folder: "cluster-api"
   network: "Airgapped"
   resource_pool: "Users"

--- a/test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl
+++ b/test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl
@@ -10,7 +10,6 @@ packer:
   ssh_bastion_private_key_file: /kib/vsphere-tests.pem
   cluster: "zone1"
   datacenter: "dc1"
-  template: "base-rhel-7-sortega"
   datastore: "esxi-06-disk1"
   folder: "cluster-api"
   network: "Airgapped"


### PR DESCRIPTION
**What problem does this PR solve?**:
Uses the correct disk for the rhel 7 template. The template is now using this disk instead based on some configuration changes we made.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
