### PR TITLE
Ubuntu fixes for vSphere

### DIFF
--- a/ansible/roles/providers/tasks/qemu.yml
+++ b/ansible/roles/providers/tasks/qemu.yml
@@ -61,9 +61,12 @@
     state: link
   when: ansible_os_family == "RedHat"
 
+- name: Get a list of services
+  service_facts:
+
 - name: Disable Hyper-V KVP protocol daemon on Ubuntu
   systemd:
     name: hv-kvp-daemon
     state: stopped
     enabled: false
-  when: ansible_os_family == "Debian"
+  when: ('hv-kvp-daemon.service' in ansible_facts.services) and (ansible_os_family == "Debian")

--- a/ansible/roles/providers/tasks/vmware.yml
+++ b/ansible/roles/providers/tasks/vmware.yml
@@ -115,12 +115,15 @@
 #     regexp: '(?i)lock_passwd: True'
 #     replace: 'lock_passwd: False'
 
+- name: Get a list of services
+  service_facts:
+
 - name: Disable Hyper-V KVP protocol daemon on Ubuntu
   systemd:
     name: hv-kvp-daemon
     state: stopped
     enabled: false
-  when: ansible_os_family == "Debian"
+  when: ('hv-kvp-daemon.service' in ansible_facts.services) and (ansible_os_family == "Debian")
 
 - name: Create provider vmtools config drop-in file
   copy:

--- a/ansible/roles/sysprep/tasks/debian.yml
+++ b/ansible/roles/sysprep/tasks/debian.yml
@@ -100,3 +100,11 @@
   file:
     state: absent
     path: /etc/udev/rules.d/70-persistent-net.rules
+
+- name: Mount /run with exec for cloud-init scripts
+  ansible.posix.mount:
+    path: /run
+    src: tmpfs
+    fstype: tmpfs
+    opts: rw,nosuid,exec,noatime,mode=755
+    state: present


### PR DESCRIPTION
**What problem does this PR solve?**:

Fixes a couple of minor issues that prevented Ubuntu 20.04 images being built on vSphere:

- Ansible failed when stopping a service that did not exist on a stock install (hv-kvp-daemon)
- /run is mounted with "noexec" by default in Ubuntu which prevented cloud-init scripts from running


**Which issue(s) does this PR fix?**:

No JIRA issue created (I can add one if required)


**Special notes for your reviewer**:

As discussed in #konvoy channel in D2IQ internal Slack

**Does this PR introduce a user-facing change?**:

No, although a new ubuntu image definition could be added to "images/ova" which would make this visible. I have not done so as part of this PR though.
