### PR TITLE
feat: move disabling swap and firewalld to a shared play

### DIFF
--- a/ansible/roles/kubeadm/tasks/main.yaml
+++ b/ansible/roles/kubeadm/tasks/main.yaml
@@ -10,3 +10,51 @@
 
 - include: debian.yaml
   when: ansible_os_family == "Debian"
+
+- name: remove swapfile
+  file:
+    state: "{{ item.state }}"
+    path: "{{ item.path }}"
+  loop:
+    - path: /swapfile
+      state: absent
+    - path: /mnt/resource/swapfile
+      state: absent
+  when: ansible_memory_mb.swap.total != 0
+
+- name: remove swap from /etc/fstab
+  mount:
+    name: "{{ item }}"
+    fstype: swap
+    state: absent
+  with_items:
+    - swap
+    - none
+
+- name: check if swap is on
+  command: swapon -s
+  register: swapon
+  changed_when: false
+
+- name: disable swap
+  command: swapoff -a
+  when: swapon.stdout
+
+- name: check if firewalld service exists
+  command: systemctl cat firewalld
+  check_mode: no
+  register: firewalld_exists
+  changed_when: False
+  failed_when: firewalld_exists.rc not in [0, 1]
+  when:
+    - disable_firewalld | default(true)
+
+- name: stop and disable firewalld service
+  systemd:
+    name: firewalld
+    enabled: false
+    masked: false
+    state: stopped
+  when:
+    - disable_firewalld | default(true)
+    - firewalld_exists.rc == 0

--- a/ansible/roles/sysprep/tasks/main.yml
+++ b/ansible/roles/sysprep/tasks/main.yml
@@ -169,17 +169,6 @@
       find /var/log -type f -name '*.gz' -exec rm {} +
   when: ansible_os_family != "Flatcar"
 
-- name: Remove swapfile
-  file:
-    state: "{{ item.state }}"
-    path: "{{ item.path }}"
-  loop:
-    - path: /swapfile
-      state: absent
-    - path: /mnt/resource/swapfile
-      state: absent
-  when: ansible_memory_mb.swap.total != 0
-
 - name: Truncate shell history
   file:
     state: absent
@@ -187,43 +176,6 @@
   loop:
     - path: /root/.bash_history
     - path: "/home/{{ ansible_env.SUDO_USER }}/.bash_history"
-
-- name: Remove swap from /etc/fstab
-  mount:
-    name: "{{ item }}"
-    fstype: swap
-    state: absent
-  with_items:
-    - swap
-    - none
-
-- name: Check if swap is on
-  command: swapon -s
-  register: swapon
-  changed_when: false
-
-- name: Disable Swap
-  command: swapoff -a
-  when: swapon.stdout
-
-- name: Check if firewalld service exists
-  command: systemctl cat firewalld
-  check_mode: no
-  register: firewalld_exists
-  changed_when: False
-  failed_when: firewalld_exists.rc not in [0, 1]
-  when:
-    - disable_firewalld | default(true)
-
-- name: Stop and disable firewalld service
-  systemd:
-    name: firewalld
-    enabled: false
-    masked: false
-    state: stopped
-  when:
-    - disable_firewalld | default(true)
-    - firewalld_exists.rc == 0
 
 - name: Ensure containterd is started
   systemd:


### PR DESCRIPTION
**What problem does this PR solve?**:
Move disabling swap and firewalld out of sysprep where it only runs for cloud images to a playbook that always runs (including preprovisioned).
Moved it into the `kubeadm` role since these are kubeadm/Kubernetes requirements. 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
