### PR TITLE
fix: remove mark inventory file as required

### DIFF
--- a/cmd/konvoy-image/cmd/artifacts.go
+++ b/cmd/konvoy-image/cmd/artifacts.go
@@ -38,12 +38,7 @@ func init() {
 	addOverridesArg(fs, &artifactsFlags.Overrides)
 	addWorkDirArg(fs, &artifactsFlags.WorkDir)
 	addExtraVarsArg(fs, &artifactsFlags.ExtraVars)
-	err := artifactsCmd.MarkFlagRequired("inventory-file")
-	if err != nil {
-		// This is a programming error
-		panic(fmt.Sprintf("unable to mark flag `inventory-file` as required: %v", err))
-	}
-	err = artifactsCmd.MarkFlagRequired("os-packages-bundle")
+	err := artifactsCmd.MarkFlagRequired("os-packages-bundle")
 	if err != nil {
 		// This is a programming error
 		panic(fmt.Sprintf("unable to mark flag `os-packaes-bundle` as required: %v", err))


### PR DESCRIPTION
**What problem does this PR solve?**:
inventory-flag as required is a breaking change. reverts this 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER
https://github.com/mesosphere/konvoy2/pull/1499

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
