### PR TITLE
backport: goreleaser from main to 1.17

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -120,6 +120,10 @@ archives:
       - LICENSE
       - README.md
 
+checksum:
+  # override the name template to include the "v" prefix
+  name_template: '{{ .ProjectName }}_v{{trimprefix .Version "v"}}_checksums.txt'
+
 release:
   github:
   prerelease: auto


### PR DESCRIPTION
**What problem does this PR solve?**:
Backports our goreleaser which breaks our signing workflow https://github.com/mesosphere/konvoy-image-builder/runs/7441613471?check_suite_focus=true#step:12:1

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
