### PR TITLE
fix: ubuntu  for vsphere 

### DIFF
--- a/ansible/roles/providers/tasks/vmware.yml
+++ b/ansible/roles/providers/tasks/vmware.yml
@@ -82,6 +82,16 @@
     group: root
     mode: 0644
 
+- name: Remove subiquity-disable-cloudinit-networking.cfg
+  file:
+    path: /etc/cloud/cloud.cfg.d/subiquity-disable-cloudinit-networking.cfg
+    state: absent
+
+- name: Remove 99-installer.cfg
+  file:
+    path: /etc/cloud/cloud.cfg.d/99-installer.cfg
+    state: absent
+
 # this program used by ds-identify to determine whether or not the
 # VMwareGuestInfo datasource is useable.
 - name: Create ds-check program to verify VMwareGuestInfo datasource

--- a/ansible/roles/providers/tasks/vmware.yml
+++ b/ansible/roles/providers/tasks/vmware.yml
@@ -142,3 +142,13 @@
     owner: root
     group: root
     mode: 0644
+
+- name: Get a list of services
+  service_facts:
+
+- name: Disable UFW firewall on Ubuntu/Debian
+  systemd:
+    name: ufw
+    state: stopped
+    enabled: false
+  when: ('ufw.service' in ansible_facts.services) and (ansible_os_family == "Debian")

--- a/ansible/roles/providers/tasks/vmware.yml
+++ b/ansible/roles/providers/tasks/vmware.yml
@@ -152,3 +152,21 @@
     state: stopped
     enabled: false
   when: ('ufw.service' in ansible_facts.services) and (ansible_os_family == "Debian")
+
+# See https://kb.vmware.com/s/article/82229
+# From systemd docs: 
+# "If a valid D-Bus machine ID is already configured for the system, 
+# the D-Bus machine ID is copied and used to initialize the machine ID in /etc/machine-id"
+# This needs to be reset/truncated as well on Ubuntu.
+- name: Truncate D-Bus machine-id
+  file:
+    path: /var/lib/dbus/machine-id
+    state: absent
+  when: ansible_os_family == "Debian" 
+
+- name: Link D-Bus machine-id to /etc/machine-id
+  file:
+    path: /var/lib/dbus/machine-id
+    state: link
+    src: /etc/machine-id
+  when: ansible_os_family == "Debian"


### PR DESCRIPTION
**What problem does this PR solve?**:

With these three patches (and the ones previously merged) it is now possible to build Ubuntu 20.04 OVAs for vSphere. I have tested these images by building DKP clusters with them, both management and workload and have deployed a full Kommander installation on top.

**Which issue(s) does this PR fix?**:

No JIRA issue for these patches

**Special notes for your reviewer**:

You may find the following image YAML useful if you want to verify the images yourself:

```yaml
---
download_images: true
build_name: "ubuntu-2004"
packer_builder_type: "vsphere" 
packer:
  cluster: ""
  datacenter: ""
  datastore: ""
  folder: ""
  insecure_connection: "false"
  network: ""
  resource_pool: ""
  template: "base-ubuntu-2004"
  vsphere_guest_os_type: "ubuntu64Guest"
  guest_os_type: "ubuntu-64"
# goss params
  distribution: "Ubuntu"
  distribution_version: "20.04"
```

You may also want to set the following override if testing with DKP 2.2.2:

```yaml
kubernetes_version: 1.22.8
```

Please feel free to reach out to me on D2IQ slack (@mdr) if you have any questions.

**Does this PR introduce a user-facing change?**:

No.