### PR TITLE
docs: nits for grammar and style

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,8 @@ export DOCKER_DEVKIT_AWS_ARGS ?= \
 	--volume "$(HOME)/.aws":"/home/$(USER_NAME)/.aws"
 
 ifeq ($(strip $(TEAMCITY_EXTRA_MOUNT)),)
-DOCKER_GCP_CREDENTIALS_ARGS=--volume "$(HOME)/.gcp":"/home/$(USER_NAME)/.gcp" \
-	                             --env GOOGLE_APPLICATION_CREDENTIALS=/home/$(USER_NAME)/.gcp/credentials.json
+DOCKER_GCP_CREDENTIALS_ARGS=--volume "$(HOME)/.gcloud":"/home/$(USER_NAME)/.gcloud" \
+	                             --env GOOGLE_APPLICATION_CREDENTIALS=/home/$(USER_NAME)/.gcloud/credentials.json
 else
 DOCKER_GCP_CREDENTIALS_ARGS=--volume $(TEAMCITY_EXTRA_MOUNT):$(TEAMCITY_EXTRA_MOUNT) \
 								 --env GOOGLE_APPLICATION_CREDENTIALS=$(TEAMCITY_EXTRA_MOUNT)/$(TEAMCITY_BUILD_ID)-credentials.json

--- a/docs/dev/gcp.md
+++ b/docs/dev/gcp.md
@@ -5,13 +5,13 @@
 - Install gcloud CLI: [Instructions](https://cloud.google.com/sdk/docs/install)
 - Authentication:
 
-    Packer plugin for google compute requires authenticate with GCP using service account credentails. Instructions to create service account and credentials file can be found [here](https://www.packer.io/plugins/builders/googlecompute#running-outside-of-google-cloud)
+    Packer plugin for Google Compute requires authenticate with GCP using service account credentials. Instructions to create service account and credentials file can be found [here](https://www.packer.io/plugins/builders/googlecompute#running-outside-of-google-cloud)
 
     **Using CLI:**
     ```bash
     export USER=<SERVICE_ACCOUNT_USER>
     export GCP_PROJECT=<GCP_PROJECT_NAME>
-    export GOOGLE_APPLICATION_CREDENTIALS=$HOME/.gcp/credentials.json
+    export GOOGLE_APPLICATION_CREDENTIALS=$HOME/.gcloud/credentials.json
     gcloud iam service-accounts create "$USER"
     gcloud projects add-iam-policy-binding $GCP_PROJECT --member="serviceAccount:$USER@$GCP_PROJECT.iam.gserviceaccount.com" --role=roles/compute.instanceAdmin.v1
     gcloud projects add-iam-policy-binding $GCP_PROJECT --member="serviceAccount:$USER@$GCP_PROJECT.iam.gserviceaccount.com" --role=roles/iam.serviceAccountUser
@@ -19,7 +19,7 @@
     ```
 - Network:
 
-    A network with firewall rule set to allow SSH traffic must be created to allow packer communicate to the VM provisioning image.
+    A network with a firewall rule set to allow SSH traffic must be created to allow Packer to communicate to the VM provisioning image.
     **Using CLI:**
     ```shell
     export NETWORK_NAME=<NAME_OF_NETWORK>
@@ -28,12 +28,15 @@
     gcloud compute firewall-rules create "${NETWORK_NAME}-allow-ssh" --project="$GCP_PROJECT" --network="projects/$GCP_PROJECT/global/networks/${CLUSTER_NAME}" --description=Allows\ TCP\ connections\ from\ any\ source\ to\ any\ instance\ on\ the\ network\ using\ port\ 22. --direction=INGRESS --priority=65534 --source-ranges=0.0.0.0/0 --action=ALLOW --rules=tcp:22
     ```
 - Environment variables
-Make sure to create file with credentials for the service account using instructions above.
-export GOOGLE_APPLICATION_CREDENTIALS=$HOME/.gcp/credentials.json
+Make sure to create a file with credentials for the service account using the instructions above.
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS=$HOME/.gcloud/credentials.json
+```
 
 **Packer variables for GCP:**
 
-Add following configuration in the `image.yaml`
+Add the following configuration in the `image.yaml`
 Substitue following variables needed for building images in GCP
 - PROJECT_NAME
 - ZONE
@@ -58,8 +61,9 @@ python_path: ""
 ```
 
 ## Create image on GCP
+
 ```bash
 konvoy-image build gcp path/to/image.yaml
 ```
 
-Checkout example image configuration at: [`<project_root>/images/gcp/`](../../images/gcp) directory.
+Checkout example image configurations at the [`<project_root>/images/gcp/`](../../images/gcp) directory.


### PR DESCRIPTION
**What problem does this PR solve?**:
just some grammar and styles for the gcp dev docs

**Which issue(s) does this PR fix?**:
n/a

**Special notes for your reviewer**:
solely documentation.
I also changed the file location from
    `export GOOGLE_APPLICATION_CREDENTIALS=$HOME/.gcp/credentials.json` to
    `export GOOGLE_APPLICATION_CREDENTIALS=$HOME/.gcloud/credentials.json`
Because it's a gcloud cli, and that's what it is in our other docs site. I don't feel strongly about that in particular, but just one for consistency.

**Does this PR introduce a user-facing change?**:
solely documentation.