### PR TITLE
fix: centos does not need RHSM. Fix ansible conditions

### DIFF
--- a/ansible/roles/repo/tasks/redhat.yaml
+++ b/ansible/roles/repo/tasks/redhat.yaml
@@ -7,8 +7,9 @@
     password: "{{ lookup('env', 'RHSM_PASS') }}"
     auto_attach: true
   when:
-    - packer_builder_type is defined   #save-image playbook resuse this role. save-image playbook is independent of platform
-    - packer_builder_type.startswith('vsphere') or packer_builder_type.startswith('vmware')
+    - lookup('env', 'RHSM_USER') | length > 0
+    - lookup('env', 'RHSM_PASS') | length > 0
+    - ansible_distribution == 'Red Hat Enterprise Linux'
 
 # The AppStream repo for Centos 8 is not available from centos mirror list.
 # AlmaLinux is 1:1 binary compatible with RHEL and subscription free.

--- a/ansible/roles/sysprep/tasks/redhat.yml
+++ b/ansible/roles/sysprep/tasks/redhat.yml
@@ -67,6 +67,6 @@
     - name: clean local subscription data
       command: subscription-manager clean
   when:
-    - packer_builder_type is defined
-    - not offline_mode_enabled
-    - packer_builder_type.startswith('vsphere') or packer_builder_type.startswith('vmware')
+    - lookup('env', 'RHSM_USER') | length > 0
+    - lookup('env', 'RHSM_PASS') | length > 0
+    - ansible_distribution == 'Red Hat Enterprise Linux'


### PR DESCRIPTION
**What problem does this PR solve?**:
When building centos images on vSphere RHSM is expected. Also unnecessary variables are used. Use ansible internal OS vars instead

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
