### PR TITLE
fix: bump mindthegap to preserves image IDs 

### DIFF
--- a/Dockerfile.devkit
+++ b/Dockerfile.devkit
@@ -68,7 +68,7 @@ ARG USER_ID=0
 ARG GROUP_NAME=root
 ARG GROUP_ID=0
 ARG DOCKER_GID=0
-ARG MINDTHEGAP_VERSION=0.19.0
+ARG MINDTHEGAP_VERSION=1.0.0-rc.1
 
 COPY requirements.txt /tmp/
 COPY requirements-devkit.txt /tmp/

--- a/Dockerfile.devkit
+++ b/Dockerfile.devkit
@@ -68,7 +68,7 @@ ARG USER_ID=0
 ARG GROUP_NAME=root
 ARG GROUP_ID=0
 ARG DOCKER_GID=0
-ARG MINDTHEGAP_VERSION=1.0.0-rc.1
+ARG MINDTHEGAP_VERSION=1.0.0
 
 COPY requirements.txt /tmp/
 COPY requirements-devkit.txt /tmp/


### PR DESCRIPTION
**What problem does this PR solve?**:
This version comes with https://github.com/mesosphere/mindthegap/pull/185

See https://mesosphere.slack.com/archives/C02GXHVTCPL/p1663163626582799

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
