### PR TITLE
fix: upgrade ansible to 6.3.0 and fix CI flakes

### DIFF
--- a/Dockerfile.devkit
+++ b/Dockerfile.devkit
@@ -58,7 +58,7 @@ RUN wget \
 # NOTE(jkoelker) From here we care about layers
 FROM golang:1.19.0-alpine3.15
 
-ARG ANSIBLE_VERSION=4.10.0
+ARG ANSIBLE_VERSION=6.3.0
 ARG DOCKER_PY_VERSION=5.0.3
 ENV ANSIBLE_PATH=/usr
 ENV PYTHON_PATH=/usr

--- a/ansible/requirements.txt
+++ b/ansible/requirements.txt
@@ -3,6 +3,6 @@ molecule-ec2
 ansible-lint
 boto
 boto3
-ansible==4.10.0
+ansible==6.3.0
 yamllint
 pytest-testinfra

--- a/ansible/roles/packages/tasks/debian.yaml
+++ b/ansible/roles/packages/tasks/debian.yaml
@@ -42,7 +42,6 @@
   apt:
     name: kubelet={{ package_versions.kubernetes_deb }}
     state: present
-    default_release: "{{ kubernetes_deb_release_name }}"
     force: true
   register: kubelet_installation_deb
   until: kubelet_installation_deb is success
@@ -53,7 +52,6 @@
   apt:
     name: kubectl={{ package_versions.kubernetes_deb }}
     state: present
-    default_release: "{{ kubernetes_deb_release_name }}"
     force: true
   register: result
   until: result is success

--- a/ansible/roles/packages/tasks/debian.yaml
+++ b/ansible/roles/packages/tasks/debian.yaml
@@ -25,7 +25,6 @@
       - nfs-common
       - python3-cryptography
       - python3-pip
-      - python3-openssl
     state: present
   register: result
   until: result is success

--- a/ansible/roles/packages/tasks/debian.yaml
+++ b/ansible/roles/packages/tasks/debian.yaml
@@ -25,6 +25,7 @@
       - nfs-common
       - python3-cryptography
       - python3-pip
+      - python3-openssl
     state: present
   register: result
   until: result is success

--- a/ansible/roles/providers/tasks/azure-pip.yml
+++ b/ansible/roles/providers/tasks/azure-pip.yml
@@ -34,3 +34,4 @@
   vars:
     packages:
       - azure-cli
+      - pyOpenSSL>=22.0.0

--- a/ansible/roles/providers/tasks/azure-pip.yml
+++ b/ansible/roles/providers/tasks/azure-pip.yml
@@ -27,7 +27,7 @@
   when:
     - ansible_os_family == "Debian"
 
-- name: install Azure clients
+- name: install Azure clients and python libraries
   pip:
     executable: pip3
     name: "{{ packages }}"

--- a/hack/pip-packages/pip-getter/Dockerfile
+++ b/hack/pip-packages/pip-getter/Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:7.9.2009
 
-RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+RUN yum install -y epel-release && \
     yum -y install python3-pip && \
     yum clean all \

--- a/pkg/packer/manifests/aws/packer.json.tmpl
+++ b/pkg/packer/manifests/aws/packer.json.tmpl
@@ -190,19 +190,6 @@
       "execute_command": "BUILD_NAME={{ user `build_name`}}; if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi"
     },
     {
-      "type": "shell",
-      "inline": [
-        "mkdir -p /tmp/.goss-dir"
-      ]
-    },
-    {
-        "type": "file",
-        "source": "/usr/local/bin/goss",
-        "destination": "/tmp/.goss-dir/goss",
-        "direction": "upload",
-        "max_retries": 10
-    },
-    {
       "type": "ansible",
       "playbook_file": "./ansible/provision.yaml",
       "user": "{{user `ssh_username`}}",
@@ -214,6 +201,19 @@
         "--extra-vars",
         "{{ user `ansible_extra_vars` }}"
       ]
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "mkdir -p /tmp/.goss-dir"
+      ]
+    },
+    {
+        "type": "file",
+        "source": "/usr/local/bin/goss",
+        "destination": "/tmp/.goss-dir/goss",
+        "direction": "upload",
+        "max_retries": 10
     },
     {
       "arch": "{{user `goss_arch`}}",

--- a/pkg/packer/manifests/azure/packer.json.tmpl
+++ b/pkg/packer/manifests/azure/packer.json.tmpl
@@ -166,19 +166,6 @@
       "execute_command": "BUILD_NAME={{ user `build_name`}}; if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi"
     },
     {
-      "type": "shell",
-      "inline": [
-        "mkdir -p /tmp/.goss-dir"
-      ]
-    },
-    {
-        "type": "file",
-        "source": "/usr/local/bin/goss",
-        "destination": "/tmp/.goss-dir/goss",
-        "direction": "upload",
-        "max_retries": 10
-    },
-    {
       "type": "ansible",
       "playbook_file": "./ansible/provision.yaml",
       "user": "{{user `ssh_username`}}",
@@ -190,6 +177,19 @@
         "--extra-vars",
         "{{ user `ansible_extra_vars` }}"
       ]
+    },
+     {
+      "type": "shell",
+      "inline": [
+        "mkdir -p /tmp/.goss-dir"
+      ]
+    },
+    {
+        "type": "file",
+        "source": "/usr/local/bin/goss",
+        "destination": "/tmp/.goss-dir/goss",
+        "direction": "upload",
+        "max_retries": 10
     },
     {
       "arch": "{{user `goss_arch`}}",

--- a/pkg/packer/manifests/gcp/packer.json.tmpl
+++ b/pkg/packer/manifests/gcp/packer.json.tmpl
@@ -129,19 +129,6 @@
       "execute_command": "BUILD_NAME={{ user `build_name`}}; if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi"
     },
     {
-      "type": "shell",
-      "inline": [
-        "mkdir -p /tmp/.goss-dir"
-      ]
-    },
-    {
-        "type": "file",
-        "source": "/usr/local/bin/goss",
-        "destination": "/tmp/.goss-dir/goss",
-        "direction": "upload",
-        "max_retries": 10
-    },
-    {
       "type": "ansible",
       "playbook_file": "./ansible/provision.yaml",
       "user": "{{user `ssh_username`}}",
@@ -153,6 +140,19 @@
         "--extra-vars",
         "{{ user `ansible_extra_vars` }}"
       ]
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "mkdir -p /tmp/.goss-dir"
+      ]
+    },
+    {
+        "type": "file",
+        "source": "/usr/local/bin/goss",
+        "destination": "/tmp/.goss-dir/goss",
+        "direction": "upload",
+        "max_retries": 10
     },
     {
       "arch": "{{user `goss_arch`}}",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ansible==4.10.0
+ansible==6.3.0
 netaddr==0.8.0

--- a/test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl
+++ b/test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl
@@ -10,7 +10,7 @@ packer:
   ssh_bastion_private_key_file: /kib/vsphere-tests.pem
   cluster: "zone1"
   datacenter: "dc1"
-  datastore: "esxi-06-disk1"
+  datastore: "ovh-nfs"
   folder: "cluster-api"
   network: "Airgapped"
   resource_pool: "Users"


### PR DESCRIPTION
**What problem does this PR solve?**:
Fixes various CI flakes.
- fixes intermittent connection failures `Connection to 127.0.0.1 closed` errors
- use repo mirrors to install epel-release rpm instead of using fixed URL to reduce 5XX errors downloading it.
- removes apt `default_release` option when installing kubectl and kubelet packages. after upgrading ansible to 6.3.0, kubectl and kubelet packages were not getting installed with `default_release` for apt set to `kubernetes-xenial`