### PR TITLE
fix: upload nvidia runfile for offline preprovisioned 

### DIFF
--- a/ansible/roles/offline/tasks/upload.yaml
+++ b/ansible/roles/offline/tasks/upload.yaml
@@ -136,6 +136,4 @@
         dest: "{{ nvidia_remote_bundle_path }}/{{ nvidia_runfile_installer }}"
         mode: 711
   when:
-    - gpu is defined
-    - "'nvidia' in gpu.types"
     - nvidia_runfile_local_file != ""

--- a/pkg/app/artifacts.go
+++ b/pkg/app/artifacts.go
@@ -68,9 +68,12 @@ func (a *ArtifactUploader) playbookOptionsFromFlag(artifactFlags ArtifactsCmdFla
 	if err != nil {
 		return nil, fmt.Errorf("failed to find absolute path for --container-images-dir %w", err)
 	}
-	nvidiaRunfile, err := filepath.Abs(artifactFlags.NvidiaRunfile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find absolute path for --nvidia-runfile %w", err)
+	var nvidiaRunfile string
+	if artifactFlags.NvidiaRunfile != "" {
+		nvidiaRunfile, err = filepath.Abs(artifactFlags.NvidiaRunfile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find absolute path for --nvidia-runfile %w", err)
+		}
 	}
 	args := make(map[string]interface{})
 	if err = mergeUserOverridesToMap(artifactFlags.Overrides, args); err != nil {


### PR DESCRIPTION
**What problem does this PR solve?**:
gpu won't be defined when we run upload artifacts. we should remove this.


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
