### PR TITLE
chore: bump Kubernetes v1.23.12

### DIFF
--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -3,7 +3,7 @@ python_path: ""
 
 # This is also in images/common.yaml as that's where the go code expects it to be.
 # If it's not there, the kubernetes_full_version will have "None" for a version number.
-kubernetes_version: "1.23.7"
+kubernetes_version: "1.23.12"
 
 containerd_version: "1.4.13"
 kubernetes_cni_version: "0.9.1"

--- a/images/common.yaml
+++ b/images/common.yaml
@@ -1,5 +1,5 @@
 ---
-kubernetes_version: "1.23.7"
+kubernetes_version: "1.23.12"
 
 download_images: true
 


### PR DESCRIPTION
**What problem does this PR solve?**:
Bumping `release-1.19` branch to latest Kubernetes `v1.23.12`.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
