### PR TITLE
fix: remove fips.configure from a user facing override

### DIFF
--- a/overrides/fips.yaml
+++ b/overrides/fips.yaml
@@ -3,7 +3,6 @@ k8s_image_registry: docker.io/mesosphere
 
 fips:
   enabled: true
-  configure: false
 
 build_name_extra: -fips
 kubernetes_build_metadata: fips.0


### PR DESCRIPTION
**What problem does this PR solve?**:
This is tested in a limit set of OSs, lets not expose it yet to users.
The value is already being set to `false` in https://github.com/mesosphere/konvoy-image-builder/blob/d226e7aeec35229c31f510a9862daecda6595c10/ansible/group_vars/all/system.yaml#L22-L24

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
