### PR TITLE
fix: force register RHSM

### DIFF
--- a/ansible/roles/repo/tasks/redhat.yaml
+++ b/ansible/roles/repo/tasks/redhat.yaml
@@ -6,6 +6,7 @@
     username: "{{ lookup('env', 'RHSM_USER') }}"
     password: "{{ lookup('env', 'RHSM_PASS') }}"
     auto_attach: true
+    force_register: true
   when:
     - lookup('env', 'RHSM_USER') | length > 0
     - lookup('env', 'RHSM_PASS') | length > 0


### PR DESCRIPTION
**What problem does this PR solve?**:
We've seen in internal testing that a machine is already registered. Force register the system. I haven't found anything online that talks about this flag having any negative side-effects.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-92155)
-->
* https://d2iq.atlassian.net/browse/D2IQ-92155


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
