### PR TITLE
feat: build AMI and OVA for RHEL 8.6 networked, nvidia and airgapped flavors

### DIFF
--- a/ansible/roles/packages/tasks/redhat.yaml
+++ b/ansible/roles/packages/tasks/redhat.yaml
@@ -1,8 +1,22 @@
 ---
-- name: install common RPMS
+- name: find installed RPMs
   yum:
-    name:
-      - "{{ 'python3-' if ansible_distribution_major_version == '8' }}audit"
+    list: installed
+    enablerepo: "{{ 'offline' if offline_mode_enabled else '' }}"
+    disablerepo: "{{ '*' if offline_mode_enabled else '' }}"
+    update_cache: true
+  register: installed_rpms
+
+- name: install common RPMS if already not installed
+  yum:
+    name: "{{ item }}"
+    state: present
+    enablerepo: "{{ 'offline' if offline_mode_enabled else '' }}"
+    disablerepo: "{{ '*' if offline_mode_enabled else '' }}"
+    update_cache: true
+  when: installed_rpms.results | selectattr('name','equalto', item ) | list | count == 0
+  with_items:
+      - audit
       - ca-certificates
       - conntrack-tools
       - chrony
@@ -15,11 +29,7 @@
       - socat
       - sysstat
       - nfs-utils
-      - "NetworkManager{{ '-cloud-setup' if packer_builder_type not in ['vsphere'] and ansible_distribution_major_version == '8' }}" # OS images on cloud platforms (AWS, AZURE, GCP) supports only NetworkManager-cloud-setup package.
-    state: present
-    enablerepo: "{{ 'offline' if offline_mode_enabled else '' }}"
-    disablerepo: "{{ '*' if offline_mode_enabled else '' }}"
-    update_cache: true
+      - NetworkManager
   register: result
   until: result is success
   retries: 5

--- a/ansible/roles/packages/tasks/redhat.yaml
+++ b/ansible/roles/packages/tasks/redhat.yaml
@@ -15,7 +15,7 @@
       - socat
       - sysstat
       - nfs-utils
-      - "NetworkManager{{ '-cloud-setup' if packer_builder_type not in ['vsphere'] }}" # OS images on cloud platforms (AWS, AZURE, GCP) supports only NetworkManager-cloud-setup package.
+      - "NetworkManager{{ '-cloud-setup' if packer_builder_type not in ['vsphere'] and ansible_distribution_major_version == '8' }}" # OS images on cloud platforms (AWS, AZURE, GCP) supports only NetworkManager-cloud-setup package.
     state: present
     enablerepo: "{{ 'offline' if offline_mode_enabled else '' }}"
     disablerepo: "{{ '*' if offline_mode_enabled else '' }}"

--- a/ansible/roles/packages/tasks/redhat.yaml
+++ b/ansible/roles/packages/tasks/redhat.yaml
@@ -2,12 +2,12 @@
 - name: install common RPMS
   yum:
     name:
-      - audit
+      - "'python3-' if ansible_distribution_major_version == '8' }}audit"
       - ca-certificates
       - conntrack-tools
       - chrony
       - curl
-      - ebtables
+      - "'iptables-' if ansible_distribution_major_version == '8' }}ebtables"
       - open-vm-tools
       - python3-pip
       - "python{{ '3' if ansible_distribution_major_version == '8' }}-netifaces"
@@ -15,7 +15,7 @@
       - socat
       - sysstat
       - nfs-utils
-      - NetworkManager
+      - "NetworkManager{{ '-cloud-setup' if packer_builder_type not in ['vsphere'] }}" # OS images on cloud platforms (AWS, AZURE, GCP) supports only NetworkManager-cloud-setup package.
     state: present
     enablerepo: "{{ 'offline' if offline_mode_enabled else '' }}"
     disablerepo: "{{ '*' if offline_mode_enabled else '' }}"

--- a/ansible/roles/packages/tasks/redhat.yaml
+++ b/ansible/roles/packages/tasks/redhat.yaml
@@ -2,12 +2,12 @@
 - name: install common RPMS
   yum:
     name:
-      - "'python3-' if ansible_distribution_major_version == '8' }}audit"
+      - "{{ 'python3-' if ansible_distribution_major_version == '8' }}audit"
       - ca-certificates
       - conntrack-tools
       - chrony
       - curl
-      - "'iptables-' if ansible_distribution_major_version == '8' }}ebtables"
+      - "{{ 'iptables-' if ansible_distribution_major_version == '8' }}ebtables"
       - open-vm-tools
       - python3-pip
       - "python{{ '3' if ansible_distribution_major_version == '8' }}-netifaces"

--- a/ansible/roles/sysprep/tasks/redhat.yml
+++ b/ansible/roles/sysprep/tasks/redhat.yml
@@ -60,7 +60,7 @@
     - name: Remove subscriptions
       rhsm_repository:
         name: '*'
-        state: absent
+        state: disabled
     - name: Unregister system
       redhat_subscription:
         state: absent
@@ -70,3 +70,5 @@
     - lookup('env', 'RHSM_USER') | length > 0
     - lookup('env', 'RHSM_PASS') | length > 0
     - ansible_distribution == 'RedHat'
+    - "packer_builder_type not in ['amazon']"
+    - not offline_mode_enabled

--- a/images/ami/rhel-86.yaml
+++ b/images/ami/rhel-86.yaml
@@ -1,0 +1,15 @@
+download_images: true
+
+packer:
+  ami_filter_name: "RHEL-8.6.0_HVM-*"
+  ami_filter_owners: "309956199498"
+  distribution: "RHEL"
+  distribution_version: "8.6"
+  source_ami: ""
+  ssh_username: "ec2-user"
+  root_device_name: "/dev/sda1"
+  volume_size: "15"
+
+build_name: "rhel-8.6"
+packer_builder_type: "amazon"
+python_path: ""

--- a/images/ova/rhel-86.yaml
+++ b/images/ova/rhel-86.yaml
@@ -1,0 +1,26 @@
+---
+download_images: true
+build_name: "rhel-86"
+packer_builder_type: "vsphere" 
+guestinfo_datasource_slug: "https://raw.githubusercontent.com/vmware/cloud-init-vmware-guestinfo"
+guestinfo_datasource_ref: "v1.4.0"
+guestinfo_datasource_script: "{{guestinfo_datasource_slug}}/{{guestinfo_datasource_ref}}/install.sh"
+packer:
+  cluster: ""
+  datacenter: ""
+  datastore: ""
+  folder: ""
+  insecure_connection: "false"
+  network: ""
+  resource_pool: ""
+  template: "base-rhel-8.6" # change default value with your base template name
+  vsphere_guest_os_type: "rhel8_64Guest"
+  guest_os_type: "rhel8-64"
+  # goss params
+  distribution: "RHEL"
+  distribution_version: "8.6"
+# Use following overrides to select the authentication method that can be used with base template
+# ssh_username: ""
+# ssh_password: ""
+# ssh_private_key_file = "" #
+# ssh_agent_auth: false  # is set to true, ssh_password and ssh_private_key will be ignored

--- a/make/ci.mk
+++ b/make/ci.mk
@@ -16,6 +16,7 @@ endif
 ci.e2e.build.all: ci.e2e.build.centos-7
 ci.e2e.build.all: ci.e2e.build.ubuntu-18
 ci.e2e.build.all: ci.e2e.build.ubuntu-20
+ci.e2e.build.all: ci.e2e.build.rhel-8.6
 ci.e2e.build.all: ci.e2e.build.sles-15
 ci.e2e.build.all: ci.e2e.build.oracle-7
 ci.e2e.build.all: ci.e2e.build.oracle-8
@@ -24,7 +25,9 @@ ci.e2e.build.all: e2e.build.centos-7-offline
 ci.e2e.build.all: e2e.build.rhel-7.9-offline-fips
 ci.e2e.build.all: e2e.build.rhel-8.2-offline-fips
 ci.e2e.build.all: e2e.build.rhel-8.4-offline-fips
+ci.e2e.build.all: e2e.build.rhel-8.6-offline
 ci.e2e.build.all: ci.e2e.build.rhel-8.4-nvidia
+ci.e2e.build.all: ci.e2e.build.rhel-8.6-nvidia
 ci.e2e.build.all: ci.e2e.build.rhel-8-fips
 ci.e2e.build.all: ci.e2e.build.centos-7-nvidia
 ci.e2e.build.all: ci.e2e.build.sles-15-nvidia
@@ -73,6 +76,12 @@ e2e.build.sles-15-nvidia: sles15-nvidia
 e2e.build.rhel-8-fips: rhel82-fips
 
 e2e.build.rhel-8.4-nvidia: rhel84-nvidia
+
+e2e.build.rhel-8.6: rhel86
+
+e2e.build.rhel-8.6-offline: rhel86-offline infra.aws.destroy
+
+e2e.build.rhel-8.6-nvidia: rhel86-nvidia
 
 # Azure
 e2e.build.centos-7-azure: centos7-azure

--- a/make/ci.mk
+++ b/make/ci.mk
@@ -107,6 +107,8 @@ e2e.build.rhel-8.4-ova: rhel84-ova
 
 e2e.build.rhel-7.9-ova: rhel79-ova
 
+e2e.build.rhel-8.6-ova: rhel86-ova
+
 # GCP
 e2e.build.centos-7.9-gcp: centos79-gcp
 

--- a/make/images.mk
+++ b/make/images.mk
@@ -433,6 +433,20 @@ rhel84-fips:
 rhel84-fips-offline:
 	$(MAKE) aws-rhel-8.4_offline-fips
 
+# RHEL 8.6 AWS
+.PHONY: rhel86
+rhel86:
+	$(MAKE) build-aws-rhel-8.6
+
+.PHONY: rhel86-nvidia
+rhel86-nvidia:
+	$(MAKE) aws-rhel-8.6_nvidia
+
+.PHONY: rhel86-offline
+rhel86-offline:
+	$(MAKE) aws-rhel-8.6_offline
+
+
 # RHEL 8 Azure
 .PHONY: rhel84-azure
 rhel84-azure:

--- a/make/images.mk
+++ b/make/images.mk
@@ -109,6 +109,7 @@ build-image: $(IMAGE)
 build-image: ## Build an image on a provider
 	./bin/konvoy-image build $(subst ova,,$(PROVIDER)) $(IMAGE) \
 	--dry-run=$(BUILD_DRY_RUN) \
+	--packer-on-error abort \
 	-v ${VERBOSITY} \
 	$(if $(ADDITIONAL_OVERRIDES),--overrides=$(ADDITIONAL_OVERRIDES)) \
 	$(call vm_size,$(PROVIDER),$(ADDITIONAL_ARGS)) \
@@ -490,9 +491,27 @@ rhel84-ova-offline:
 rhel84-ova-fips:
 	$(MAKE) ova-rhel-8.4_fips
 
-.PHONY: rhel82-ova-fips-offline
+.PHONY: rhel84-ova-fips-offline
 rhel84-ova-fips-offline:
 	$(MAKE) ova-rhel-8.4_offline-fips
+
+# RHEL 8.6 vSphere
+.PHONY: rhel86-ova
+rhel86-ova:
+	$(MAKE) build-ova-rhel-8.6
+
+.PHONY: rhel86-ova-offline
+rhel86-ova-offline:
+	$(MAKE) ova-rhel-8.6_offline
+
+.PHONY: rhel86-ova-fips
+rhel86-ova-fips:
+	$(MAKE) ova-rhel-8.6_fips
+
+.PHONY: rhel86-ova-fips-offline
+rhel86-ova-fips-offline:
+	$(MAKE) ova-rhel-8.6_offline-fips
+
 
 # SLES 15 AWS
 .PHONY: sles15


### PR DESCRIPTION
**What problem does this PR solve?**:
- builds AMI and OVA for RHEL 8.6 
- fixes to install RHEL 8.6 compatible rpms of NetworkManager, nfs-utils, python3-audit 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-92617)
-->
* https://d2iq.atlassian.net/browse/D2IQ-92617


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note
support for building AMI and OVA for RHEL 8.6
```
