### PR TITLE
fix: add retries when installing SUSE packages 

### DIFF
--- a/ansible/roles/containerd/tasks/suse.yaml
+++ b/ansible/roles/containerd/tasks/suse.yaml
@@ -4,6 +4,10 @@
   zypper:
     name: containerd
     state: absent
+  register: result
+  until: result is success
+  retries: 15
+  delay: 60
 
 - name: remove versionlock for containerd
   command: zypper removelock containerd.io
@@ -13,6 +17,10 @@
   register: command_result
   changed_when: |
     'command_result.stdout is regex(".*lock has been successfully removed.")'
+  register: result
+  until: result is success
+  retries: 15
+  delay: 60
   when:
     - exportedversionlocklist is defined and exportedversionlocklist.stdout is defined
     - "(
@@ -36,5 +44,5 @@
     state: present
   register: result
   until: result is success
-  retries: 3
-  delay: 3
+  retries: 15
+  delay: 60

--- a/ansible/roles/containerd/tasks/suse.yaml
+++ b/ansible/roles/containerd/tasks/suse.yaml
@@ -17,8 +17,7 @@
   register: command_result
   changed_when: |
     'command_result.stdout is regex(".*lock has been successfully removed.")'
-  register: result
-  until: result is success
+  until: command_result is success
   retries: 15
   delay: 60
   when:

--- a/ansible/roles/packages/tasks/suse.yaml
+++ b/ansible/roles/packages/tasks/suse.yaml
@@ -30,6 +30,9 @@
     warn: false
   ignore_errors: True
   register: command_result
+  until: command_result is success
+  retries: 15
+  delay: 60
   changed_when: 'command_result.stdout is regex(".*lock has been successfully removed.")'
   when:
     - exportedversionlocklist is defined and exportedversionlocklist.stdout is defined
@@ -64,4 +67,7 @@
   args:
     warn: false
   register: command_result
+  until: result is success
+  retries: 15
+  delay: 60
   changed_when: 'command_result.stdout is regex(".*lock has been successfully removed.")'

--- a/ansible/roles/providers/tasks/googlecompute.yml
+++ b/ansible/roles/providers/tasks/googlecompute.yml
@@ -79,3 +79,7 @@
       - cloud-init
       - cloud-init-guestinfo
   when: ansible_os_family == "Suse"
+  register: result
+  until: result is success
+  retries: 15
+  delay: 60

--- a/ansible/roles/providers/tasks/qemu.yml
+++ b/ansible/roles/providers/tasks/qemu.yml
@@ -44,6 +44,10 @@
     packages:
       - cloud-init
   when: ansible_os_family == "Suse"
+  register: result
+  until: result is success
+  retries: 15
+  delay: 60
 
 # - name: Unlock password
 #   replace:

--- a/ansible/roles/providers/tasks/vmware.yml
+++ b/ansible/roles/providers/tasks/vmware.yml
@@ -47,6 +47,10 @@
       - cloud-init
       - cloud-init-vmware-guestinfo
   when: ansible_os_family == "Suse"
+  register: result
+  until: result is success
+  retries: 15
+  delay: 60
 
 - name: Install cloud-init and tools for VMware Photon OS
   command: tdnf install {{ packages }} -y

--- a/ansible/roles/sysprep/tasks/suse.yml
+++ b/ansible/roles/sysprep/tasks/suse.yml
@@ -53,6 +53,10 @@
 
 - name: Remove zypper package cache
   command: zypper clean -a
+  register: result
+  until: result is success
+  retries: 15
+  delay: 60
 
 - name: Reset network interface IDs
   shell: sed -i '/^\(HWADDR\|UUID\)=/d' /etc/sysconfig/network/ifcfg-*


### PR DESCRIPTION
**What problem does this PR solve?**:
- attempt to fix E2E flakes because of following errors. Some `zypper` tasks missing retries. This PR sets same retry and delay for all `zypper` tasks.

```
sles-15-nvidia: TASK [containerd : remove preinstalled containerd] *****************************
      sles-15-nvidia: fatal: [default]: FAILED! => {"changed": false, "cmd": ["/usr/bin/zypper", "--quiet", "--non-interactive", "--xmlout", "--disable-repositories", "search", "--type", "package", "--match-exact", "--details", "--installed-only", "containerd"], "msg": "Zypper run command failed with return code 7.", "rc": 7, "stderr": "", "stderr_lines": [], "stdout": "<?xml version='1.0'?>\n<stream>\n<message type=\"error\">System management is locked by the application with pid 4463 (zypper).\nClose this application before trying again.</message>\n</stream>\n", "stdout_lines": ["<?xml version='1.0'?>", "<stream>", "<message type=\"error\">System management is locked by the application with pid 4463 (zypper).", "Close this application before trying again.</message>", "</stream>"]}
```
**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
I looked up SUSE forums for this. only suggestion i found is to manually `kill` the running task. 
The delay(1 minute) and retry attempts (15) are large, but keeping them to match with existing tasks. These can be tuned once we are sure that this eliminates flakes we are seeing in the CI.

