### PR TITLE
ci: add e2e.build.rhel-8.6-offline-fips target

### DIFF
--- a/make/ci.mk
+++ b/make/ci.mk
@@ -55,6 +55,8 @@ e2e.build.rhel-8.4-offline-fips: rhel84-fips-offline infra.aws.destroy
 
 e2e.build.rhel-8.4-offline-nvidia: rhel84-offline-nvidia infra.aws.destroy
 
+e2e.build.rhel-8.6-offline-fips: rhel86-fips-offline infra.aws.destroy
+
 e2e.build.ubuntu-18: ubuntu18
 
 e2e.build.ubuntu-20: ubuntu20

--- a/make/images.mk
+++ b/make/images.mk
@@ -447,6 +447,9 @@ rhel86-nvidia:
 rhel86-offline:
 	$(MAKE) aws-rhel-8.6_offline
 
+.PHONY: rhel86-fips-offline
+rhel86-fips-offline:
+	$(MAKE) aws-rhel-8.6_offline-fips
 
 # RHEL 8 Azure
 .PHONY: rhel84-azure


### PR DESCRIPTION
**What problem does this PR solve?**:
Adds the make targets for rhel86 FIPS.

See https://teamcity.mesosphere.io/buildConfiguration/ClosedSource_KonvoyImageBuilder_BuildAmiRhel86fipsOffline/3656428 and https://teamcity.mesosphere.io/buildConfiguration/ClosedSource_KonvoyImageBuilder_BuildAmiRhel86/3656425 for ✅  runs. 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-92617)
-->
* https://d2iq.atlassian.net/browse/D2IQ-92617

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
