### PR TITLE
fix: nvidia override files with correct information

### DIFF
--- a/overrides/nvidia.yaml
+++ b/overrides/nvidia.yaml
@@ -2,6 +2,4 @@
 gpu:
   types:
     - nvidia
-
 build_name_extra: "-nvidia"
-nvidia_cuda_version: "470"

--- a/overrides/offline-nvidia.yaml
+++ b/overrides/offline-nvidia.yaml
@@ -1,7 +1,7 @@
+# Use this file when building a machine image, not as a override secret for preprovisioned environments
 nvidia_runfile_local_file: "{{ playbook_dir}}/../artifacts/{{ nvidia_runfile_installer }}"
 gpu:
   types:
     - nvidia
 
 build_name_extra: "-nvidia"
-nvidia_cuda_version: "470"

--- a/pkg/app/config_test.go
+++ b/pkg/app/config_test.go
@@ -199,7 +199,7 @@ func TestGenPackerVars(t *testing.T) {
 		"gpu": map[interface{}]interface{}{
 			"types": []string{"nvidia"},
 		},
-		"nvidia_cuda_version": "1234",
+		"nvidia_driver_version": "1234",
 	}
 
 	jsonVars, err := app.GenPackerVars(config, extraVarsPath)

--- a/pkg/app/constants.go
+++ b/pkg/app/constants.go
@@ -16,7 +16,7 @@ const (
 	DefaultBuildName = "provision_build"
 
 	GPUTypesKey      = "/gpu/types"
-	GPUNvidiaVersion = "/nvidia_cuda_version"
+	GPUNvidiaVersion = "/nvidia_driver_version"
 
 	KubernetesVersionKey       = "kubernetes_version"
 	KubernetesFullVersionKey   = "kubernetes_full_version"


### PR DESCRIPTION
**What problem does this PR solve?**:

Fixes override files for nvidia by removing unnecessary "nvidia_cuda_version" with a more detailed version of what the driver value should be 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
