### PR TITLE
build: enable Nvidia offline for rhel 8.6

### DIFF
--- a/make/ci.mk
+++ b/make/ci.mk
@@ -55,6 +55,8 @@ e2e.build.rhel-8.4-offline-fips: rhel84-fips-offline infra.aws.destroy
 
 e2e.build.rhel-8.4-offline-nvidia: rhel84-offline-nvidia infra.aws.destroy
 
+e2e.build.rhel-8.6-offline-nvidia: rhel86-offline-nvidia infra.aws.destroy
+
 e2e.build.rhel-8.6-offline-fips: rhel86-fips-offline infra.aws.destroy
 
 e2e.build.ubuntu-18: ubuntu18

--- a/make/images.mk
+++ b/make/images.mk
@@ -451,6 +451,10 @@ rhel86-offline:
 rhel86-fips-offline:
 	$(MAKE) aws-rhel-8.6_offline-fips
 
+.PHONY: rhel86-offline-nvidia
+rhel86-offline-nvidia:
+	$(MAKE) aws-rhel-8.6_offline-nvidia
+
 # RHEL 8 Azure
 .PHONY: rhel84-azure
 rhel84-azure:


### PR DESCRIPTION
**What problem does this PR solve?**:
This allows for the makefile targets to build rhel 8.6 offline gpu and also fixes building for rhel.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-92651)
-->
* https://jira.d2iq.com/browse/D2IQ-92651


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
