### PR TITLE
fix: add image_name and kubernetes_version to all infrastructure's outtput manifest.yaml

### DIFF
--- a/pkg/packer/manifests/azure/packer.json.tmpl
+++ b/pkg/packer/manifests/azure/packer.json.tmpl
@@ -237,7 +237,8 @@
         "kubernetes_cni_version": "{{user `kubernetes_cni_semver`}}",
         "kubernetes_version": "{{user `kubernetes_full_version`}}",
         "distribution": "{{user `distribution`}}",
-        "distribution_version": "{{user `distribution_version`}}"
+        "distribution_version": "{{user `distribution_version`}}",
+        "compute_gallery_image_id": "/subscriptions/{{user `subscription_id`}}/resourceGroups/{{user `resource_group_name`}}/providers/Microsoft.Compute/galleries/{{user `shared_image_gallery_name`}}/images/{{user `gallery_image_name`}}/versions/{{user `shared_image_gallery_image_version`}}"
       }
     }
   ]

--- a/pkg/packer/manifests/vsphere/packer.json.tmpl
+++ b/pkg/packer/manifests/vsphere/packer.json.tmpl
@@ -91,7 +91,6 @@
         "build_date": "{{isotime}}",
         "build_name": "{{user `build_name`}}",
         "build_timestamp": "{{user `build_timestamp`}}",
-        "build_type": "node",
         "containerd_version": "{{user `containerd_version`}}",
         "custom_role": "{{user `custom_role`}}",
         "disk_size": "{{user `disk_size`}}",
@@ -104,12 +103,12 @@
         "gpu_types": "{{user `gpu_types`}}",
         "guest_os_type": "{{user `guest_os_type`}}",
         "ib_version": "{{user `ib_version`}}",
-        "kubernetes_cni_semver": "{{user `kubernetes_cni_semver`}}",
-        "kubernetes_semver": "{{user `kubernetes_semver`}}",
-        "kubernetes_source_type": "{{user `kubernetes_source_type`}}",
-        "kubernetes_typed_version": "{{user `kubernetes_typed_version`}}",
+        "kubernetes_cni_version": "{{user `kubernetes_cni_semver`}}",
+        "kubernetes_version": "{{user `kubernetes_full_version`}}",
         "os_name": "{{user `os_display_name`}}",
-        "vsphere_guest_os_type": "{{user `vsphere_guest_os_type`}}"
+        "vsphere_guest_os_type": "{{user `vsphere_guest_os_type`}}",
+        "distribution": "{{user `distribution`}}",
+        "distribution_version": "{{user `distribution_version`}}"
       },
       "output": "{{user `manifest_output`}}",
       "strip_path": true


### PR DESCRIPTION
**What problem does this PR solve?**:
- adds `kubernetes_version` to vsphere `manifest.json` 
- adds `compute_gallery_image_id` for azure `manifest.json`
- remove unused custom output fields from vsphere manifest.json

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-93782)
-->
* https://d2iq.atlassian.net/browse/D2IQ-93782
