### PR TITLE
fix: fips.configure default value

### DIFF
--- a/ansible/roles/fips/tasks/main.yaml
+++ b/ansible/roles/fips/tasks/main.yaml
@@ -5,4 +5,4 @@
     - ansible_distribution == 'RedHat'
     - ansible_distribution_version is version('8.1', '>')
     - fips.enabled
-    - fips.configure
+    - fips.configure | default(False)


### PR DESCRIPTION
**What problem does this PR solve?**:
This is need because the `fips.enabled` in `override/fips.yaml` key overrides the whole fips map, removing `fips.configure`

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
