### PR TITLE
fix: always set feature flag

### DIFF
--- a/ansible/roles/providers/tasks/misc.yml
+++ b/ansible/roles/providers/tasks/misc.yml
@@ -57,7 +57,7 @@
     register: system_cloud_init_cmd
   - name: Set cloud-init version fact
     set_fact:
-      system_cloud_init_version: "{{ system_cloud_init_cmd.stdout | regex_replace('^.*cloud-init\\s(?P<version>\\d+?\\.?\\d+)-.*$', '\\g<version>') }}"
+      system_cloud_init_version: "{{ system_cloud_init_cmd.stdout | regex_replace('^.*cloud-init\\s(?P<version>\\d+?\\.?\\d+)(-.*)?$', '\\g<version>') }}"
   when: ansible_os_family != "Flatcar"
 
 - name: set cloudinit feature flags
@@ -67,7 +67,7 @@
     owner: root
     group: root
     mode: 0644
-  when: ansible_os_family == "Debian" and system_cloud_init_version | float > 20.0
+  when: ansible_os_family == "Debian"
 
 - name: get python3 location for non-debian
   register: python3_version

--- a/ansible/roles/providers/tasks/misc.yml
+++ b/ansible/roles/providers/tasks/misc.yml
@@ -57,7 +57,7 @@
     register: system_cloud_init_cmd
   - name: Set cloud-init version fact
     set_fact:
-      system_cloud_init_version: "{{ system_cloud_init_cmd.stdout | regex_replace('^.*cloud-init\\s(?P<version>\\d+?\\.?\\d+)(-.*)?$', '\\g<version>') }}"
+      system_cloud_init_version: "{{ system_cloud_init_cmd.stdout | regex_replace('^.*cloud-init\\s(?P<version>\\d+?\\.?\\d+)-.*$', '\\g<version>') }}"
   when: ansible_os_family != "Flatcar"
 
 - name: set cloudinit feature flags
@@ -81,7 +81,7 @@
     owner: root
     group: root
     mode: 0644
-  when: ansible_os_family not in ["Debian", "Flatcar"] and system_cloud_init_version is version('20.0', '>')
+  when: ansible_os_family not in ["Debian", "Flatcar"] and system_cloud_init_version | float > 20.0
 
 - name: Ensure chrony is running
   systemd:

--- a/ansible/roles/providers/tasks/misc.yml
+++ b/ansible/roles/providers/tasks/misc.yml
@@ -81,7 +81,7 @@
     owner: root
     group: root
     mode: 0644
-  when: ansible_os_family not in ["Debian", "Flatcar"] and system_cloud_init_version | float > 20.0
+  when: ansible_os_family not in ["Debian", "Flatcar"] and system_cloud_init_version is version('20.0', '>')
 
 - name: Ensure chrony is running
   systemd:


### PR DESCRIPTION
**What problem does this PR solve?**:
https://d2iq.atlassian.net/browse/D2IQ-93868

upstream seems to always sets these flags https://github.com/kubernetes-sigs/image-builder/blob/02df45969409c7f18f2cf7e63b70c4dc0e2fa442/images/capi/ansible/roles/providers/tasks/main.yml#L105

i started vm with ubuntu 20.04 and ran cloud-init version 

```bash
root@ip-10-0-122-187:/var/snap/amazon-ssm-agent/6312# cloud-init --version
/usr/bin/cloud-init 22.3.4-0ubuntu1~20.04.1
```

so i also updated the regex and the version comparision command as well.

See this conversation in the kubernetes slack for why we included this version check in the first place https://kubernetes.slack.com/archives/CD6U2V71N/p1629737897163400 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
