### PR TITLE
Fix D2IQ-93868

### DIFF
--- a/ansible/molecule/default/molecule.yml
+++ b/ansible/molecule/default/molecule.yml
@@ -10,12 +10,6 @@ platforms:
     region: us-east-1
     instance_type: t3.small
     ssh_user: centos
-  - name: konvoyimage-centos8.3-${USER:-ci}-${HOSTNAME:-local}
-    image_search_name: "CentOS 8.3.2011 x86_64"
-    image_search_owner: "125523088429"
-    region: us-east-1
-    instance_type: t3.small
-    ssh_user: centos
   - name: konvoyimage-flatcar-stable-${USER:-ci}-${HOSTNAME:-local}
     image_search_name: "Flatcar*stable*"
     image_search_owner: "075585003325"
@@ -29,6 +23,30 @@ platforms:
     region: us-east-1
     instance_type: t3.small
     ssh_user: ec2-user
+  - name: konvoyimage-oracle-79-${USER:-ci}-${HOSTNAME:-local}
+    image_search_name: "OL7.9-x86_64-HVM-2020-12-07"
+    image_search_owner: "131827586825"
+    region: us-east-1
+    instance_type: t3.small
+    ssh_user: ec2-user
+  - name: konvoyimage-oracle-84-${USER:-ci}-${HOSTNAME:-local}
+    image_search_name: "OL8.4-x86_64-HVM-2021-05-28"
+    image_search_owner: "131827586825"
+    region: us-east-1
+    instance_type: t3.small
+    ssh_user: ec2-user
+  - name: konvoyimage-ubuntu-18.04-${USER:-ci}-${HOSTNAME:-local}
+    image_search_name: "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server*"
+    image_search_owner: "099720109477"
+    region: us-east-1
+    instance_type: t3.small
+    ssh_user: ubuntu
+  - name: konvoyimage-ubuntu-20.04-${USER:-ci}-${HOSTNAME:-local}
+    image_search_name: "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server*"
+    image_search_owner: "099720109477"
+    region: us-east-1
+    instance_type: t3.small
+    ssh_user: ubuntu
 
 provisioner:
   name: ansible

--- a/ansible/molecule/default/tests/test_default.py
+++ b/ansible/molecule/default/tests/test_default.py
@@ -1,5 +1,5 @@
 import os
-
+import pytest
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
@@ -27,3 +27,46 @@ def test_kubeadm_avail(host):
     # the path is only set on interactive shell. SO lets append it here
     cmd = host.run("bash -c 'PATH=$PATH:/opt/bin type kubeadm'")
     assert cmd.succeeded is True
+
+def test_cloudinit_feature_flags(host):
+    """
+    ubuntu 18.04: does not need the feature flag
+    all other except flatcar: expect feature overrides
+    """
+    distro = host.system_info.distribution
+    release = host.system_info.release
+
+    # for flatcar we can skip
+    if distro == "flatcar":
+        pytest.skip("no changes on flatcar")
+
+    # if cloud-init is lower than 20.0 we can skip
+    cloud_init_version = host.run("cloud-init --version")
+    assert cloud_init_version.succeeded
+
+    cloud_init_version_str = cloud_init_version.stdout.strip('\n')
+    if not cloud_init_version_str:
+        cloud_init_version_str = cloud_init_version.stderr.strip('\n')
+
+    assert cloud_init_version_str
+
+    cloud_init_version_str_version_part = cloud_init_version_str.split(" ")[-1]
+    major_version = cloud_init_version_str_version_part.split(".")[0]
+
+    if int(major_version) < 20:
+        pytest.skip("cloud-init major version ({}) below 20".format(major_version))
+
+    if distro != "ubuntu":
+        cmd = host.run("python3 -c \"import sysconfig; print(sysconfig.get_path('purelib'))\"")
+        assert cmd.succeeded
+
+        featurefile = host.file("{}/cloudinit/feature_overrides.py".format(cmd.stdout.strip('\n')))
+        assert featurefile.exists
+        assert b'ERROR_ON_USER_DATA_FAILURE = False' in featurefile.content
+    # ubuntu 18.04 still supported and no need for this feature flag
+    elif distro == "ubuntu" and not release == "18.04":
+        featurefile = host.file("/usr/lib/python3/dist-packages/cloudinit/feature_overrides.py")
+        assert featurefile.exists
+        assert b'ERROR_ON_USER_DATA_FAILURE = False' in featurefile.content
+    else:
+        assert True

--- a/ansible/roles/providers/tasks/misc.yml
+++ b/ansible/roles/providers/tasks/misc.yml
@@ -57,7 +57,11 @@
     register: system_cloud_init_cmd
   - name: Set cloud-init version fact
     set_fact:
-      system_cloud_init_version: "{{ system_cloud_init_cmd.stdout | regex_replace('^.*cloud-init\\s(?P<version>\\d+?\\.?\\d+)-.*$', '\\g<version>') }}"
+      system_cloud_init_version: "{{ system_cloud_init_cmd.stdout | regex_replace('^.*cloud-init\\s+(\\d+.*)$', '\\1') }}"
+  - name: Set cloud-init version fact from stderr
+    set_fact:
+      system_cloud_init_version: "{{ system_cloud_init_cmd.stderr | regex_replace('^.*cloud-init\\s+(\\d+.*)$', '\\1') }}"
+    when: not system_cloud_init_version
   when: ansible_os_family != "Flatcar"
 
 - name: set cloudinit feature flags
@@ -67,7 +71,7 @@
     owner: root
     group: root
     mode: 0644
-  when: ansible_os_family == "Debian" and system_cloud_init_version | float > 20.0
+  when: ansible_os_family == "Debian" and system_cloud_init_version is version('20.0.0', '>')
 
 - name: get python3 location for non-debian
   register: python3_version
@@ -81,7 +85,7 @@
     owner: root
     group: root
     mode: 0644
-  when: ansible_os_family not in ["Debian", "Flatcar"] and system_cloud_init_version | float > 20.0
+  when: ansible_os_family not in ["Debian", "Flatcar"] and system_cloud_init_version is version('20.0.0', '>')
 
 - name: Ensure chrony is running
   systemd:


### PR DESCRIPTION
**What problem does this PR solve?**:
- feature flags for ubuntu 20.04 not set due to regex and version missmatch. 
- on centos 7.9 no featureflags set due to cloud-init sending version string on stderr 

**Which issue(s) does this PR fix?**:
* https://jira.d2iq.com/browse/D2IQ-93868


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note
fix: cloud-init feature flags where not set on ubuntu 20.04 leading to images not being usable by CAPI
```
