### PR TITLE
chore: use konvoy image wrapper for  build targets 

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -65,6 +65,7 @@ builds:
 
 dockers:
   - dockerfile: Dockerfile.devkit
+    id: docker-devkit
     image_templates:
       - 'mesosphere/konvoy-image-builder:v{{ trimprefix .Version "v" }}-devkit'
     build_flag_templates:
@@ -85,6 +86,7 @@ dockers:
       - 'mesosphere/konvoy-image-builder:v{{ trimprefix .Version "v" }}'
     ids:
       - konvoy-image
+      - docker-devkit
     # NOTE(jkoelker) Exclude `--pull` from the build flags, since the devkit
     #                was just build and is local, it will not be found.
     build_flag_templates:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ FROM alpine:3.15.4
 
 ENV ANSIBLE_PATH=/usr
 ENV PYTHON_PATH=/usr
+ENV PACKER_PLUGIN_PATH=/opt/packer/plugins
 
 COPY requirements.txt /tmp/
 # NOTE(jkoelker) Ignore "Pin versions in [pip | apk add]"
@@ -28,7 +29,7 @@ COPY --from=devkit /usr/local/bin/mindthegap /usr/local/bin/
 COPY --from=devkit /usr/local/bin/packer /usr/local/bin/
 COPY --from=devkit /usr/local/bin/packer-provisioner-goss /usr/local/bin/
 COPY --from=devkit /usr/local/bin/govc /usr/local/bin/
-COPY --from=devkit /root/.config/packer/plugins/ /root/.config/packer/plugins/
+COPY --from=devkit /root/.config/packer/plugins/ ${PACKER_PLUGIN_PATH}
 COPY bin/konvoy-image /usr/local/bin
 COPY images /root/images
 COPY ansible /root/ansible

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ COPY --from=devkit /usr/local/bin/goss /usr/local/bin/
 COPY --from=devkit /usr/local/bin/mindthegap /usr/local/bin/
 COPY --from=devkit /usr/local/bin/packer /usr/local/bin/
 COPY --from=devkit /usr/local/bin/packer-provisioner-goss /usr/local/bin/
+COPY --from=devkit /usr/local/bin/govc /usr/local/bin/
 COPY --from=devkit /root/.config/packer/plugins/ /root/.config/packer/plugins/
 COPY bin/konvoy-image /usr/local/bin
 COPY images /root/images

--- a/Dockerfile.devkit
+++ b/Dockerfile.devkit
@@ -110,14 +110,13 @@ COPY --from=docker /usr/local/bin/docker /usr/local/bin/
 COPY --from=govc /govc /usr/local/bin/
 COPY --from=builder /tools /usr/local/bin
 
-
 RUN getent group "${GROUP_ID}" > /dev/null 2>&1 \
     || addgroup -S -g "${GROUP_ID}" "${GROUP_NAME}"
 
 # NOTE(jkoelker) Ignore "Multiple consecutive `RUN`"
 # hadolint ignore=DL3059
 RUN getent passwd "${USER_ID}" > /dev/null 2>&1 \
-    || adduser -D -u "${USER_ID}" -G "${GROUP_NAME}" "${USER_NAME}"
+    || adduser -D -u "${USER_ID}" -g "${GROUP_ID}" "${USER_NAME}"
 
 # NOTE(jkoelker) Ignore "A && B || C is not if-then-else"
 # NOTE(jkoelker) Ignore "Multiple consecutive `RUN`"

--- a/Makefile
+++ b/Makefile
@@ -403,11 +403,10 @@ define print-target
     @printf "Executing target: \033[36m$@\033[0m\n"
 endef
 
-release-bundle-GOOS: cmd/konvoy-image-wrapper/image/konvoy-image-builder.tar.gz
 release-bundle-GOOS:
-	GOOS=$(GOOS) go build -tags EMBED_DOCKER_IMAGE \
-		-ldflags="-X github.com/mesosphere/konvoy-image-builder/pkg/version.version=$(REPO_REV)" \
-		-o "$(REPO_ROOT_DIR)/dist/bundle/konvoy-image-bundle-$(REPO_REV)_$(GOOS)/konvoy-image" $(REPO_ROOT_DIR)/cmd/konvoy-image-wrapper/main.go
+	$(MAKE) make docker GOOS=$(GOOS) WHAT="go build -tags EMBED_DOCKER_IMAGE \
+		-ldflags='-X github.com/mesosphere/konvoy-image-builder/pkg/version.version=$(REPO_REV)' \
+		-o '$(REPO_ROOT_DIR)/dist/bundle/konvoy-image-bundle-$(REPO_REV)_$(GOOS)/konvoy-image' $(REPO_ROOT_DIR)/cmd/konvoy-image-wrapper/main.go"
 	cp -a "$(REPO_ROOT_DIR)/ansible" "$(REPO_ROOT_DIR)/dist/bundle/konvoy-image-bundle-$(REPO_REV)_$(GOOS)/"
 	cp -a "$(REPO_ROOT_DIR)/goss" "$(REPO_ROOT_DIR)/dist/bundle/konvoy-image-bundle-$(REPO_REV)_$(GOOS)/"
 	cp -a "$(REPO_ROOT_DIR)/images" "$(REPO_ROOT_DIR)/dist/bundle/konvoy-image-bundle-$(REPO_REV)_$(GOOS)/"
@@ -418,6 +417,7 @@ release-bundle-GOOS:
 cmd/konvoy-image-wrapper/image/konvoy-image-builder.tar.gz: $(DOCKER_PHONY_FILE)
 	docker save $(DOCKER_IMG) | gzip -c - > "$(REPO_ROOT_DIR)/cmd/konvoy-image-wrapper/image/konvoy-image-builder.tar.gz"
 
+release-bundle: cmd/konvoy-image-wrapper/image/konvoy-image-builder.tar.gz
 release-bundle:
 	$(MAKE) GOOS=linux release-bundle-GOOS
 	$(MAKE) GOOS=windows release-bundle-GOOS

--- a/Makefile
+++ b/Makefile
@@ -259,9 +259,9 @@ bin/konvoy-image:
 bin/konvoy-image-wrapper: $(DOCKER_PHONY_FILE)
 bin/konvoy-image-wrapper: 
 	$(call print-target)
-	go build \
+	$(MAKE) docker WHAT="go build \
 		-ldflags='-X github.com/mesosphere/konvoy-image-builder/pkg/version.version=$(REPO_REV)' \
-		-o ./bin/konvoy-image-wrapper ./cmd/konvoy-image-wrapper/main.go
+		-o ./bin/konvoy-image-wrapper ./cmd/konvoy-image-wrapper/main.go"
 
 dist/konvoy-image_linux_amd64/konvoy-image: $(REPO_ROOT_DIR)/cmd
 dist/konvoy-image_linux_amd64/konvoy-image: $(shell find $(REPO_ROOT_DIR)/cmd -type f -name '*'.go)

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ INVENTORY_FILE ?= $(REPO_ROOT_DIR)/inventory.yaml
 COMMA:=,
 
 export CGO_ENABLED=0
-export GO_VERSION := 1.19 #$(shell grep -oP '^(go )\K(\d+.\d+)$$' go.mod)
+export GO_VERSION := $(shell grep -oP '^(go )\K(\d+.\d+)$$' go.mod)
 GOLANG_IMAGE := golang:$(GO_VERSION)
 
 export CI ?= no

--- a/Makefile
+++ b/Makefile
@@ -180,8 +180,8 @@ $(DOCKER_DEVKIT_PHONY_FILE): Dockerfile.devkit
 	&& touch $(DOCKER_DEVKIT_PHONY_FILE)
 
 $(DOCKER_PHONY_FILE): $(DOCKER_DEVKIT_PHONY_FILE)
+$(DOCKER_PHONY_FILE): konvoy-image-linux
 $(DOCKER_PHONY_FILE): Dockerfile
-	$(MAKE) docker WHAT="GOOS=linux make bin/konvoy-image"
 	docker build \
 		--file $(REPO_ROOT_DIR)/Dockerfile \
 		--tag "$(DOCKER_IMG)" \
@@ -255,6 +255,9 @@ bin/konvoy-image:
 	go build \
 		-ldflags='-X github.com/mesosphere/konvoy-image-builder/pkg/version.version=$(REPO_REV)' \
 		-o ./bin/konvoy-image ./cmd/konvoy-image/main.go
+
+konvoy-image-linux:
+	$(MAKE) docker GOOS=linux WHAT="make bin/konvoy-image"
 
 bin/konvoy-image-wrapper: $(DOCKER_PHONY_FILE)
 bin/konvoy-image-wrapper: 

--- a/README.md
+++ b/README.md
@@ -102,25 +102,11 @@ make build
 
 ### Building the Wrapper
 
-These are temporary instructions for building the wrapper for testing
+To build the wrapper for testing. 
 
 ```sh
-make build.snapshot
+make build-wrapper
 ```
-
-Replace image tag with the version created by go releaser
-
-```sh
-docker save mesosphere/konvoy-image-builder:v1.0.0-alpha1-SNAPSHOT-e590962 \
- | gzip -c - > cmd/konvoy-image-wrapper/image/konvoy-image-builder.tar.gz
-```
-
-Build the wrapper
-
-```sh
-go build -tags EMBED_DOCKER_IMAGE \
- -ldflags="-X github.com/mesosphere/konvoy-image-builder/pkg/version.version=v1.0.0-alpha1-SNAPSHOT-e590962" \
- -o ./bin/konvoy-image-wrapper ./cmd/konvoy-image-wrapper/main.go
-```
+creates `./bin/konvoy-image-wrapper` binary for testing using konvoy image wrapper. 
 
 For further development, see the [Dev Docs](docs/dev).

--- a/README.md
+++ b/README.md
@@ -102,11 +102,11 @@ make build
 
 ### Building the Wrapper
 
-To build the wrapper for testing. 
+To build the wrapper for testing.
 
 ```sh
 make build-wrapper
 ```
-creates `./bin/konvoy-image-wrapper` binary for testing using konvoy image wrapper. 
+creates `./bin/konvoy-image-wrapper` binary for testing using konvoy image wrapper.
 
 For further development, see the [Dev Docs](docs/dev).

--- a/cmd/konvoy-image-wrapper/cmd/wrapper.go
+++ b/cmd/konvoy-image-wrapper/cmd/wrapper.go
@@ -55,6 +55,7 @@ const (
 	envNoProxy    = "NO_PROXY"
 
 	containerWorkingDir = "/tmp/kib"
+	windows             = "windows"
 )
 
 var ErrEnv = errors.New("manifest not support")
@@ -282,15 +283,10 @@ func (r *Runner) dockerRun(args []string) error {
 		"-w", containerWorkingDir,
 	)
 
-	r.addBindVolume(r.workingDir, containerWorkingDir)
-
-	if runtime.GOOS != "windows" {
+	if runtime.GOOS != windows {
 		cmd.Args = append(cmd.Args, "-u", r.usr.Uid+":"+r.usr.Gid)
 
-		r.addBindVolume(r.tempDir+"/passwd", "/etc/passwd")
-		r.addBindVolume(r.tempDir+"/group", "/etc/group")
 		r.addBindVolume(r.homeDir, r.homeDir)
-		r.addBindVolume(r.tempDir+"/ssh_known_hosts", r.usr.HomeDir+"/.ssh/known_hosts")
 	}
 
 	for _, gid := range r.supplementaryGroupIDs {
@@ -360,6 +356,9 @@ func (r *Runner) checkRequirements() error {
 }
 
 func (r *Runner) setUserMapping() error {
+	if runtime.GOOS == windows {
+		return nil
+	}
 	filePath := filepath.Join(r.tempDir, "passwd")
 	content := fmt.Sprintf(
 		"%s:!:%s:%s::%s:/bin/sh\n",
@@ -369,10 +368,17 @@ func (r *Runner) setUserMapping() error {
 		r.homeDir,
 	)
 	//nolint:gosec // file must be world readable
-	return os.WriteFile(filePath, []byte(content), 0o644)
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		return err
+	}
+	r.addBindVolume(filePath, "/etc/passwd")
+	return nil
 }
 
 func (r *Runner) setGroupMapping() error {
+	if runtime.GOOS == windows {
+		return nil
+	}
 	filePath := filepath.Join(r.tempDir, "group")
 
 	// Default to "konvoy" as the group name in the container.
@@ -387,13 +393,20 @@ func (r *Runner) setGroupMapping() error {
 		r.usr.Gid,
 	)
 	//nolint:gosec // file must be world readable
-	return os.WriteFile(filePath, []byte(content), 0o644)
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		return err
+	}
+	r.addBindVolume(filePath, "/etc/group")
+	return nil
 }
 
 // Mask the ssh config from the host. The ssh config format on OSX is
 // slightly different than that in Linux, which will cause Ansible to
 // fail sometimes.
 func (r *Runner) maskSSHConfig() error {
+	if runtime.GOOS == windows {
+		return nil
+	}
 	_, err := os.Stat(r.usr.HomeDir + "/.ssh/config")
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -416,6 +429,21 @@ func (r *Runner) maskSSHConfig() error {
 
 	r.addBindVolume(r.tempDir+"/ssh_config", r.usr.HomeDir+"/.ssh/config")
 
+	return nil
+}
+
+// Mask the ssh known_hosts file from the host.
+// This will prevent multiple runs from interfering with each other when targeting hosts with the same IPs.
+func (r *Runner) maskSSHKnownHosts() error {
+	if runtime.GOOS == windows {
+		return nil
+	}
+	f, err := os.Create(filepath.Join(r.tempDir, "ssh_known_hosts"))
+	if err != nil {
+		return err
+	}
+	f.Close()
+	r.addBindVolume(f.Name(), r.usr.HomeDir+"/.ssh/known_hosts")
 	return nil
 }
 
@@ -442,6 +470,7 @@ func (r *Runner) Run(args []string) error {
 	if err != nil {
 		return err
 	}
+	r.addBindVolume(r.workingDir, containerWorkingDir)
 
 	// Create a temporary dir to hold some files that need to be mounted to the container,
 	// eg. /etc/passwd, /etc/group, etc.
@@ -467,13 +496,10 @@ func (r *Runner) Run(args []string) error {
 		return err
 	}
 
-	// Mask the ssh known_hosts file from the host.
-	// This will prevent multiple runs from interfering with each other when targeting hosts with the same IPs.
-	f, err := os.Create(filepath.Join(r.tempDir, "ssh_known_hosts"))
+	err = r.maskSSHKnownHosts()
 	if err != nil {
 		return err
 	}
-	f.Close()
 
 	err = r.setAWSEnv()
 	if err != nil {

--- a/cmd/konvoy-image-wrapper/cmd/wrapper.go
+++ b/cmd/konvoy-image-wrapper/cmd/wrapper.go
@@ -201,6 +201,7 @@ func (r *Runner) setVSphereEnv() error {
 }
 
 func (r *Runner) setGCPEnv() error {
+	// mount same path as the host path set by GOOGLE_APPLICATION_CREDENTIALS environment variable.
 	return r.mountFileEnv(envGCPApplicationCredentials, "")
 }
 

--- a/cmd/konvoy-image-wrapper/cmd/wrapper.go
+++ b/cmd/konvoy-image-wrapper/cmd/wrapper.go
@@ -214,9 +214,11 @@ func (r *Runner) mountFileEnv(envName string, containerPath string) error {
 	fi, err := os.Stat(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return fmt.Errorf("env %s is set, but file %s does not exist", envName, filePath)
+			// Ignore if file does not exists
+			// The wrapper is common for all the provider so validation of the provider specific env variable should be moved to its subcommand
+			return nil
 		}
-		return fmt.Errorf("could not determine if file %q assigned to %s environment variable exists: %w", filePath, envName, err)
+		return fmt.Errorf("error accessing file %q assigned to %s environment variable %w", filePath, envName, err)
 	}
 
 	if fi.IsDir() {

--- a/cmd/konvoy-image-wrapper/cmd/wrapper_test.go
+++ b/cmd/konvoy-image-wrapper/cmd/wrapper_test.go
@@ -78,15 +78,6 @@ func Test_mountFileEnv(t *testing.T) {
 		})
 	}
 
-	// test invalid path
-	t.Run("error on invalid path", func(t *testing.T) {
-		g := NewGomegaWithT(t)
-		t.Setenv("TEST_INVALID_PATH", "/path/doesnot/exists")
-		r := NewRunner()
-		err := r.mountFileEnv("TEST_INVALID_PATH", "")
-		g.Expect(err).ToNot(BeNil())
-	})
-
 	// test path set to dir
 	t.Run("error on path set to dir", func(t *testing.T) {
 		g := NewGomegaWithT(t)

--- a/cmd/konvoy-image-wrapper/main.go
+++ b/cmd/konvoy-image-wrapper/main.go
@@ -11,5 +11,6 @@ func main() {
 	err := cmd.NewRunner().Run(os.Args[1:])
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error encountered: %s\n", err)
+		os.Exit(1)
 	}
 }

--- a/cmd/konvoy-image/cmd/gcp.go
+++ b/cmd/konvoy-image/cmd/gcp.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 
@@ -12,6 +15,11 @@ var (
 	gcpUse     = "gcp <image.yaml>"
 )
 
+const (
+	//nolint:gosec // environment var set by user
+	envGCPApplicationCredentials = "GOOGLE_APPLICATION_CREDENTIALS"
+)
+
 func NewGCPBuildCmd() *cobra.Command {
 	flags := &buildCLIFlags{}
 	cmd := &cobra.Command{
@@ -19,6 +27,21 @@ func NewGCPBuildCmd() *cobra.Command {
 		Short:   "build and provision gcp images",
 		Example: gcpExample,
 		Args:    cobra.ExactArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			filePath, found := os.LookupEnv(envGCPApplicationCredentials)
+			if !found {
+				return fmt.Errorf("envornment variable %s is not set", envGCPApplicationCredentials)
+			}
+			_, err := os.Stat(filePath)
+			if err != nil {
+				return fmt.Errorf(
+					"could not determine if file %q assigned to %s environment variable exists: %w",
+					filePath,
+					envGCPApplicationCredentials,
+					err)
+			}
+			return nil
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			runBuild(args[0], flags)
 		},

--- a/make/ci.mk
+++ b/make/ci.mk
@@ -36,7 +36,7 @@ ci.e2e.build.all: ci.e2e.build.rhel-7.9-ova
 
 # Run an E2E test in its own devkit container.
 ci.e2e.build.%:
-	make devkit.run WHAT="make e2e.build.$* ADDITIONAL_OVERRIDES=$(ADDITIONAL_OVERRIDES) VERBOSITY=$(VERBOSITY) ADDITIONAL_ARGS=$(ADDITIONAL_ARGS)"
+	$(MAKE) e2e.build.$* ADDITIONAL_OVERRIDES=$(ADDITIONAL_OVERRIDES) VERBOSITY=$(VERBOSITY) ADDITIONAL_ARGS=$(ADDITIONAL_ARGS)
 
 # AWS
 e2e.build.centos-7: centos7

--- a/make/images.mk
+++ b/make/images.mk
@@ -151,11 +151,11 @@ build-%:
 		download-os-packages-bundle
 	$(MAKE) pip-packages-artifacts
 	$(MAKE) bundle_suffix= download-images-bundle
-	$(MAKE) devkit.run WHAT="make build-$* \
+	$(MAKE) build-$* \
 		BUILD_DRY_RUN=$(BUILD_DRY_RUN) \
 		VERBOSITY=$(VERBOSITY) \
 		ADDITIONAL_ARGS=\"$(ADDITIONAL_ARGS)\" \
-		ADDITIONAL_OVERRIDES=overrides/offline.yaml,packer-$(call provider, $*)-offline-override.yaml$(if $(ADDITIONAL_OVERRIDES),$(COMMA)$(ADDITIONAL_OVERRIDES))"
+		ADDITIONAL_OVERRIDES=overrides/offline.yaml,packer-$(call provider, $*)-offline-override.yaml$(if $(ADDITIONAL_OVERRIDES),$(COMMA)$(ADDITIONAL_OVERRIDES))
 
 .PHONY: %_offline-fips
 %_offline-fips:
@@ -169,11 +169,11 @@ build-%:
 		download-os-packages-bundle
 	$(MAKE) pip-packages-artifacts
 	$(MAKE) download-images-bundle bundle_suffix=$$( if [ $$(echo "$(DEFAULT_KUBERNETES_VERSION_SEMVER)" | cut -f2 -d.) -lt 24 ];then echo "_fips"; else echo "-fips";fi )
-	$(MAKE) devkit.run WHAT="make $*_fips \
+	$(MAKE) $*_fips \
 		BUILD_DRY_RUN=${BUILD_DRY_RUN} \
 		VERBOSITY=$(VERBOSITY) \
 		ADDITIONAL_ARGS=\"$(ADDITIONAL_ARGS)\" \
-		ADDITIONAL_OVERRIDES=overrides/offline-fips.yaml,packer-$(call provider,$*)-offline-override.yaml$(if $(ADDITIONAL_OVERRIDES),$(COMMA)${ADDITIONAL_OVERRIDES})"
+		ADDITIONAL_OVERRIDES=overrides/offline-fips.yaml,packer-$(call provider,$*)-offline-override.yaml$(if $(ADDITIONAL_OVERRIDES),$(COMMA)${ADDITIONAL_OVERRIDES})
 
 .PHONY: %_offline-nvidia
 %_offline-nvidia:
@@ -187,11 +187,11 @@ build-%:
 	$(MAKE) download-nvidia-runfile
 	$(MAKE) pip-packages-artifacts
 	$(MAKE) download-images-bundle
-	$(MAKE) devkit.run WHAT="make build-$* \
+	$(MAKE) make build-$* \
 		BUILD_DRY_RUN=${BUILD_DRY_RUN} \
 		VERBOSITY=$(VERBOSITY) \
 		ADDITIONAL_ARGS="--instance-type=g4dn.2xlarge$(if $(ADDITIONAL_ARGS),$(SPACE)$(ADDITIONAL_ARGS))" \
-		ADDITIONAL_OVERRIDES=overrides/offline.yaml,overrides/offline-nvidia.yaml,packer-$(call provider,$*)-offline-override.yaml$(if $(ADDITIONAL_OVERRIDES),$(COMMA)${ADDITIONAL_OVERRIDES})"
+		ADDITIONAL_OVERRIDES=overrides/offline.yaml,overrides/offline-nvidia.yaml,packer-$(call provider,$*)-offline-override.yaml$(if $(ADDITIONAL_OVERRIDES),$(COMMA)${ADDITIONAL_OVERRIDES})
 
 .PHONY: %_nvidia
 %_nvidia:

--- a/make/images.mk
+++ b/make/images.mk
@@ -17,6 +17,8 @@ ARTIFACTS_DIR ?= artifacts/
 CONTAINERD_URL ?= https://packages.d2iq.com/dkp/containerd
 NVIDIA_URL ?= https://download.nvidia.com/XFree86/Linux-x86_64
 
+KONVOY_IMAGE_BIN ?= ./bin/konvoy-image-wrapper
+
 NVIDIA_DRIVER_VERSION ?= $(shell \
 	grep -E -e "nvidia_driver_version:" ansible/group_vars/all/defaults.yaml | \
 	cut -d\" -f2 \
@@ -104,12 +106,11 @@ azure-build-image-cleanup: ;
 
 # NOTE(jkoelker) The common build target every other target ends up calling.
 .PHONY: build-image
-build-image: build
+build-image: $(KONVOY_IMAGE_BIN)
 build-image: $(IMAGE)
 build-image: ## Build an image on a provider
-	./bin/konvoy-image build $(subst ova,,$(PROVIDER)) $(IMAGE) \
+	$(KONVOY_IMAGE_BIN) build $(subst ova,,$(PROVIDER)) $(IMAGE) \
 	--dry-run=$(BUILD_DRY_RUN) \
-	--packer-on-error abort \
 	-v ${VERBOSITY} \
 	$(if $(ADDITIONAL_OVERRIDES),--overrides=$(ADDITIONAL_OVERRIDES)) \
 	$(call vm_size,$(PROVIDER),$(ADDITIONAL_ARGS)) \

--- a/test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl
+++ b/test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl
@@ -7,7 +7,7 @@
 packer:
   ssh_bastion_username: "${SSH_BASTION_USERNAME}"
   ssh_bastion_host: "${SSH_BASTION_HOST}"
-  ssh_bastion_private_key_file: /kib/vsphere-tests.pem
+  ssh_bastion_private_key_file: vsphere-tests.pem
   cluster: "zone1"
   datacenter: "dc1"
   datastore: "ovh-nfs"


### PR DESCRIPTION
**What problem does this PR solve?**:
- Use konvoy image wrapper binary as default for all CI build targets (TC configuration does not needs to be changed)
  - This will make the CI runs same as how production users would use KIB
- Remove using `konvoy-image` binary for running image build targets
- Replace direct use of `devkit` container to run `konvoy-image` binary. 
- Refactor `wrapper.go` (first pass) to better organize code
- start using `make build-wrapper` instead of `make build` for development. All dependency required for building wrapper will be handled by Makefile targets automatically. 
- **Enable running konvoy-image command on Mac without Sudo access, hacking Makefile, changing file permissions,  propagating env variables to sudo etc**

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
**feature enhancements:**
-  remove direct use of `devkit` container. use `devkit` container only as a base for building konvoy-image docker image.
- make `devkit` container "static" and upload to DockerHub instead of building it all the time.
- refactor `wrapper.go` file one more time to reduce boilerplate code
- Move all build target to use `goreleaser` to make sure same mechanism is used for development, CI and creating releases. 

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
