### PR TITLE
fix: Can not specify custom Packer directory 

### DIFF
--- a/images/ami/rhel-82.yaml
+++ b/images/ami/rhel-82.yaml
@@ -1,12 +1,12 @@
 download_images: true
 
 packer:
-  # ami_filter_name: "RHEL-8.2.0*2020*-x86_64-*"
-  # ami_filter_owners: "309956199498"
+  ami_filter_name: "RHEL-8.2.0*2020*-x86_64-*"
+  ami_filter_owners: "309956199498"
   ami_filter_name: 
   distribution: "RHEL"
   distribution_version: "8.2"
-  source_ami: "ami-0f6fa84b9ae33698d"
+  source_ami: ""
   ssh_username: "ec2-user"
   root_device_name: "/dev/sda1"
   volume_size: "15"

--- a/images/ami/rhel-82.yaml
+++ b/images/ami/rhel-82.yaml
@@ -3,7 +3,6 @@ download_images: true
 packer:
   ami_filter_name: "RHEL-8.2.0*2020*-x86_64-*"
   ami_filter_owners: "309956199498"
-  ami_filter_name: 
   distribution: "RHEL"
   distribution_version: "8.2"
   source_ami: ""

--- a/images/ami/rhel-82.yaml
+++ b/images/ami/rhel-82.yaml
@@ -9,7 +9,6 @@ packer:
   ssh_username: "ec2-user"
   root_device_name: "/dev/sda1"
   volume_size: "15"
-  remote_folder: "/home/ec2-user"
 
 build_name: "rhel-8.2"
 packer_builder_type: "amazon"

--- a/images/ami/rhel-82.yaml
+++ b/images/ami/rhel-82.yaml
@@ -1,14 +1,16 @@
 download_images: true
 
 packer:
-  ami_filter_name: "RHEL-8.2.0*2020*-x86_64-*"
-  ami_filter_owners: "309956199498"
+  # ami_filter_name: "RHEL-8.2.0*2020*-x86_64-*"
+  # ami_filter_owners: "309956199498"
+  ami_filter_name: 
   distribution: "RHEL"
   distribution_version: "8.2"
-  source_ami: ""
+  source_ami: "ami-0f6fa84b9ae33698d"
   ssh_username: "ec2-user"
   root_device_name: "/dev/sda1"
   volume_size: "15"
+  remote_folder: "/home/ec2-user"
 
 build_name: "rhel-8.2"
 packer_builder_type: "amazon"

--- a/pkg/packer/manifests/aws/packer.json.tmpl
+++ b/pkg/packer/manifests/aws/packer.json.tmpl
@@ -26,7 +26,7 @@
     "kubernetes_full_version": "",
     "manifest_output": "manifest.json",
     "python_path": "",
-    "remote_folder": "",
+    "remote_folder": "/tmp",
     "security_group_id":  "",
     "ssh_bastion_host": "{{ user `ssh_bastion_host`}}",
     "ssh_bastion_username": "{{ user `ssh_bastion_username`}}",
@@ -201,7 +201,8 @@
       "playbook_file": "./ansible/provision.yaml",
       "user": "{{user `ssh_username`}}",
       "ansible_env_vars": [
-        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes -o HostkeyAlgorithms=+ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa'"
+        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes -o HostkeyAlgorithms=+ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa'",
+        "ANSIBLE_REMOTE_TEMP='{{user `remote_folder` }}/.ansible/'"
       ],
       "extra_arguments": [
         "--extra-vars",

--- a/pkg/packer/manifests/aws/packer.json.tmpl
+++ b/pkg/packer/manifests/aws/packer.json.tmpl
@@ -213,13 +213,13 @@
       "type": "shell",
       "remote_folder":"{{user `remote_folder`}}",
       "inline": [
-        "mkdir -p ~/.goss-dir"
+        "mkdir -p {{user `remote_folder` }}/.goss-dir"
       ]
     },
     {
         "type": "file",
         "source": "/usr/local/bin/goss",
-        "destination": "~/.goss-dir/goss",
+        "destination": "{{user `remote_folder` }}/.goss-dir/goss",
         "direction": "upload",
         "max_retries": 10
     },
@@ -230,7 +230,7 @@
       "goss_file": "{{user `goss_entry_file`}}",
       "inspect": "{{user `goss_inspect_mode`}}",
       "skip_install": true,
-      "download_path": "~/.goss-dir/goss",
+      "download_path": "{{user `remote_folder` }}/.goss-dir/goss",
       "type": "goss",
       "tests": [
         "{{user `goss_tests_dir`}}"
@@ -257,7 +257,7 @@
       "type": "shell",
       "remote_folder":"{{user `remote_folder`}}",
       "inline": [
-        "rm -r  ~/.goss-dir"
+        "rm -r  {{user `remote_folder` }}/.goss-dir"
       ]
     }
   ],

--- a/pkg/packer/manifests/aws/packer.json.tmpl
+++ b/pkg/packer/manifests/aws/packer.json.tmpl
@@ -26,6 +26,7 @@
     "kubernetes_full_version": "",
     "manifest_output": "manifest.json",
     "python_path": "",
+    "remote_folder": "",
     "security_group_id":  "",
     "ssh_bastion_host": "{{ user `ssh_bastion_host`}}",
     "ssh_bastion_username": "{{ user `ssh_bastion_username`}}",
@@ -122,6 +123,7 @@
   "provisioners": [
     {
       "type": "shell",
+      "remote_folder":"{{user `remote_folder`}}",
       "environment_vars": [
         "HTTP_PROXY={{user `http_proxy`}}",
         "http_proxy={{user `http_proxy`}}",
@@ -139,6 +141,7 @@
     },
     {
       "type": "shell",
+      "remote_folder":"{{user `remote_folder`}}",
       "environment_vars": [
         "HTTP_PROXY={{user `http_proxy`}}",
         "http_proxy={{user `http_proxy`}}",
@@ -153,6 +156,7 @@
     },
     {
       "type": "shell",
+      "remote_folder":"{{user `remote_folder`}}",
       "environment_vars": [
         "HTTP_PROXY={{user `http_proxy`}}",
         "http_proxy={{user `http_proxy`}}",
@@ -167,6 +171,7 @@
     },
     {
       "type": "shell",
+      "remote_folder":"{{user `remote_folder`}}",
       "environment_vars": [
         "BUILD_NAME={{ user `build_name`}}"
       ],
@@ -175,6 +180,7 @@
     },
     {
       "type": "shell",
+      "remote_folder":"{{user `remote_folder`}}",
       "environment_vars": [
         "BUILD_NAME={{build_name}}"
       ],
@@ -183,6 +189,7 @@
     },
     {
       "type": "shell",
+      "remote_folder":"{{user `remote_folder`}}",
       "environment_vars": [
         "BUILD_NAME={{build_name}}"
       ],
@@ -194,8 +201,7 @@
       "playbook_file": "./ansible/provision.yaml",
       "user": "{{user `ssh_username`}}",
       "ansible_env_vars": [
-        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes -o HostkeyAlgorithms=+ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa'",
-        "ANSIBLE_REMOTE_TEMP='/tmp/.ansible/'"
+        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes -o HostkeyAlgorithms=+ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa'"
       ],
       "extra_arguments": [
         "--extra-vars",
@@ -204,14 +210,15 @@
     },
     {
       "type": "shell",
+      "remote_folder":"{{user `remote_folder`}}",
       "inline": [
-        "mkdir -p /tmp/.goss-dir"
+        "mkdir -p ~/.goss-dir"
       ]
     },
     {
         "type": "file",
         "source": "/usr/local/bin/goss",
-        "destination": "/tmp/.goss-dir/goss",
+        "destination": "~/.goss-dir/goss",
         "direction": "upload",
         "max_retries": 10
     },
@@ -222,7 +229,7 @@
       "goss_file": "{{user `goss_entry_file`}}",
       "inspect": "{{user `goss_inspect_mode`}}",
       "skip_install": true,
-      "download_path": "/tmp/.goss-dir/goss",
+      "download_path": "~/.goss-dir/goss",
       "type": "goss",
       "tests": [
         "{{user `goss_tests_dir`}}"
@@ -247,8 +254,9 @@
     },
     {
       "type": "shell",
+      "remote_folder":"{{user `remote_folder`}}",
       "inline": [
-        "rm -r  /tmp/.goss-dir"
+        "rm -r  ~/.goss-dir"
       ]
     }
   ],

--- a/pkg/packer/manifests/azure/packer.json.tmpl
+++ b/pkg/packer/manifests/azure/packer.json.tmpl
@@ -27,7 +27,7 @@
     "plan_image_publisher": "",
     "plan_image_sku": "",
     "private_virtual_network_with_public_ip": "",
-    "remote_folder": "",
+    "remote_folder": "/tmp",
     "resource_group_name": "dkp",
     "shared_image_gallery_name": "dkp",
     "shared_image_gallery_image_version": "0.0.{{timestamp}}",
@@ -178,6 +178,7 @@
       "user": "{{user `ssh_username`}}",
       "ansible_env_vars": [
         "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes -o HostkeyAlgorithms=+ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa'",
+        "ANSIBLE_REMOTE_TEMP='{{user `remote_folder` }}/.ansible/'"
       ],
       "extra_arguments": [
         "--extra-vars",

--- a/pkg/packer/manifests/azure/packer.json.tmpl
+++ b/pkg/packer/manifests/azure/packer.json.tmpl
@@ -189,13 +189,13 @@
       "type": "shell",
       "remote_folder":"{{user `remote_folder`}}",
       "inline": [
-        "mkdir -p ~/.goss-dir"
+        "mkdir -p {{user `remote_folder` }}/.goss-dir"
       ]
     },
     {
         "type": "file",
         "source": "/usr/local/bin/goss",
-        "destination": "~/.goss-dir/goss",
+        "destination": "{{user `remote_folder` }}/.goss-dir/goss",
         "direction": "upload",
         "max_retries": 10
     },
@@ -206,7 +206,7 @@
       "goss_file": "{{user `goss_entry_file`}}",
       "inspect": "{{user `goss_inspect_mode`}}",
       "skip_install": true,
-      "download_path": "~/.goss-dir/goss",
+      "download_path": "{{user `remote_folder` }}/.goss-dir/goss",
       "type": "goss",
       "tests": [
         "{{user `goss_tests_dir`}}"
@@ -233,7 +233,7 @@
       "type": "shell",
       "remote_folder":"{{user `remote_folder`}}",
       "inline": [
-        "rm -r  ~/.goss-dir"
+        "rm -r  {{user `remote_folder` }}/.goss-dir"
       ]
     }
   ],

--- a/pkg/packer/manifests/azure/packer.json.tmpl
+++ b/pkg/packer/manifests/azure/packer.json.tmpl
@@ -27,6 +27,7 @@
     "plan_image_publisher": "",
     "plan_image_sku": "",
     "private_virtual_network_with_public_ip": "",
+    "remote_folder": "",
     "resource_group_name": "dkp",
     "shared_image_gallery_name": "dkp",
     "shared_image_gallery_image_version": "0.0.{{timestamp}}",
@@ -98,6 +99,7 @@
   "provisioners": [
     {
       "type": "shell",
+      "remote_folder":"{{user `remote_folder`}}",
       "environment_vars": [
         "HTTP_PROXY={{user `http_proxy`}}",
         "http_proxy={{user `http_proxy`}}",
@@ -115,6 +117,7 @@
     },
     {
       "type": "shell",
+      "remote_folder":"{{user `remote_folder`}}",
       "environment_vars": [
         "HTTP_PROXY={{user `http_proxy`}}",
         "http_proxy={{user `http_proxy`}}",
@@ -129,6 +132,7 @@
     },
     {
       "type": "shell",
+      "remote_folder":"{{user `remote_folder`}}",
       "environment_vars": [
         "HTTP_PROXY={{user `http_proxy`}}",
         "http_proxy={{user `http_proxy`}}",
@@ -143,6 +147,7 @@
     },
     {
       "type": "shell",
+      "remote_folder":"{{user `remote_folder`}}",
       "environment_vars": [
         "BUILD_NAME={{ user `build_name`}}"
       ],
@@ -151,6 +156,7 @@
     },
     {
       "type": "shell",
+      "remote_folder":"{{user `remote_folder`}}",
       "environment_vars": [
         "BUILD_NAME={{build_name}}"
       ],
@@ -159,6 +165,7 @@
     },
     {
       "type": "shell",
+      "remote_folder":"{{user `remote_folder`}}",
       "environment_vars": [
         "BUILD_NAME={{build_name}}"
       ],
@@ -171,7 +178,6 @@
       "user": "{{user `ssh_username`}}",
       "ansible_env_vars": [
         "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes -o HostkeyAlgorithms=+ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa'",
-        "ANSIBLE_REMOTE_TEMP='/tmp/.ansible/'"
       ],
       "extra_arguments": [
         "--extra-vars",
@@ -180,14 +186,15 @@
     },
      {
       "type": "shell",
+      "remote_folder":"{{user `remote_folder`}}",
       "inline": [
-        "mkdir -p /tmp/.goss-dir"
+        "mkdir -p ~/.goss-dir"
       ]
     },
     {
         "type": "file",
         "source": "/usr/local/bin/goss",
-        "destination": "/tmp/.goss-dir/goss",
+        "destination": "~/.goss-dir/goss",
         "direction": "upload",
         "max_retries": 10
     },
@@ -198,7 +205,7 @@
       "goss_file": "{{user `goss_entry_file`}}",
       "inspect": "{{user `goss_inspect_mode`}}",
       "skip_install": true,
-      "download_path": "/tmp/.goss-dir/goss",
+      "download_path": "~/.goss-dir/goss",
       "type": "goss",
       "tests": [
         "{{user `goss_tests_dir`}}"
@@ -223,8 +230,9 @@
     },
     {
       "type": "shell",
+      "remote_folder":"{{user `remote_folder`}}",
       "inline": [
-        "rm -r  /tmp/.goss-dir"
+        "rm -r  ~/.goss-dir"
       ]
     }
   ],

--- a/pkg/packer/manifests/gcp/packer.json.tmpl
+++ b/pkg/packer/manifests/gcp/packer.json.tmpl
@@ -14,6 +14,7 @@
     "network": "",
     "project_id": "",
     "region": "",
+    "remote_folder": "",
     "zone": "{{ user `region` }}-a",
     "disk_size": "80",
     "disk_type": "pd-standard"
@@ -61,6 +62,7 @@
   "provisioners": [
     {
       "type": "shell",
+      "remote_folder":"{{user `remote_folder`}}",
       "environment_vars": [
         "HTTP_PROXY={{user `http_proxy`}}",
         "http_proxy={{user `http_proxy`}}",
@@ -78,6 +80,7 @@
     },
     {
       "type": "shell",
+      "remote_folder":"{{user `remote_folder`}}",
       "environment_vars": [
         "HTTP_PROXY={{user `http_proxy`}}",
         "http_proxy={{user `http_proxy`}}",
@@ -92,6 +95,7 @@
     },
     {
       "type": "shell",
+      "remote_folder":"{{user `remote_folder`}}",
       "environment_vars": [
         "HTTP_PROXY={{user `http_proxy`}}",
         "http_proxy={{user `http_proxy`}}",
@@ -106,6 +110,7 @@
     },
     {
       "type": "shell",
+      "remote_folder":"{{user `remote_folder`}}",
       "environment_vars": [
         "BUILD_NAME={{ user `build_name`}}"
       ],
@@ -114,6 +119,7 @@
     },
     {
       "type": "shell",
+      "remote_folder":"{{user `remote_folder`}}",
       "environment_vars": [
         "BUILD_NAME={{build_name}}"
       ],
@@ -122,6 +128,7 @@
     },
     {
       "type": "shell",
+      "remote_folder":"{{user `remote_folder`}}",
       "environment_vars": [
         "BUILD_NAME={{build_name}}"
       ],
@@ -134,7 +141,6 @@
       "user": "{{user `ssh_username`}}",
       "ansible_env_vars": [
         "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes -o HostkeyAlgorithms=+ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa'",
-        "ANSIBLE_REMOTE_TEMP='/tmp/.ansible/'"
       ],
       "extra_arguments": [
         "--extra-vars",
@@ -143,14 +149,15 @@
     },
     {
       "type": "shell",
+      "remote_folder":"{{user `remote_folder`}}",
       "inline": [
-        "mkdir -p /tmp/.goss-dir"
+        "mkdir -p ~/.goss-dir"
       ]
     },
     {
         "type": "file",
         "source": "/usr/local/bin/goss",
-        "destination": "/tmp/.goss-dir/goss",
+        "destination": "~/.goss-dir/goss",
         "direction": "upload",
         "max_retries": 10
     },
@@ -161,7 +168,7 @@
       "goss_file": "{{user `goss_entry_file`}}",
       "inspect": "{{user `goss_inspect_mode`}}",
       "skip_install": true,
-      "download_path": "/tmp/.goss-dir/goss",
+      "download_path": "~/.goss-dir/goss",
       "type": "goss",
       "tests": [
         "{{user `goss_tests_dir`}}"
@@ -186,8 +193,9 @@
     },
     {
       "type": "shell",
+      "remote_folder":"{{user `remote_folder`}}",
       "inline": [
-        "rm -r  /tmp/.goss-dir"
+        "rm -r  ~/.goss-dir"
       ]
     }
   ],

--- a/pkg/packer/manifests/gcp/packer.json.tmpl
+++ b/pkg/packer/manifests/gcp/packer.json.tmpl
@@ -152,13 +152,13 @@
       "type": "shell",
       "remote_folder":"{{user `remote_folder`}}",
       "inline": [
-        "mkdir -p ~/.goss-dir"
+        "mkdir -p {{user `remote_folder` }}/.goss-dir"
       ]
     },
     {
         "type": "file",
         "source": "/usr/local/bin/goss",
-        "destination": "~/.goss-dir/goss",
+        "destination": "{{user `remote_folder` }}/.goss-dir/goss",
         "direction": "upload",
         "max_retries": 10
     },
@@ -169,7 +169,7 @@
       "goss_file": "{{user `goss_entry_file`}}",
       "inspect": "{{user `goss_inspect_mode`}}",
       "skip_install": true,
-      "download_path": "~/.goss-dir/goss",
+      "download_path": "{{user `remote_folder` }}/.goss-dir/goss",
       "type": "goss",
       "tests": [
         "{{user `goss_tests_dir`}}"
@@ -196,7 +196,7 @@
       "type": "shell",
       "remote_folder":"{{user `remote_folder`}}",
       "inline": [
-        "rm -r  ~/.goss-dir"
+        "rm -r  {{user `remote_folder` }}/.goss-dir"
       ]
     }
   ],

--- a/pkg/packer/manifests/gcp/packer.json.tmpl
+++ b/pkg/packer/manifests/gcp/packer.json.tmpl
@@ -14,7 +14,7 @@
     "network": "",
     "project_id": "",
     "region": "",
-    "remote_folder": "",
+    "remote_folder": "/tmp",
     "zone": "{{ user `region` }}-a",
     "disk_size": "80",
     "disk_type": "pd-standard"
@@ -141,6 +141,7 @@
       "user": "{{user `ssh_username`}}",
       "ansible_env_vars": [
         "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes -o HostkeyAlgorithms=+ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa'",
+        "ANSIBLE_REMOTE_TEMP='{{user `remote_folder` }}/.ansible/'"
       ],
       "extra_arguments": [
         "--extra-vars",

--- a/pkg/packer/manifests/vsphere/packer.json.tmpl
+++ b/pkg/packer/manifests/vsphere/packer.json.tmpl
@@ -24,6 +24,7 @@
     "linked_clone": "true",
     "manifest_output": "manifest.json",
     "memory": "8192",
+    "remote_folder": "",
     "ssh_bastion_host": "{{ user `ssh_bastion_host`}}",
     "ssh_bastion_username": "{{ user `ssh_bastion_username`}}",
     "ssh_bastion_password": "{{ user `ssh_bastion_password`}}",
@@ -134,7 +135,6 @@
       "user": "{{user `ssh_username`}}",
       "ansible_env_vars": [
         "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes -o HostkeyAlgorithms=+ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa'",
-        "ANSIBLE_REMOTE_TEMP='/tmp/.ansible/'"
       ],
       "extra_arguments": [
         "--extra-vars",
@@ -143,14 +143,15 @@
     },
     {
     "type": "shell",
+    "remote_folder":"{{user `remote_folder`}}",
     "inline": [
-      "mkdir -p /tmp/.goss-dir"
+      "mkdir -p ~/.goss-dir"
     ]
     },
     {
         "type": "file",
         "source": "/usr/local/bin/goss",
-        "destination": "/tmp/.goss-dir/goss",
+        "destination": "~/.goss-dir/goss",
         "direction": "upload",
         "max_retries": 10
     },
@@ -161,7 +162,7 @@
     "goss_file": "{{user `goss_entry_file`}}",
     "inspect": "{{user `goss_inspect_mode`}}",
     "skip_install": true,
-    "download_path": "/tmp/.goss-dir/goss",
+    "download_path": "~/.goss-dir/goss",
     "type": "goss",
     "tests": [
       "{{user `goss_tests_dir`}}"
@@ -186,8 +187,9 @@
     },
     {
       "type": "shell",
+      "remote_folder":"{{user `remote_folder`}}",
       "inline": [
-        "rm -r  /tmp/.goss-dir"
+        "rm -r  ~/.goss-dir"
       ]
     }
   ]

--- a/pkg/packer/manifests/vsphere/packer.json.tmpl
+++ b/pkg/packer/manifests/vsphere/packer.json.tmpl
@@ -146,13 +146,13 @@
     "type": "shell",
     "remote_folder":"{{user `remote_folder`}}",
     "inline": [
-      "mkdir -p ~/.goss-dir"
+      "mkdir -p {{user `remote_folder` }}/.goss-dir"
     ]
     },
     {
         "type": "file",
         "source": "/usr/local/bin/goss",
-        "destination": "~/.goss-dir/goss",
+        "destination": "{{user `remote_folder` }}/.goss-dir/goss",
         "direction": "upload",
         "max_retries": 10
     },
@@ -163,7 +163,7 @@
     "goss_file": "{{user `goss_entry_file`}}",
     "inspect": "{{user `goss_inspect_mode`}}",
     "skip_install": true,
-    "download_path": "~/.goss-dir/goss",
+    "download_path": "{{user `remote_folder` }}/.goss-dir/goss",
     "type": "goss",
     "tests": [
       "{{user `goss_tests_dir`}}"
@@ -190,7 +190,7 @@
       "type": "shell",
       "remote_folder":"{{user `remote_folder`}}",
       "inline": [
-        "rm -r  ~/.goss-dir"
+        "rm -r  {{user `remote_folder` }}/.goss-dir"
       ]
     }
   ]

--- a/pkg/packer/manifests/vsphere/packer.json.tmpl
+++ b/pkg/packer/manifests/vsphere/packer.json.tmpl
@@ -24,7 +24,7 @@
     "linked_clone": "true",
     "manifest_output": "manifest.json",
     "memory": "8192",
-    "remote_folder": "",
+    "remote_folder": "/tmp",
     "ssh_bastion_host": "{{ user `ssh_bastion_host`}}",
     "ssh_bastion_username": "{{ user `ssh_bastion_username`}}",
     "ssh_bastion_password": "{{ user `ssh_bastion_password`}}",
@@ -135,6 +135,7 @@
       "user": "{{user `ssh_username`}}",
       "ansible_env_vars": [
         "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes -o HostkeyAlgorithms=+ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa'",
+        "ANSIBLE_REMOTE_TEMP='{{user `remote_folder` }}/.ansible/'"
       ],
       "extra_arguments": [
         "--extra-vars",


### PR DESCRIPTION
**What problem does this PR solve?**:
This PR supports packer provisioning with STIG requirements by using the `remote_folder` parameter in packer to override the default `/tmp` directory.

**Which issue(s) does this PR fix?**:
* https://jira.d2iq.com/browse/D2IQ-93657/


**Special notes for your reviewer**:
- @supershal and I tested using a custom `source_ami` image in `rhel-82.yaml` where we remounted the `/tmp` directory with the `noexec` flag to match STIG requirements. We also commented out `ami_filter_name` and `ami_filter_owners`.