### PR TITLE
fix: always use RHEL 7.9 AMI with a known kernel

### DIFF
--- a/images/ami/rhel-79.yaml
+++ b/images/ami/rhel-79.yaml
@@ -1,7 +1,8 @@
 download_images: true
 
 packer:
-  ami_filter_name: "RHEL-7.9*-x86_64-*"
+  # Use an AMI with the supported kernel version 3.10.0-1160.66.1.el7.x86_64
+  ami_filter_name: "RHEL-7.9_HVM-20220512-x86_64-*"
   ami_filter_owners: "309956199498"
   distribution: "RHEL"
   distribution_version: "7.9"


### PR DESCRIPTION
**What problem does this PR solve?**:
The supported version is 3.10.0-1160.66.1.el7.x86_64, ubi-7 repo does not yet have the kernel-devel package thats required for air-gapped nvidia installs.

```
[root@672e072c8e59 /]# yum install kernel-headers-3.10.0-1160.80.1.el7.x86_64 kernel-devel-3.10.0-1160.80.1.el7.x86_64
Loaded plugins: ovl, product-id, search-disabled-repos, subscription-manager

This system is not registered with an entitlement server. You can use subscription-manager to register.

No package kernel-devel-3.10.0-1160.80.1.el7.x86_64 available.
...
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-94041)
-->
* https://d2iq.atlassian.net/browse/D2IQ-94041


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
