### PR TITLE
ci: regenerate release notes when replacing release artifacts

### DIFF
--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -141,6 +141,7 @@ jobs:
           tag: "${{ github.ref_name }}"
           artifacts: konvoy-image-bundle-${{ github.ref_name }}_darwin_amd64.tar.gz,konvoy-image-builder_${{ github.ref_name }}_checksums.txt
           replacesArtifacts: true
+          generateReleaseNotes: true
           token: ${{ secrets.MESOSPHERECI_USER_TOKEN }}
           artifactErrorsFailBuild: true
           allowUpdates: true


### PR DESCRIPTION
**What problem does this PR solve?**:
- regenerate release notes when replacing the release artifacts
The [github action](https://github.com/mesosphere/konvoy-image-builder/blob/main/.github/workflows/release-tag.yaml#L138) for release replaces current released artifact with notarized artifacts, which deletes existing release notes
This fix should regenerate the release notes when replacing artifacts