### PR TITLE
ci: enable debug for goreleaser release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,9 +393,9 @@ diff: ## git diff
 	RES=$$(git status --porcelain) ; if [ -n "$$RES" ]; then echo $$RES && exit 1 ; fi
 
 .PHONY: release
-release: ## goreleaser --rm-dist
+release: ## goreleaser --rm-dist --debug
 	$(call print-target)
-	goreleaser --parallelism=1 --rm-dist
+	goreleaser --parallelism=1 --rm-dist --debug
 
 .PHONY: release-snapshot
 release-snapshot: ## goreleaser --snapshot --rm-dist


### PR DESCRIPTION
**What problem does this PR solve?**:
Enable debugging for goreleaser, should make debugging release failures easier.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
