### PR TITLE
ci: run goreleaser not in a container 

### DIFF
--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -13,6 +13,14 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.ref }}
 
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+           go-version: '1.18.0'
+
+      - name: Download GoReleaser
+        run: go install github.com/goreleaser/goreleaser@v1.11.5
+
       - name: Docker Login
         uses: docker/login-action@v2
         with:
@@ -21,11 +29,10 @@ jobs:
           password: ${{ secrets.DOCKER_PASS }}
 
       - name: Release
-        run: make devkit.run
+        run:  make release
         env:
           DOCKER_CLI_EXPERIMENTAL: "enabled"
           GITHUB_TOKEN: ${{ secrets.MESOSPHERECI_USER_TOKEN }}
-          WHAT: make release
 
   bump-kib:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**What problem does this PR solve?**:
GoReleaser runs in a container and then more steps from goreleaser also run in containers. This simplifies the workflow and should reduce build time as well


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
