### PR TITLE
[release-1.5][BACKPORT] fix:skip adding GPG key when offline mode is enabled

### DIFF
--- a/ansible/roles/packages/tasks/install-redhat.yaml
+++ b/ansible/roles/packages/tasks/install-redhat.yaml
@@ -70,6 +70,7 @@
   when:
     - ansible_distribution == 'RedHat'
     - ansible_distribution_major_version|int == 7
+    - not offline_mode_enabled
 
 - name: install container-selinux rpm package
   yum:


### PR DESCRIPTION
**What problem does this PR solve?**:
Backport https://github.com/mesosphere/konvoy-image-builder/pull/205

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-93793)
-->
* https://d2iq.atlassian.net/browse/D2IQ-93793


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
