### PR TITLE
fix: Configure containerd runc plugin options with systemd cgroup drivers 

### DIFF
--- a/ansible/roles/config/templates/config.toml.tmpl
+++ b/ansible/roles/config/templates/config.toml.tmpl
@@ -64,7 +64,6 @@ imports = ["/etc/containerd/conf.d/*.toml"]
     enable_selinux = false
     sandbox_image = "{{ pause_image }}"
     stats_collect_period = 10
-    systemd_cgroup = false
     enable_tls_streaming = false
     max_container_log_line_size = 16384
     disable_cgroup = false
@@ -92,14 +91,12 @@ imports = ["/etc/containerd/conf.d/*.toml"]
         privileged_without_host_devices = false
       [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
         [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-          runtime_type = "io.containerd.runc.v1"
+          runtime_type = "io.containerd.runc.v2"
           runtime_engine = ""
           runtime_root = ""
           privileged_without_host_devices = false
-        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia-container-runtime]
-          runtime_type = "io.containerd.runc.v1"
-          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia-container-runtime.options]
-            BinaryName = "{{ sysusr_prefix }}/bin/nvidia-container-runtime"
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            SystemdCgroup = true
     [plugins."io.containerd.grpc.v1.cri".cni]
       bin_dir = "/opt/cni/bin"
       conf_dir = "/etc/cni/net.d"

--- a/ansible/roles/containerd/tasks/install-flatcar.yaml
+++ b/ansible/roles/containerd/tasks/install-flatcar.yaml
@@ -28,16 +28,3 @@
   copy:
     content: "export PATH=$PATH:/run/torcx/unpack/docker/bin/"
     dest: "/etc/profile.d/my_path.sh"
-
-- name: ensure cgroups v2 are disabled
-  command: grep -q systemd.unified_cgroup_hierarchy=0 /usr/share/oem/grub.cfg
-  changed_when: no
-  failed_when: false
-  register: cgroupsv2_check
-
-- name: cgroups setup
-  when:
-    - cgroupsv2_check.rc != 0
-  block:
-    - name: disable cgroups v2
-      command: sed -E -i 's/^(set linux_append=.*)"$/\1 systemd.unified_cgroup_hierarchy=0 systemd.legacy_systemd_cgroup_controller"/g' /usr/share/oem/grub.cfg


### PR DESCRIPTION
**What problem does this PR solve?**:
backports #493 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
