### PR TITLE
fix: allow existing zypper process to finish and release lock

### DIFF
--- a/ansible/roles/setup_versionlock/tasks/suse.yaml
+++ b/ansible/roles/setup_versionlock/tasks/suse.yaml
@@ -1,10 +1,14 @@
 ---
 - name: check if versionlock exists
   command: zypper locks -s
+  environment:
+    # The systemd `guestregister` service runs on boot. It runs a python script that, in turn, runs zypper. Because the
+    # service is of type "oneshot," it is not easy to tell whether the service has already run; it is "inactive" both
+    # before and after it runs. Instead, let's allow the service 60 seconds to finish, and release the lock.
+    ZYPP_LOCK_TIMEOUT: 60
   register: versionlocklist
   args:
     warn: false
-  ignore_errors: true
   changed_when: false
 
 - name: export versionlocklist


### PR DESCRIPTION
**What problem does this PR solve?**:

Sometimes, another instance of zypper is running when KIB calls zypper to install packages. 

```console
sles-15: TASK [setup_versionlock : check if versionlock exists] *************************
    sles-15: fatal: [default]: FAILED! => {"changed": false, "cmd": ["zypper", "locks", "-s"], "delta": "0:00:00.040021", "end": "2022-12-01 21:00:39.553172
", "msg": "non-zero return code", "rc": 7, "start": "2022-12-01 21:00:39.513151", "stderr": "System management is locked by the application with pid 4219 (z
ypper).\nClose this application before trying again.", "stderr_lines": ["System management is locked by the application with pid 4219 (zypper).", "Close thi
s application before trying again."], "stdout": "", "stdout_lines": []}
```

~This may be due to the `purge-kernels.service` systemd unit, which runs zypper. Wait an addition 60 seconds for zypper to finish and release its lock.~ When the SLES 15 AMI boots, it runs a systemd service that “registers” the instance. The `guestregister` service runs a python program that, in turn, [calls zypper](https://github.com/SUSE-Enceladus/cloud-regionsrv-client/blob/863a3dec5a31631d78874e467811bb76623e8f34/lib/cloudregister/registerutils.py#L654).

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://d2iq.atlassian.net/browse/D2IQ-92098

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
