### PR TITLE
fix: dont ipv6 forward if you dont have ipv6 forwarding file 

### DIFF
--- a/ansible/roles/networking/tasks/main.yaml
+++ b/ansible/roles/networking/tasks/main.yaml
@@ -28,6 +28,22 @@
     state: present
     reload: yes
 
+- name: stat ipv6 in proc/sys/net
+  stat:
+    path: /proc/sys/net/ipv6
+  register: ipv6
+
+- name: "check if ipv6 is disabled"
+  lineinfile:
+    dest: /proc/sys/net/ipv6/conf/default/disable_ipv6
+    line: "1"
+    state: present
+  become: yes
+  check_mode: yes
+  register: ipv6Disabled
+  when:
+    - ipv6.stat.exists
+
 - name: set net.ipv6.conf.all.forwarding to 1
   sysctl:
     name: net.ipv6.conf.all.forwarding
@@ -35,6 +51,9 @@
     sysctl_file: /etc/sysctl.d/ipv6-forwarding.conf
     state: present
     reload: yes
+  when:
+    - ipv6.stat.exists
+    - ipv6Disabled is not changed
 
 - name: Check if iptables service exists
   command: systemctl cat iptables

--- a/ansible/roles/networking/tasks/main.yaml
+++ b/ansible/roles/networking/tasks/main.yaml
@@ -30,30 +30,8 @@
 
 - name: stat ipv6 in proc/sys/net
   stat:
-    path: /proc/sys/net/ipv6
-  register: ipv6
-
-- name: "check if ipv6 is disabled"
-  lineinfile:
-    dest: /proc/sys/net/ipv6/conf/default/disable_ipv6
-    line: "1"
-    state: present
-  become: yes
-  check_mode: yes
-  register: ipv6Disabled
-  when:
-    - ipv6.stat.exists
-
-- name: "check if ipv6 is disabled from all"
-  lineinfile:
-    dest: /proc/sys/net/ipv6/conf/all/disable_ipv6"
-    line: "1"
-    state: present
-  become: yes
-  check_mode: yes
-  register: ipv6DisabledAll
-  when:
-    - ipv6.stat.exists
+    path: /proc/sys/net/ipv6/conf/all/forwarding
+  register: ipv6forwarding
 
 - name: set net.ipv6.conf.all.forwarding to 1
   sysctl:
@@ -63,9 +41,7 @@
     state: present
     reload: yes
   when:
-    - ipv6.stat.exists
-    - ipv6Disabled is not changed
-    - ipv6DisabledAll is not changed
+    - ipv6forwarding.stat.exists
 
 - name: Check if iptables service exists
   command: systemctl cat iptables

--- a/ansible/roles/networking/tasks/main.yaml
+++ b/ansible/roles/networking/tasks/main.yaml
@@ -44,6 +44,17 @@
   when:
     - ipv6.stat.exists
 
+- name: "check if ipv6 is disabled from all"
+  lineinfile:
+    dest: /proc/sys/net/ipv6/conf/all/disable_ipv6"
+    line: "1"
+    state: present
+  become: yes
+  check_mode: yes
+  register: ipv6DisabledAll
+  when:
+    - ipv6.stat.exists
+
 - name: set net.ipv6.conf.all.forwarding to 1
   sysctl:
     name: net.ipv6.conf.all.forwarding
@@ -54,6 +65,7 @@
   when:
     - ipv6.stat.exists
     - ipv6Disabled is not changed
+    - ipv6DisabledAll is not changed
 
 - name: Check if iptables service exists
   command: systemctl cat iptables


### PR DESCRIPTION
**What problem does this PR solve?**:
checks before enabling ipv6 forwarding if ipv6 is present


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://d2iq.atlassian.net/browse/D2IQ-94653


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note
checks if ipv6 is enabled to set forwarding
```
