### PR TITLE
ci: added --no-cache and fixed trailing slash path issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ OS := $(shell uname -s)
 INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 
 root_mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
-export REPO_ROOT_DIR := $(dir $(root_mkfile_path))
+export REPO_ROOT_DIR := $(patsubst %/,%,$(dir $(root_mkfile_path)))
 export REPO_REV ?= $(shell cd $(REPO_ROOT_DIR) && git describe --abbrev=12 --tags --match='v*' HEAD)
 
 UID ?= $(shell id -u)


### PR DESCRIPTION
**What problem does this PR solve?**:
On Mac, there was an extra trailing slash on the `REPO_ROOT_DIR` variable. This checks for and removes it

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
Needs to be checked on Linux. When running `make docker-build-amd64`,

In the Dockerfile path outputted here:
```
docker buildx build \
                -t docker.io/mesosphere/konvoy-image-builder:v1.25.2-25-g6d41e49e620f-devkit-arm64 \
                --build-arg USER_ID=502 --build-arg GROUP_ID=20 --build-arg USER_NAME=marykarroqe --build-arg GROUP_NAME=staff --build-arg DOCKER_GID=1 --build-arg BUILDARCH=arm64 --platform linux/arm64 --file /Users/marykarroqe/go/src/github.com/mesosphere/konvoy-image-builder/Dockerfile.devkit  \
```

`--file /Users/marykarroqe/go/src/github.com/mesosphere/konvoy-image-builder/Dockerfile.devkit` should have only one slash before `Dockerfile.devkit`.