### PR TITLE
fix: use --force when retagging CoreDNS image

### DIFF
--- a/ansible/roles/images/tasks/check-or-pull-images.yaml
+++ b/ansible/roles/images/tasks/check-or-pull-images.yaml
@@ -27,6 +27,7 @@
 # [ERROR ImagePull]: failed to pull image k8s.gcr.io/coredns:v1.9.3
 #
 # Retag the coredns image
+# Use --force flag to force retag when already exists
 - name: retag coredns image
-  command: ctr --address {{ containerd_cri_socket }} --namespace k8s.io image tag {{ image_name }} k8s.gcr.io/coredns:{{ image_name | split(':') | last }}
+  command: ctr --address {{ containerd_cri_socket }} --namespace k8s.io image tag --force {{ image_name }} k8s.gcr.io/coredns:{{ image_name | split(':') | last }}
   when: "k8s_image_registry_for_coredns + '/coredns/coredns' in image_name"


### PR DESCRIPTION
**What problem does this PR solve?**:
Otherwise this play is not idempotent and would fail with: "ctr: image "k8s.gcr.io/coredns:v1.9.3": already exists"

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
