### PR TITLE
feat: Install specific cri-tools package on debian derivatives

### DIFF
--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -3,12 +3,27 @@ python_path: ""
 
 # This is also in images/common.yaml as that's where the go code expects it to be.
 # If it's not there, the kubernetes_full_version will have "None" for a version number.
+#
+# IMPORTANT When you update kubernetes_version, also update crictl_version.
 kubernetes_version: "1.25.4"
-
-containerd_version: "1.6.10"
-kubernetes_cni_version: "0.9.1"
-crictl_version: "1.22.0"
 kubernetes_semver: "v{{ kubernetes_version }}"
+
+kubernetes_cni_version: "0.9.1"
+
+# The crictl CLI is released as part of the http://sigs.k8s.io/cri-tools project.
+# The project release closely follows the Kubernetes release cycle, and uses a
+# nearly identical version scheme.
+# IMPORTANT When you update crictl_version, also update crictl_sha256.
+crictl_version: "1.22.0"
+
+# On flatcar Linux, we install crictl from a release artifact, not a system package.
+# The url points to the linux/amd64 release artifact.
+crictl_url: https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{ crictl_version }}/crictl-v{{ crictl_version }}-linux-amd64.tar.gz
+# The sha256 sum verifies the integrity of the release artifact.
+crictl_sha256: 45e0556c42616af60ebe93bf4691056338b3ea0001c0201a6a8ff8b1dbc0652a
+
+# Containerd container runtime version.
+containerd_version: "1.6.10"
 
 # NOTE(jkoelker) `nvidia_cuda_version` is set via an override, it is listed
 #                empty here for documentation.
@@ -42,8 +57,6 @@ kubernetes_http_source: https://storage.googleapis.com/kubernetes-release/releas
 kubernetes_cni_semver: v{{ kubernetes_cni_version }}
 kubernetes_cni_http_checksum: sha256:https://storage.googleapis.com/k8s-artifacts-cni/release/{{ kubernetes_cni_semver }}/cni-plugins-linux-amd64-{{ kubernetes_cni_semver }}.tgz.sha256
 kubernetes_cni_http_source: https://github.com/containernetworking/plugins/releases/download
-crictl_url: https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{ crictl_version }}/crictl-v{{ crictl_version }}-linux-amd64.tar.gz
-crictl_sha256: 45e0556c42616af60ebe93bf4691056338b3ea0001c0201a6a8ff8b1dbc0652a
 containerd_cri_socket: /run/containerd/containerd.sock
 flatcar_containerd_cri_socket: /run/docker/libcontainerd/docker-containerd.sock
 systemd_prefix: /usr/lib/systemd/site-packages

--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -22,6 +22,13 @@ crictl_url: https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{ c
 # The sha256 sum verifies the integrity of the release artifact.
 crictl_sha256: 45e0556c42616af60ebe93bf4691056338b3ea0001c0201a6a8ff8b1dbc0652a
 
+# The critools deb and rpm package versions. While the version derives directly from
+# the crictl verson, the package revision can change independently.
+# The initial revision is 00.
+critools_deb: "{{ crictl_version }}-00"
+# The initial revision 0.
+critools_rpm: "{{ crictl_version }}-0"
+
 # Containerd container runtime version.
 containerd_version: "1.6.10"
 

--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -14,13 +14,14 @@ kubernetes_cni_version: "0.9.1"
 # The project release closely follows the Kubernetes release cycle, and uses a
 # nearly identical version scheme.
 # IMPORTANT When you update crictl_version, also update crictl_sha256.
-crictl_version: "1.22.0"
+crictl_version: "1.25.0"
 
 # On flatcar Linux, we install crictl from a release artifact, not a system package.
 # The url points to the linux/amd64 release artifact.
 crictl_url: https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{ crictl_version }}/crictl-v{{ crictl_version }}-linux-amd64.tar.gz
 # The sha256 sum verifies the integrity of the release artifact.
-crictl_sha256: 45e0556c42616af60ebe93bf4691056338b3ea0001c0201a6a8ff8b1dbc0652a
+crictl_sha256: 86ab210c007f521ac4cdcbcf0ae3fb2e10923e65f16de83e0e1db191a07f0235
+
 
 # The critools deb and rpm package versions. While the version derives directly from
 # the crictl verson, the package revision can change independently.

--- a/ansible/roles/kubeadm/tasks/debian.yaml
+++ b/ansible/roles/kubeadm/tasks/debian.yaml
@@ -2,6 +2,29 @@
 - name: remove version hold for kubeadm packages
   command: apt-mark unhold kubeadm
 
+- name: remove version hold for cri-tools package
+  command: apt-mark unhold cri-tools
+
+# cri-tools version should be, approximately, the Kubernetes version.
+# The community-maintained kubeadm package installs the latest version of
+# cri-tools, which may be incompatible with the Kubernetes version.
+# Therefore, we install a version that we know to be compatible.
+- name: install cri-tools remote deb package
+  shell: |
+    apt-get install --force-yes --yes \
+      cri-tools={{ critools_deb }}
+  args:
+    warn: false
+  register: result
+  until: result is success
+  retries: 3
+  delay: 3
+
+# Prevent kubeadm from installing a different cri-tools version by
+# placing a hold on cri-tools before installing kubeadm.
+- name: add version hold for cri-tools package
+  command: apt-mark hold cri-tools
+
 - name: install kubeadm remote deb package
   shell: |
     apt-get install --force-yes --yes \


### PR DESCRIPTION
**What problem does this PR solve?**:
The cri-tools package is a dependency of kubeadm. However, kubeadm installs the latest cri-tools version. And while the kubeadm is compatible with the container runtime, the latest cri-tools version may not be.

For example, on January 20, 2023, kubeadm v1.25.x installs cri-tools v1.26.0. The former is compatible with containerd v1.5.x, but the latter is not.

Please see https://github.com/kubernetes/release/issues/2866 for more details.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://d2iq.atlassian.net/browse/D2IQ-95429


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note
On Debian-based Linux distributions, install a version of the cri-tools package known to be compatible with both the Kubernetes and container runtime versions.
```
