### PR TITLE
[release-1.17] feat: Use cri-tools v1.23.0 on debian derivatives

### DIFF
--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -4,15 +4,35 @@ python_path: ""
 # This is also in images/common.yaml as that's where the go code expects it to be.
 # If it's not there, the kubernetes_full_version will have "None" for a version number.
 kubernetes_version: "1.22.8"
+kubernetes_semver: "v{{ kubernetes_version }}"
 
 containerd_version: "1.4.13"
 kubernetes_cni_version: "0.9.1"
-crictl_version: "1.22.0"
-kubernetes_semver: "v{{ kubernetes_version }}"
 
 # NOTE(jkoelker) `nvidia_cuda_version` is set via an override, it is listed
 #                empty here for documentation.
 nvidia_cuda_version: ""
+
+# The crictl CLI is released as part of the http://sigs.k8s.io/cri-tools project.
+# The project release closely follows the Kubernetes release cycle, and uses a
+# nearly identical version scheme.
+# The critools deb and rpm package versions. While the version derives directly from
+# the crictl verson, the package revision can change independently.
+# The initial revision is 00.
+# Because versions v1.20 through v1.22 are not published as deb and rpm packages,
+# we must use v1.23.
+critools_version_deb: "1.23.0-00"
+# DKP publishes its own RPM packages, which include cri-tools, so KIB
+# cannot select a different version.
+# critools_version_rpm: n/a
+
+# IMPORTANT When you update crictl_version_flatcar, also update crictl_sha256.
+crictl_version_flatcar: "1.22.0"
+# The sha256 sum verifies the integrity of the release artifact.
+crictl_sha256: 45e0556c42616af60ebe93bf4691056338b3ea0001c0201a6a8ff8b1dbc0652a
+# On flatcar Linux, we install crictl from a release artifact, not a system package.
+# The url points to the linux/amd64 release artifact.
+crictl_url: https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{ crictl_version_flatcar }}/crictl-v{{ crictl_version_flatcar }}-linux-amd64.tar.gz
 
 # Adding kubernetes_full_version for mitogen runs. This variable is always overridden
 # in go code.
@@ -39,8 +59,6 @@ kubernetes_http_source: https://storage.googleapis.com/kubernetes-release/releas
 kubernetes_cni_semver: v{{ kubernetes_cni_version }}
 kubernetes_cni_http_checksum: sha256:https://storage.googleapis.com/k8s-artifacts-cni/release/{{ kubernetes_cni_semver }}/cni-plugins-linux-amd64-{{ kubernetes_cni_semver }}.tgz.sha256
 kubernetes_cni_http_source: https://github.com/containernetworking/plugins/releases/download
-crictl_url: https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{ crictl_version }}/crictl-v{{ crictl_version }}-linux-amd64.tar.gz
-crictl_sha256: 45e0556c42616af60ebe93bf4691056338b3ea0001c0201a6a8ff8b1dbc0652a
 containerd_cri_socket: /run/containerd/containerd.sock
 flatcar_containerd_cri_socket: /run/docker/libcontainerd/docker-containerd.sock
 systemd_prefix: /usr/lib/systemd/site-packages

--- a/ansible/roles/kubeadm/tasks/debian.yaml
+++ b/ansible/roles/kubeadm/tasks/debian.yaml
@@ -2,6 +2,29 @@
 - name: remove version hold for kubeadm packages
   command: apt-mark unhold kubeadm
 
+- name: remove version hold for cri-tools package
+  command: apt-mark unhold cri-tools
+
+# cri-tools version should be, approximately, the Kubernetes version.
+# The community-maintained kubeadm package installs the latest version of
+# cri-tools, which may be incompatible with the Kubernetes version.
+# Therefore, we install a version that we know to be compatible.
+- name: install cri-tools remote deb package
+  shell: |
+    apt-get install --force-yes --yes \
+      cri-tools={{ critools_version_deb }}
+  args:
+    warn: false
+  register: result
+  until: result is success
+  retries: 3
+  delay: 3
+
+# Prevent kubeadm from installing a different cri-tools version by
+# placing a hold on cri-tools before installing kubeadm.
+- name: add version hold for cri-tools package
+  command: apt-mark hold cri-tools
+
 - name: install kubeadm remote deb package
   shell: |
     apt-get install --force-yes --yes \

--- a/ansible/roles/packages/tasks/flatcar.yaml
+++ b/ansible/roles/packages/tasks/flatcar.yaml
@@ -17,7 +17,7 @@
 # must include crictl-url.yml after installing containerd,
 # as the cri-containerd tarball also includes crictl.
 - include: crictl-url.yaml
-  when: crictl_version != system_crictl_version
+  when: crictl_version_flatcar != system_crictl_version
 
 - name: create kubelet systemd directory
   file:


### PR DESCRIPTION
**What problem does this PR solve?**:
Upstream kubeadm packages will pull in the latest cri-tools, which may be incompatible with the installed container runtime. For KIB v1.17.x, kubeadm v1.22.8 pulls in cri-tools v1.26.0, which is incompatible with containerd v1.4.13.

cri-tools v1.22.0 is not among the [deb](https://packages.cloud.google.com/apt/dists/kubernetes-xenial/main/binary-amd64/Packages) or [rpm](https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64/repodata/filelists.xml) packages published by kubernetes. Because the kubeadm package has already been installing the latest available cri-tools package, we use v1.23.0, the oldest available and compatible version.

On flatcar Linux, KIB will continue to install cri-tools v1.22.0.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://d2iq.atlassian.net/browse/D2IQ-95429


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
