### PR TITLE
ci: change vsphere e2e test's datastore to ovh-netapp-users

### DIFF
--- a/test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl
+++ b/test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl
@@ -10,7 +10,7 @@ packer:
   ssh_bastion_private_key_file: vsphere-tests.pem
   cluster: "zone1"
   datacenter: "dc1"
-  datastore: "ovh-nfs"
+  datastore: "ovh-netapp-users"
   folder: "cluster-api"
   network: "Airgapped"
   resource_pool: "Users"


### PR DESCRIPTION
**What problem does this PR solve?**:
- vsphere datastore `ovh-nfs` is deprecated. moving the template creation to `ovh-netapp-users`
