### PR TITLE
fix: use new centos 7.9 base AMI (#573)

### DIFF
--- a/images/ami/centos-7.yaml
+++ b/images/ami/centos-7.yaml
@@ -1,7 +1,7 @@
 download_images: true
 
 packer:
-  ami_filter_name: "CentOS 7.9.2009 x86_64"
+  ami_filter_name: "CentOS Linux 7*"
   ami_filter_owners: "125523088429"
   distribution: "CentOS"
   distribution_version: "7.9"


### PR DESCRIPTION
**What problem does this PR solve?**:
* fix: use new centos 7.9 base AMI

We need this to be able to run CentOS 7.9 tests for this and any new PRs for release-1.5 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://d2iq.atlassian.net/browse/D2IQ-94286


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
