### PR TITLE
fix: configure containerd runc plugin for nvidia

### DIFF
--- a/ansible/roles/config/templates/config.toml.tmpl
+++ b/ansible/roles/config/templates/config.toml.tmpl
@@ -95,6 +95,10 @@ imports = ["/etc/containerd/conf.d/*.toml"]
           runtime_engine = ""
           runtime_root = ""
           privileged_without_host_devices = false
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia-container-runtime]
+          runtime_type = "io.containerd.runc.v1"
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia-container-runtime.options]
+            BinaryName = "{{ sysusr_prefix }}/bin/nvidia-container-runtime"
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
             SystemdCgroup = true
     [plugins."io.containerd.grpc.v1.cri".cni]


### PR DESCRIPTION
**What problem does this PR solve?**:
- revert nvidia configuration changes made by https://github.com/mesosphere/konvoy-image-builder/pull/585
The changes in https://github.com/mesosphere/konvoy-image-builder/pull/585 was made to support GPU using nvidia operator.  This feature is not available in `release-1.19.x` so reverting it back to the original configuration. 
