### PR TITLE
ci: don't use docker-container driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ github-token.txt:
 .PHONY: buildx
 buildx:
 buildx:
-	 docker buildx create --driver=docker-container --use --name=konvoy-image-builder || true
+	 docker buildx create --use --name=konvoy-image-builder || true
 	 docker run --privileged --rm tonistiigi/binfmt --install all || true
 
 


### PR DESCRIPTION
**What problem does this PR solve?**:
Removed docker-driver buildx instance for faster builds 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
