### PR TITLE
ci: bump CAPPP on successful release jobs

### DIFF
--- a/.github/workflows/release-kib.yaml
+++ b/.github/workflows/release-kib.yaml
@@ -44,9 +44,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.MESOSPHERECI_USER_TOKEN }}
 
   bump-kib:
-    needs: [release-artifacts, sign-binary]
     runs-on: ubuntu-latest
-    needs: [release-to-github, sign-macos-binary]
+    needs: release-to-github
     steps:
       - name: Setup Go
         uses: actions/setup-go@v3

--- a/.github/workflows/release-kib.yaml
+++ b/.github/workflows/release-kib.yaml
@@ -44,6 +44,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.MESOSPHERECI_USER_TOKEN }}
 
   bump-kib:
+    needs: [release-artifacts, sign-binary]
     runs-on: ubuntu-latest
     needs: [release-to-github, sign-macos-binary]
     steps:


### PR DESCRIPTION
**What problem does this PR solve?**:
Prevents CAPPP bump in case of KIB release failure
