### PR TITLE
ci: pin buildx version to v0.9.1

### DIFF
--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -30,6 +30,12 @@ jobs:
 
       - name: setup buildkit
         uses: docker/setup-buildx-action@v2
+        with:
+          # Pinnning to specific version. The buildx version > v0.10.x fails to create multi-arch docker image manifest
+          # Executing `docker create manifest` command fails when using buildx > v0.10.x.
+          # The manifest file for arm64 build is generated with incorrect format causing failure in generating multiarch manifest
+          # Inspect manifest using: `docker manifest inspect <IMAGE_REF>`
+          version: v0.9.1
 
       - name: Release
         run: make release


### PR DESCRIPTION
**What problem does this PR solve?**:
Pinnning to specific version. The buildx version > v0.10.x fails to create multi-arch docker image manifest
Executing `docker create manifest` command fails when using buildx > v0.10.x.
The manifest file for arm64 build is generated with incorrect format causing failure in generating multiarch manifest
Inspect manifest using: `docker manifest inspect <IMAGE_REF>`

Current failures blocks v2.0.0 release.
Error:
```
docker manifest create \
	mesosphere/konvoy-image-builder:v2.0.0 \
	--amend mesosphere/konvoy-image-builder:v2.0.0-arm64 \
	--amend mesosphere/konvoy-image-builder:v2.0.0-amd64
docker.io/mesosphere/konvoy-image-builder:v2.0.0-arm64 is a manifest list
```
Release job: https://github.com/mesosphere/konvoy-image-builder/actions/runs/4086337249/jobs/7089303825#step:8:4327

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
Tested fix on temporary branch:
https://github.com/mesosphere/konvoy-image-builder/actions/runs/4117665617/jobs/7109243350#step:8:4320


