### PR TITLE
fix: build rocky linux 9.0 azure image

### DIFF
--- a/.github/workflows/azure-e2e.yaml
+++ b/.github/workflows/azure-e2e.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os:
         - "ubuntu 20.04"
-        - "rocky 9.1"
+        - "rocky 9.0"
         buildConfig:
         - "basic"
     runs-on: self-hosted

--- a/images/azure/rocky-90.yaml
+++ b/images/azure/rocky-90.yaml
@@ -12,6 +12,6 @@ packer:
   plan_image_offer: "rockylinux-9" # offer
   plan_image_publisher: "erockyenterprisesoftwarefoundationinc1653071250513" # publisher
 
-build_name: "rocky-91-az"
+build_name: "rocky-90-az"
 packer_builder_type: "azure"
 python_path: ""

--- a/magefile.go
+++ b/magefile.go
@@ -43,6 +43,7 @@ var (
 		"flatcar",
 		"ubuntu 18.04",
 		"ubuntu 20.04",
+		"rocky 9.0",
 		"rocky 9.1",
 	}
 


### PR DESCRIPTION
**What problem does this PR solve?**:
- We support only Rocky 9.0 for azure. This PR fixes incorrect references used for rocky linux 9.0 azure builds.
