### PR TITLE
ci: create vSphere template and GCP image on release tag

### DIFF
--- a/.github/workflows/release-gcp-template.yaml
+++ b/.github/workflows/release-gcp-template.yaml
@@ -1,0 +1,65 @@
+# Builds GCP image when a release tag is created
+name: Build GCP image for Konvoy E2E tests
+on:
+  push:
+    branch:
+      - 'shalin//build-ova-on-tags'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  rune2e:
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix:
+        include:
+          - os: "ubuntu 20.04"
+            buildConfig: "basic"
+    runs-on: self-hosted
+    continue-on-error: true
+    steps:
+      - name: Checkout konvoy-image-builder repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Login to dockerhub Registry
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.NEXUS_USERNAME }}
+          password: ${{ secrets.NEXUS_PASSWORD }}
+
+      - name: Login to D2iQ's Mirror Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ secrets.D2IQ_DOCKER_MIRROR_REGISTRY}}
+          username: ${{ secrets.NEXUS_USERNAME }}
+          password: ${{ secrets.NEXUS_PASSWORD }}
+
+      - name: Setup buildkit
+        uses: docker/setup-buildx-action@v2
+
+      - name: Setup GOOGLE_APPLICATION_CREDENTIALS
+        run: |-
+          echo -n "${GOOGLE_APPLICATION_CREDENTIALS_E2E_BASE64}" | base64 --decode >> google-credentials.json
+          echo "GOOGLE_APPLICATION_CREDENTIALS=google-credentials.json" >> $GITHUB_ENV
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS_E2E_BASE64: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_E2E_BASE64 }}
+
+      - name: Build GCP image for ${{ matrix.os }} with ${{ matrix.buildConfig }} configuration
+        uses: magefile/mage-action@v2
+        with:
+          version: latest
+          args: runE2e "${{ matrix.os }}" "${{ matrix.buildConfig }}" gcp false
+        env:
+          GITHUB_TOKEN: ${{ secrets.MESOSPHERECI_USER_TOKEN }}

--- a/.github/workflows/release-gcp-template.yaml
+++ b/.github/workflows/release-gcp-template.yaml
@@ -2,8 +2,8 @@
 name: Build GCP image for Konvoy E2E tests
 on:
   push:
-    branch:
-      - 'shalin//build-ova-on-tags'
+    tags:
+      - 'v*'
 
 permissions:
   contents: read

--- a/.github/workflows/release-vsphere-template.yaml
+++ b/.github/workflows/release-vsphere-template.yaml
@@ -2,8 +2,8 @@
 name: Build vSphere templates for Konvoy E2E tests
 on:
   push:
-    branch:
-      - 'shalin//build-ova-on-tags'
+    tags:
+      - 'v*'
 
 jobs:
   build-e2e:

--- a/.github/workflows/release-vsphere-template.yaml
+++ b/.github/workflows/release-vsphere-template.yaml
@@ -1,0 +1,71 @@
+# Builds vSphere image template when a release tag is created
+name: Build vSphere templates for Konvoy E2E tests
+on:
+  push:
+    branch:
+      - 'shalin//build-ova-on-tags'
+
+jobs:
+  build-e2e:
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        include:
+          - os: "redhat 8.4"
+            buildConfig: "offline"
+          - os: "redhat 8.4"
+            buildConfig: "offline-fips"
+          - os: "ubuntu 20.04"
+            buildConfig: "offline"
+          - os: "rocky 9.1"
+            buildConfig: "offline"
+    runs-on: self-hosted
+    continue-on-error: true
+    steps:
+      - name: Checkout konvoy-image-builder repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Login to dockerhub Registry
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.NEXUS_USERNAME }}
+          password: ${{ secrets.NEXUS_PASSWORD }}
+      
+      - name: Login to D2iQ's Mirror Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ secrets.D2IQ_DOCKER_MIRROR_REGISTRY}}
+          username: ${{ secrets.NEXUS_USERNAME }}
+          password: ${{ secrets.NEXUS_PASSWORD }}
+
+      - name: Setup buildkit
+        uses: docker/setup-buildx-action@v2
+
+      - name: Setup SSH agent with private key to connect with pre-configured bastion host
+        uses: webfactory/ssh-agent@v0.7.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_BASTION_KEY_CONTENTS }}
+
+      - name: Build vSphere template for ${{ matrix.os }} with ${{ matrix.buildConfig }} configuration
+        uses: magefile/mage-action@v2
+        with:
+          version: latest
+          args: runE2e "${{ matrix.os }}" "${{ matrix.buildConfig }}" ova false
+        env:
+          SSH_BASTION_KEY_CONTENTS: ${{ secrets.SSH_BASTION_KEY_CONTENTS }}
+          SSH_BASTION_HOST: ${{ secrets.SSH_BASTION_HOST }}
+          SSH_BASTION_USERNAME: ${{ secrets.SSH_BASTION_USERNAME }}
+          VSPHERE_USERNAME: ${{ secrets.VSPHERE_USERNAME }}
+          VSPHERE_PASSWORD: ${{ secrets.VSPHERE_PASSWORD }}
+          GITHUB_TOKEN: ${{ secrets.MESOSPHERECI_USER_TOKEN }}
+          VSPHERE_SERVER: ${{ secrets.VSPHERE_SERVER }}


### PR DESCRIPTION
**What problem does this PR solve?**:
Creates vSphere templates and GCP images and persists them in respective cloud service. 
These images are later used in the konvoy e2e tests. 
