### PR TITLE
ci: fix KIB to CAPPP bump job

### DIFF
--- a/.github/workflows/release-kib.yaml
+++ b/.github/workflows/release-kib.yaml
@@ -47,12 +47,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: release-to-github
     steps:
-      - name: Setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-
       - name: Checkout mesosphere/cluster-api-provider-preprovisioned repository
         uses: actions/checkout@v3
         with:
@@ -60,6 +54,12 @@ jobs:
           token: ${{ secrets.MESOSPHERECI_USER_TOKEN }}
           path: cluster-api-provider-preprovisioned
           fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'cluster-api-provider-preprovisioned/go.mod'
+          cache: true
 
       - name: Track default github workspace as safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"


### PR DESCRIPTION
**What problem does this PR solve?**:
Checkout CAPPP repo before running Action to install GO.
Determine go version based on CAPPP's go.mod file.

