### PR TITLE
ci: add oracle 7.9 fips AMI build configuration

### DIFF
--- a/.github/workflows/release-ami.yaml
+++ b/.github/workflows/release-ami.yaml
@@ -20,6 +20,8 @@ jobs:
             buildConfig: "offline"
           - os: "centos 7.9"
             buildConfig: "offline-fips"
+          - os: "oracle 7.9"
+            buildConfig: "fips"
           - os: "redhat 7.9"
             buildConfig: "offline"
           - os: "redhat 7.9"


### PR DESCRIPTION
**What problem does this PR solve?**:
add oracle 7.9 fips AMI build configuration missing from the building release AMI