### PR TITLE
ci: enable manual trigger for GHA build and e2e jobs

### DIFF
--- a/.github/workflows/aws-e2e.yaml
+++ b/.github/workflows/aws-e2e.yaml
@@ -1,6 +1,7 @@
 # Runs AWS tests when pull request opened, repopened or synchronized
 name: E2E Tests - Build AWS AMI
 on:
+  workflow_dispatch:
   pull_request:
     types: [labeled, synchronize]
 

--- a/.github/workflows/azure-e2e.yaml
+++ b/.github/workflows/azure-e2e.yaml
@@ -1,6 +1,7 @@
 # Runs Azure tests when pull request opened, repopened or synchronized
 name: E2E Tests - Build Azure Image
 on:
+  workflow_dispatch:
   pull_request:
     types: [labeled, synchronize]
 

--- a/.github/workflows/gcp-e2e.yaml
+++ b/.github/workflows/gcp-e2e.yaml
@@ -1,6 +1,7 @@
 # Runs Azure tests when pull request opened, repopened or synchronized
 name: E2E Tests - Build GCP Image
 on:
+  workflow_dispatch:
   pull_request:
     types: [labeled, synchronize]
 

--- a/.github/workflows/release-ami.yaml
+++ b/.github/workflows/release-ami.yaml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v*'

--- a/.github/workflows/release-azure.yaml
+++ b/.github/workflows/release-azure.yaml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v*'

--- a/.github/workflows/release-gcp-template.yaml
+++ b/.github/workflows/release-gcp-template.yaml
@@ -1,6 +1,7 @@
 # Builds GCP image when a release tag is created
 name: Build GCP image for Konvoy E2E tests
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v*'

--- a/.github/workflows/release-kib.yaml
+++ b/.github/workflows/release-kib.yaml
@@ -4,6 +4,7 @@
 # - Signs mac-os binary and reuploads artifacts to the github release
 # - Bumps KIB version in mesosphere/cluster-api-provider-preprovisioned repository
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v*'

--- a/.github/workflows/release-vsphere-template.yaml
+++ b/.github/workflows/release-vsphere-template.yaml
@@ -1,6 +1,7 @@
 # Builds vSphere image template when a release tag is created
 name: Build vSphere templates for Konvoy E2E tests
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v*'

--- a/.github/workflows/vsphere-e2e.yaml
+++ b/.github/workflows/vsphere-e2e.yaml
@@ -1,6 +1,7 @@
 # Runs vSphere tests when pull request opened, repopened or synchronized
 name: E2E Tests - Build Vsphere template
 on:
+  workflow_dispatch:
   pull_request:
     types: [labeled, synchronize]
 


### PR DESCRIPTION
**What problem does this PR solve?**:
- allow user to trigger GHA build manually. 
