### PR TITLE
fix: use subscription manager to get kernel headers

### DIFF
--- a/.github/workflows/aws-e2e.yaml
+++ b/.github/workflows/aws-e2e.yaml
@@ -138,3 +138,5 @@ jobs:
           args: runE2e "${{ matrix.os }}" "${{ matrix.buildConfig }}" aws true
         env:
           GITHUB_TOKEN: ${{ secrets.MESOSPHERECI_USER_TOKEN }}
+          RHSM_USER: ${{ secrets.RHSM_USER }}
+          RHSM_PASS: ${{ secrets.RHSM_PASS }}

--- a/ansible/group_vars/all/system.yaml
+++ b/ansible/group_vars/all/system.yaml
@@ -60,3 +60,7 @@ offline:
   os_packages_local_bundle_file: "{{ os_packages_local_bundle_file }}"
   os_packages_remote_bundle_path: "{{ os_packages_remote_bundle_path }}"
   os_packages_remote_filesystem_repo_path: "{{ os_packages_remote_bundle_path }}/offline-repo/"
+
+# subscription manager variables to be secret
+rhsm_user: ""
+rhsm_password: ""

--- a/ansible/group_vars/all/system.yaml
+++ b/ansible/group_vars/all/system.yaml
@@ -64,3 +64,5 @@ offline:
 # subscription manager variables to be secret
 rhsm_user: ""
 rhsm_password: ""
+rhsm_activation_key: ""
+rhsm_org_id: ""

--- a/ansible/provision.yaml
+++ b/ansible/provision.yaml
@@ -53,10 +53,21 @@
           name: sysprep
         when: sysprep # make the finalize process skipable
     rescue:
-      - name: RHEL unsubscribe
-        redhat_subscription:
-          state: absent
+      - name: Remove RHEL subscription
+        block:
+          - name: Remove subscriptions
+            rhsm_repository:
+              name: '*'
+              state: disabled
+          - name: Unregister system
+            redhat_subscription:
+              state: absent
+          - name: clean local subscription data
+            command: subscription-manager clean
         when:
           - ansible_distribution == 'RedHat'
+          - "packer_builder_type not in ['amazon']"
+          - not offline_mode_enabled
+          - rhelorg != None or rheluser != None
 
   environment: "{{ default_env }}"

--- a/ansible/provision.yaml
+++ b/ansible/provision.yaml
@@ -26,18 +26,37 @@
   pre_tasks:
     - include_vars: vars/flatcar/flatcar.yaml
       when: ansible_os_family == "Flatcar"
-  roles:
-    - role: offline
-    - role: packages
-    - role: fips
-    - role: kubeadm
-    - role: version
-    - role: gpu
-    - role: config
-    - role: networking
-    - role: providers
-    - role: images
-      when: download_images
-    - role: sysprep
-      when: sysprep # make the finalize process skipable
+  tasks:
+  - block:
+      - import_role:
+          name: offline
+      - import_role:
+          name: packages
+      - import_role:
+          name: fips
+      - import_role:
+          name: kubeadm
+      - import_role:
+          name: version
+      - import_role:
+          name: gpu
+      - import_role:
+          name: config
+      - import_role:
+          name: networking
+      - import_role:
+          name: providers
+      - import_role:
+          name: images
+        when: download_images
+      - import_role:
+          name: sysprep
+        when: sysprep # make the finalize process skipable
+    rescue:
+      - name: RHEL unsubscribe
+        redhat_subscription:
+          state: absent
+        when:
+          - ansible_distribution == 'RedHat'
+
   environment: "{{ default_env }}"

--- a/ansible/roles/gpu/tasks/nvidia-gpu-RHEL.yaml
+++ b/ansible/roles/gpu/tasks/nvidia-gpu-RHEL.yaml
@@ -1,7 +1,7 @@
 ---
 - name: RHEL subscription
   redhat_subscription:
-    release: "{{ ansible_distribution_major_version }}.{{ ansible_distribution_minor_version }}"
+    release: "{{ ansible_distribution_version }}"
   when:
     - not offline_mode_enabled
 

--- a/ansible/roles/gpu/tasks/nvidia-gpu-RHEL.yaml
+++ b/ansible/roles/gpu/tasks/nvidia-gpu-RHEL.yaml
@@ -5,7 +5,7 @@
   when:
     - not offline_mode_enabled
 
-- name:
+- name: enable eus repository
   rhsm_repository:
     name: rhel-8-for-x86_64-baseos-eus-rpms
     state: enabled

--- a/ansible/roles/gpu/tasks/nvidia-gpu-RHEL.yaml
+++ b/ansible/roles/gpu/tasks/nvidia-gpu-RHEL.yaml
@@ -1,4 +1,10 @@
 ---
+- name: enable RHEL 8 repos
+  shell: subscription-manager repos --enable=rhel-8-for-x86_64-baseos-eus-rpms 
+  when:
+    - rhelorg != None or rheluser != None
+    - ansible_distribution_major_version == '8'
+
 - name: install kernel {{ hostvars[inventory_hostname].ansible_kernel }} headers and devel
   yum:
     name:

--- a/ansible/roles/gpu/tasks/nvidia-gpu-RHEL.yaml
+++ b/ansible/roles/gpu/tasks/nvidia-gpu-RHEL.yaml
@@ -1,4 +1,16 @@
 ---
+- name: RHEL subscription
+  redhat_subscription:
+    release: "{{ ansible_distribution_major_version }}.{{ ansible_distribution_minor_version }}"
+  when:
+    - not offline_mode_enabled
+
+- name:
+  rhsm_repository:
+    name: rhel-8-for-x86_64-baseos-eus-rpms
+    state: enabled
+  when:
+    - not offline_mode_enabled
 
 - name: install kernel {{ hostvars[inventory_hostname].ansible_kernel }} headers and devel
   yum:

--- a/ansible/roles/gpu/tasks/nvidia-gpu-RHEL.yaml
+++ b/ansible/roles/gpu/tasks/nvidia-gpu-RHEL.yaml
@@ -1,17 +1,4 @@
 ---
-- name: RHEL subscription
-  redhat_subscription:
-    release: "{{ ansible_distribution_version }}"
-  when:
-    - not offline_mode_enabled
-
-- name: enable eus repository
-  rhsm_repository:
-    name: rhel-8-for-x86_64-baseos-eus-rpms
-    state: enabled
-  when:
-    - not offline_mode_enabled
-
 - name: install kernel {{ hostvars[inventory_hostname].ansible_kernel }} headers and devel
   yum:
     name:

--- a/ansible/roles/repo/tasks/redhat.yaml
+++ b/ansible/roles/repo/tasks/redhat.yaml
@@ -5,15 +5,47 @@
 - set_fact:
    rhsm_password: "{{ lookup('env', 'RHSM_PASS' ) | ternary (lookup('env', 'RHSM_PASS' ), rhsm_password) }}"
 
-- name: RHEL subscription
+- set_fact:
+   rhsm_activation_key: "{{ lookup('env', 'RHSM_ACTIVATION_KEY' ) | ternary (lookup('env', 'RHSM_ACTIVATION_KEY' ), rhsm_activation_key) }}"
+
+- set_fact:
+   rhsm_activation_key: "{{ lookup('env', 'RHSM_ACTIVATION_KEY' ) | ternary (lookup('env', 'RHSM_ACTIVATION_KEY' ), rhsm_activation_key) }}"
+
+- set_fact:
+   rhsm_org_id: "{{ lookup('env', 'RHSM_ORG_ID' ) | ternary (lookup('env', 'RHSM_ORG_ID' ), rhsm_org_id) }}"
+
+- name: RHEL subscription using username and password
   redhat_subscription:
     state: present
     username: "{{ rhsm_user }}"
     password: "{{ rhsm_password }}"
     auto_attach: true
     force_register: true
+    release: "{{ ansible_distribution_version }}"
+  register: rheluser
   when:
     - ansible_distribution == 'RedHat'
+    - rhsm_user | length > 0
+    - rhsm_password | length > 0
+
+- name: RHEL subscription using org_id and activationkey
+  redhat_subscription:
+    state: present
+    org_id: "{{ rhsm_org_id }}"
+    activationkey: "{{ rhsm_activation_key }}"
+    force_register: true
+    release: "{{ ansible_distribution_version }}"
+  register: rhelorg
+  when:
+    - ansible_distribution == 'RedHat'
+    - rhsm_org_id | length > 0
+    - rhsm_activation_key | length > 0
+
+- name: RHEL subscription refresh
+  shell: subscription-manager repos --enable=rhel-8-for-x86_64-baseos-eus-rpms && subscription-manager refresh && subscription-manager attach --auto
+  when:
+    - ansible_distribution == 'RedHat'
+    - rhelorg.subscribed_pool_ids != None or rheluser.subscribed_pool_ids != None
 
 # The AppStream repo for Centos 8 is not available from centos mirror list.
 # AlmaLinux is 1:1 binary compatible with RHEL and subscription free.

--- a/ansible/roles/repo/tasks/redhat.yaml
+++ b/ansible/roles/repo/tasks/redhat.yaml
@@ -1,17 +1,8 @@
 ---
 - set_fact:
    rhsm_user: "{{ lookup('env', 'RHSM_USER' ) | ternary (lookup('env', 'RHSM_USER' ), rhsm_user) }}"
-
-- set_fact:
    rhsm_password: "{{ lookup('env', 'RHSM_PASS' ) | ternary (lookup('env', 'RHSM_PASS' ), rhsm_password) }}"
-
-- set_fact:
    rhsm_activation_key: "{{ lookup('env', 'RHSM_ACTIVATION_KEY' ) | ternary (lookup('env', 'RHSM_ACTIVATION_KEY' ), rhsm_activation_key) }}"
-
-- set_fact:
-   rhsm_activation_key: "{{ lookup('env', 'RHSM_ACTIVATION_KEY' ) | ternary (lookup('env', 'RHSM_ACTIVATION_KEY' ), rhsm_activation_key) }}"
-
-- set_fact:
    rhsm_org_id: "{{ lookup('env', 'RHSM_ORG_ID' ) | ternary (lookup('env', 'RHSM_ORG_ID' ), rhsm_org_id) }}"
 
 - name: RHEL subscription using username and password

--- a/ansible/roles/repo/tasks/redhat.yaml
+++ b/ansible/roles/repo/tasks/redhat.yaml
@@ -45,7 +45,7 @@
   shell: subscription-manager config --rhsm.manage_repos=1 && subscription-manager repos --enable=rhel-8-for-x86_64-baseos-eus-rpms && subscription-manager refresh && subscription-manager attach --auto
   when:
     - ansible_distribution == 'RedHat'
-    - rhelorg.subscribed_pool_ids != None or rheluser.subscribed_pool_ids != None
+    - rhelorg != None or rheluser != None
 
 # The AppStream repo for Centos 8 is not available from centos mirror list.
 # AlmaLinux is 1:1 binary compatible with RHEL and subscription free.

--- a/ansible/roles/repo/tasks/redhat.yaml
+++ b/ansible/roles/repo/tasks/redhat.yaml
@@ -32,6 +32,14 @@
     - rhsm_org_id | length > 0
     - rhsm_activation_key | length > 0
 
+- name: Warning for missing repos
+  debug:
+    msg: "WARN: Your system is not using subscription manager fetching packages such as kernel-headers might fail"
+  when:
+    - ansible_distribution == 'RedHat'
+    - rhelorg != None or rheluser != None
+    - ansible_distribution_major_version == '8'
+
 # make sure rhsm can manage repos + refresh and attach if needed
 - name: RHEL subscription refresh
   shell: subscription-manager config --rhsm.manage_repos=1 && subscription-manager refresh && subscription-manager attach --auto

--- a/ansible/roles/repo/tasks/redhat.yaml
+++ b/ansible/roles/repo/tasks/redhat.yaml
@@ -42,7 +42,7 @@
     - rhsm_activation_key | length > 0
 
 - name: RHEL subscription refresh
-  shell: subscription-manager repos --enable=rhel-8-for-x86_64-baseos-eus-rpms && subscription-manager refresh && subscription-manager attach --auto
+  shell: subscription-manager config --rhsm.manage_repos=1 && subscription-manager repos --enable=rhel-8-for-x86_64-baseos-eus-rpms && subscription-manager refresh && subscription-manager attach --auto
   when:
     - ansible_distribution == 'RedHat'
     - rhelorg.subscribed_pool_ids != None or rheluser.subscribed_pool_ids != None

--- a/ansible/roles/repo/tasks/redhat.yaml
+++ b/ansible/roles/repo/tasks/redhat.yaml
@@ -41,11 +41,13 @@
     - rhsm_org_id | length > 0
     - rhsm_activation_key | length > 0
 
+# we need rhel-8-base-eus-rpms for kernel headers to support gpus
 - name: RHEL subscription refresh
   shell: subscription-manager config --rhsm.manage_repos=1 && subscription-manager repos --enable=rhel-8-for-x86_64-baseos-eus-rpms && subscription-manager refresh && subscription-manager attach --auto
   when:
     - ansible_distribution == 'RedHat'
     - rhelorg != None or rheluser != None
+    - ansible_distribution_major_version == '8'
 
 # The AppStream repo for Centos 8 is not available from centos mirror list.
 # AlmaLinux is 1:1 binary compatible with RHEL and subscription free.

--- a/ansible/roles/repo/tasks/redhat.yaml
+++ b/ansible/roles/repo/tasks/redhat.yaml
@@ -41,9 +41,9 @@
     - rhsm_org_id | length > 0
     - rhsm_activation_key | length > 0
 
-# we need rhel-8-base-eus-rpms for kernel headers to support gpus
+# make sure rhsm can manage repos + refresh and attach if needed
 - name: RHEL subscription refresh
-  shell: subscription-manager config --rhsm.manage_repos=1 && subscription-manager repos --enable=rhel-8-for-x86_64-baseos-eus-rpms && subscription-manager refresh && subscription-manager attach --auto
+  shell: subscription-manager config --rhsm.manage_repos=1 && subscription-manager refresh && subscription-manager attach --auto
   when:
     - ansible_distribution == 'RedHat'
     - rhelorg != None or rheluser != None

--- a/ansible/roles/repo/tasks/redhat.yaml
+++ b/ansible/roles/repo/tasks/redhat.yaml
@@ -1,15 +1,18 @@
 ---
+- set_fact:
+   rhsm_user: "{{ lookup('env', 'RHSM_USER' ) | ternary (lookup('env', 'RHSM_USER' ), rhsm_user) }}"
+
+- set_fact:
+   rhsm_password: "{{ lookup('env', 'RHSM_PASS' ) | ternary (lookup('env', 'RHSM_PASS' ), rhsm_password) }}"
 
 - name: RHEL subscription
   redhat_subscription:
     state: present
-    username: "{{ lookup('env', 'RHSM_USER') }}"
-    password: "{{ lookup('env', 'RHSM_PASS') }}"
+    username: "{{ rhsm_user }}"
+    password: "{{ rhsm_password }}"
     auto_attach: true
     force_register: true
   when:
-    - lookup('env', 'RHSM_USER') | length > 0
-    - lookup('env', 'RHSM_PASS') | length > 0
     - ansible_distribution == 'RedHat'
 
 # The AppStream repo for Centos 8 is not available from centos mirror list.

--- a/ansible/roles/sysprep/tasks/redhat.yml
+++ b/ansible/roles/sysprep/tasks/redhat.yml
@@ -95,8 +95,7 @@
     - name: clean local subscription data
       command: subscription-manager clean
   when:
-    - lookup('env', 'RHSM_USER') | length > 0
-    - lookup('env', 'RHSM_PASS') | length > 0
     - ansible_distribution == 'RedHat'
     - "packer_builder_type not in ['amazon']"
     - not offline_mode_enabled
+    - rhelorg != None or rheluser != None


### PR DESCRIPTION
**What problem does this PR solve?**:
Subscribe to the appropriate repos from redhat to fetch kernel headers.
Fall back to environment variables if rhsm_user and rhsm_password are not present 
Allows user to use activation key to subscribe to redhat subscription manager 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
*https://d2iq.atlassian.net/browse/D2IQ-95717


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note
Subscribe to the appropriate repos from redhat to fetch kernel headers.
Fall back to environment variables if rhsm_user and rhsm_password are not present 
Allows user to use activation key to subscribe to redhat subscription manager 
```
