### PR TITLE
fix: epel repos not working with some RHEL images

### DIFF
--- a/ansible/roles/repo/tasks/redhat.yaml
+++ b/ansible/roles/repo/tasks/redhat.yaml
@@ -41,6 +41,28 @@
   when:
     - ansible_distribution_major_version == '8'
 
+# The epel repo files installed from alma linux contain variable "$releasever".
+# This variable may not get properly replaced in all environments.
+# Replace it with the minor version "8" (similar to what upstream does).
+# see https://access.redhat.com/discussions/5473561?page=2
+- name: find epel-release repo files
+  find:
+    depth: 1
+    paths: /etc/yum.repos.d
+    patterns: 'epel*.repo'
+  register: epel_repo_files
+  when:
+    - ansible_distribution_major_version == '8'
+
+- name: set $releasever variables in epel-release repo files
+  replace:
+    path: "{{ item.path }}"
+    regexp: '\$releasever'
+    replace: '8'
+  loop: "{{ epel_repo_files.files }}"
+  when:
+    - ansible_distribution_major_version == '8'
+
 - name: add epel gpg key for centos 7
   rpm_key:
     state: present


### PR DESCRIPTION
**What problem does this PR solve?**:
Seen in Azure where `$releasever` is not being correctly replaced, but can happen in other images

I was able to repro this issue in Azure and test this fix, see:
```
TASK [repo : add alma linux extra repository] **********************************
changed: [20.228.111.34]

TASK [repo : install epel-release for RHEL 8.x] ********************************
changed: [20.228.111.34]

TASK [repo : find epel-release repo files] *************************************
ok: [20.228.111.34]

TASK [repo : set $releasever variables in epel-release repo files] *************
changed: [20.228.111.34] => (item={'path': '/etc/yum.repos.d/epel-modular.repo', 'mode': '0644', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 1177, 'inode': 2118938, 'dev': 64772, 'nlink': 1, 'atime': 1607202791.0, 'mtime': 1607202791.0, 'ctime': 1676064021.6165278, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False})
changed: [20.228.111.34] => (item={'path': '/etc/yum.repos.d/epel-playground.repo', 'mode': '0644', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 1259, 'inode': 2118939, 'dev': 64772, 'nlink': 1, 'atime': 1607202791.0, 'mtime': 1607202791.0, 'ctime': 1676064021.6165278, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False})
changed: [20.228.111.34] => (item={'path': '/etc/yum.repos.d/epel-testing-modular.repo', 'mode': '0644', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 1276, 'inode': 2118940, 'dev': 64772, 'nlink': 1, 'atime': 1607202791.0, 'mtime': 1607202791.0, 'ctime': 1676064021.6175277, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False})
changed: [20.228.111.34] => (item={'path': '/etc/yum.repos.d/epel-testing.repo', 'mode': '0644', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 1213, 'inode': 2118941, 'dev': 64772, 'nlink': 1, 'atime': 1607202791.0, 'mtime': 1607202791.0, 'ctime': 1676064021.6175277, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False})
changed: [20.228.111.34] => (item={'path': '/etc/yum.repos.d/epel.repo', 'mode': '0644', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 1114, 'inode': 2118942, 'dev': 64772, 'nlink': 1, 'atime': 1607202791.0, 'mtime': 1607202791.0, 'ctime': 1676064021.6175277, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False})
...
TASK [setup_versionlock : install yum utilities] *******************************
changed: [20.228.111.34]
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-95864)
-->
* https://d2iq.atlassian.net/browse/D2IQ-95864


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
