### PR TITLE
ci: add build metadata to the released image name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ vsphere-tests.pem
 authorized_keys
 github-token.txt
 .local
+/overrides/release.yaml


### PR DESCRIPTION
**What problem does this PR solve?**:
- adds `-release`, `-fips-release`, `-nvidia-release` as build name extra to release names.
- This will enable konvoy e2e tests to find released AMIs directly.

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
Tested by creating release AMI locally: `"konvoy-ami-rocky-9.1-release-1.25.4-20230210213910"`
