### PR TITLE
feat: Install only required ansible collections 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apk add --no-cache \
         py3-wheel \
     && pip3 install --no-cache-dir --requirement /tmp/requirements.txt \
     && rm -rf /root/.cache
+# Managing the below ansible dependencies is covered in docs/dev/ansible-modules.md
 RUN mkdir -p /usr/share/ansible/collections \
     && ansible-galaxy \
     collection install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,14 @@ RUN apk add --no-cache \
         py3-wheel \
     && pip3 install --no-cache-dir --requirement /tmp/requirements.txt \
     && rm -rf /root/.cache
+RUN mkdir -p /usr/share/ansible/collections \
+    && ansible-galaxy \
+    collection install \
+    community.general \
+    ansible.netcommon \
+    ansible.posix \
+    ansible.utils \
+    -p /usr/share/ansible/collections
 
 ARG BUILDARCH
 # we copy this to remote hosts to execute GOSS
@@ -40,10 +48,6 @@ COPY bin/konvoy-image-${BUILDARCH} /usr/local/bin/konvoy-image
 COPY images /root/images
 COPY ansible /root/ansible
 COPY packer /root/packer
-
-# this is needed for containerd tar
-# place it in /usr/share/ansible/collections, the container will be run with a different user
-RUN mkdir -p /usr/share/ansible/collections && ansible-galaxy collection install ansible.utils -p /usr/share/ansible/collections
 
 WORKDIR /root
 ENTRYPOINT ["/usr/local/bin/konvoy-image"]

--- a/Dockerfile.devkit
+++ b/Dockerfile.devkit
@@ -110,6 +110,14 @@ RUN apk add --no-cache \
         --requirement /tmp/requirements-devkit.txt \
     && rm -rf \
         /root/.cache
+RUN mkdir -p /usr/share/ansible/collections \
+    && ansible-galaxy \
+    collection install \
+    community.general \
+    ansible.netcommon \
+    ansible.posix \
+    ansible.utils \
+    -p /usr/share/ansible/collections
 
 # hadolint ignore=DL4006
 RUN  curl -Lf https://github.com/mesosphere/mindthegap/releases/download/v"${MINDTHEGAP_VERSION}"/mindthegap_v"${MINDTHEGAP_VERSION}"_linux_amd64.tar.gz |tar xzf - -C /usr/local/bin
@@ -146,10 +154,6 @@ RUN if [ "${DOCKER_GID}" -ne "${GROUP_ID}" ]; then \
             && addgroup "${USER_NAME}" "$(cat /tmp/docker.group_name)"; \
         rm -rf /tmp/docker.group*; \
     fi
-
-# this is needed for containerd tar
-# place it in /usr/share/ansible/collections, the container will be run with a different user
-RUN mkdir -p /usr/share/ansible/collections && ansible-galaxy collection install ansible.utils -p /usr/share/ansible/collections
 
 # hadolint ignore=DL3059
 RUN --mount=type=secret,id=githubtoken PACKER_GITHUB_API_TOKEN="$(cat /run/secrets/githubtoken)" export PACKER_GITHUB_API_TOKEN && \

--- a/Dockerfile.devkit
+++ b/Dockerfile.devkit
@@ -110,6 +110,7 @@ RUN apk add --no-cache \
         --requirement /tmp/requirements-devkit.txt \
     && rm -rf \
         /root/.cache
+# Managing the below ansible dependencies is covered in docs/dev/ansible-modules.md
 RUN mkdir -p /usr/share/ansible/collections \
     && ansible-galaxy \
     collection install \

--- a/ansible/requirements.txt
+++ b/ansible/requirements.txt
@@ -3,6 +3,6 @@ molecule-ec2
 ansible-lint
 boto
 boto3
-ansible==6.3.0
+ansible-core==2.13.7
 yamllint
 pytest-testinfra

--- a/ansible/roles/offline/tasks/upload.yaml
+++ b/ansible/roles/offline/tasks/upload.yaml
@@ -10,9 +10,12 @@
 
 - name: Set containerd_tar_file
   set_fact:
-    # we need os_release.ID because d2iqs containerd tars are released with using /etc/os-release for determining OS
-    # distribution_version is used instead of an os_release fact because centos 7 does not include minor version
-    # in VERSION_ID and ansible_distribution_version does get the minor version
+    # Notes
+    # 1. Containerd artifact filenames use the ID value in /etc/os-release. Because this value is not available in
+    # the builtin ansible_facts, we use a module to populate this value into os_release.ID.
+    # 2. Containerd artifact filenames use the major and minor OS version. On CentOS 7, the minor version is not
+    # available in the VERSION_ID value in /etc/os-release. Instead, we use ansible_distribution_version, which contains
+    # the major and minor version for every OS.
     containerd_tar_file: "containerd-{{ containerd_version }}-d2iq.1-{{ os_release.ID }}-{{ ansible_distribution_version }}-{{ ansible_architecture }}{{ '_fips' if fips.enabled else '' }}.tar.gz"
 
 - block:

--- a/docs/dev/ansible-modules.md
+++ b/docs/dev/ansible-modules.md
@@ -1,0 +1,25 @@
+# Managing Ansible Modules Dependencies
+
+KIB uses Ansible to provision the machine image. Most modules are included in ansible-core, but some are available in collections that we install using ansible-galaxy CLI.
+
+I do not know of a way to reliably enumerate all the necessary modules, but the following script generates a good candidate list. Note that it requires `curl`, `fd`, `gojq`, which you may need to install.
+
+```shell
+#!/usr/bin/env bash
+# List all ansible keywords
+curl -q https://raw.githubusercontent.com/ansible/ansible/devel/lib/ansible/keyword_desc.yml | gojq --yaml-input --raw-output '.. | keys? | flatten[] | select(type=="string")' > ansible_keywords
+
+# List all keys in yml/yaml files in the ansible directory (and subdirectories).
+fd . ansible -e 'yml' -e 'yaml' -x gojq --yaml-input --raw-output '.. | keys? | flatten[] | select(type=="string")' > keys
+
+# List every possible module by calculating the set difference (all keys) - (ansible keywords).
+diff --new-line-format="" --unchanged-line-format="" keys ansible_keywords | sort | uniq > possible_modules
+```
+
+Some non-builtin modules are namespaced, and it's easy to tell the collection to which they belong. For example, `ansible.posix.mount` belongs to `ansible.posix`, and `ansible.utils.cli_parse` belongs to `ansible.utils`.
+
+Other non-builtin modules are NOT namespaced. For example, `redhat_subscription` belongs to the `community.general` module.
+
+Finally, modules can be referenced dynamically. That is, not as a YAML key. For example, the `ansible.netcommon.native` module (which belongs to `ansible.netcommon`) is referenced in a YAML value.
+
+I will look into more reliable methods of enumerating modules in the future. It would be nice to 'dry-run' all tasks, have Ansible throw missing module errors, but continue until it tries all tasks.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ansible==6.3.0
+ansible-core==2.13.7
 netaddr==0.8.0


### PR DESCRIPTION
**What problem does this PR solve?**:
The single largest component (approximately 42%, 331MB out of 791MB) in the KIB image is the ansible collections install.

```
/ # du -hmd4 | sort -nr | head -n20
791	.
729	./usr
434	./usr/lib
427	./usr/lib/python3.9
384	/usr/lib/python3.9/site-packages/
331	/usr/lib/python3.9/site-packages/ansible_collections
```

 I believe we only need to use two collections (`community.general` and `ansible.posix`), which need  about 20MB:
```
/usr/lib/python3.9/site-packages/ansible_collections # du -hmd2 | egrep "posix|general"
19	./community/general
1	./ansible/posix
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
