### PR TITLE
ci: skip posting coverage matrix on the dependabot PRs

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -27,7 +27,9 @@ jobs:
           path: coverage.xml
 
       - name: Display the coverage metrics in a GitHub Pull Request comments
-        if: ${{ github.event_name == 'pull_request' }}
+        if: |
+            github.event_name == 'pull_request' &&
+            github.actor != 'dependabot[bot]'
         uses: 5monkeys/cobertura-action@v13
         with:
           path: coverage.xml


### PR DESCRIPTION
**What problem does this PR solve?**:
The unit test github workflow posts coverage report on the PR as a comment once it finish running it.
Dependabot github actor does not have access to the repository artifacts. So when a PR is created by the dependabot, it can not access the coverage report resulting in following error.
https://github.com/mesosphere/konvoy-image-builder/actions/runs/4119541717/jobs/7113326601
```
1s
Run 5monkeys/cobertura-action@v[1](https://github.com/mesosphere/konvoy-image-builder/actions/runs/4119541717/jobs/7113326601#step:5:1)3
Error: Resource not accessible by integration
```

This is designed is intended by github actions for security purpose.
There are workarounds/alternatives to run this in privileged mode as given in the blog post by github.
https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

IMHO, we dont need to post the coverage report in dependabot PRs. So instead of impnlemetina these workarounds, this PR prevents posting the report when the PR is created by dependabot.
