### PR TITLE
fix: Use always section instead of rescue to remove RHEL subscription

### DIFF
--- a/ansible/provision.yaml
+++ b/ansible/provision.yaml
@@ -52,7 +52,7 @@
       - import_role:
           name: sysprep
         when: sysprep # make the finalize process skipable
-    rescue:
+    always:
       - name: Remove RHEL subscription
         block:
           - name: Remove subscriptions


### PR DESCRIPTION
Using a `rescue` section hides errors in the failed task. From docs:

> If an error occurs in the block and the rescue task succeeds, Ansible
> reverts the failed status of the original task for the run and continues
> to run the play as if the oriinal task had succeeded. The rescued task
> is considered successful

In this case we want the error to be propagated, and should use an
`always` section to ensure the machine is unregistered from RHSM.

Tested locally and it works for me if there is a failure in any task then the always section runs and exits correctly:

```
    amazon-ebs.kib_image:
    amazon-ebs.kib_image: TASK [Remove subscriptions] ****************************************************
    amazon-ebs.kib_image: skipping: [default]
    amazon-ebs.kib_image:
    amazon-ebs.kib_image: TASK [Unregister system] *******************************************************
    amazon-ebs.kib_image: skipping: [default]
    amazon-ebs.kib_image:
    amazon-ebs.kib_image: TASK [clean local subscription data] *******************************************
    amazon-ebs.kib_image: skipping: [default]
    amazon-ebs.kib_image:
    amazon-ebs.kib_image: RUNNING HANDLER [config : reload systemd] **************************************
    amazon-ebs.kib_image:
    amazon-ebs.kib_image: RUNNING HANDLER [config : restart containerd] **********************************
    amazon-ebs.kib_image:
    amazon-ebs.kib_image: PLAY RECAP *********************************************************************
    amazon-ebs.kib_image: default                    : ok=133  changed=58   unreachable=0    failed=1    skipped=221  rescued=0    ignored=0
    amazon-ebs.kib_image:
==> amazon-ebs.kib_image: Provisioning step had errors: Running the cleanup provisioner, if present...
==> amazon-ebs.kib_image: Terminating the source AWS instance...
==> amazon-ebs.kib_image: Cleaning up any extra volumes...
==> amazon-ebs.kib_image: No volumes to clean up, skipping
==> amazon-ebs.kib_image: Deleting temporary security group...
==> amazon-ebs.kib_image: Deleting temporary keypair...
Build 'amazon-ebs.kib_image' errored after 12 minutes 42 seconds: Error executing Ansible: Non-zero exit status: exit status 2

==> Wait completed after 12 minutes 42 seconds

==> Some builds didn't complete successfully and had errors:
--> amazon-ebs.kib_image: Error executing Ansible: Non-zero exit status: exit status 2

==> Builds finished but no artifacts were created.
ERRO error during run: error running packer build: error running command: exit status 1
error encountered: cmd failed exit status 3
```
