### PR TITLE
ci: Fail workflow run if any job fails

### DIFF
--- a/.github/workflows/aws-e2e.yaml
+++ b/.github/workflows/aws-e2e.yaml
@@ -89,7 +89,7 @@ jobs:
         - os: "rocky 9.1"
           buildConfig: offline-nvidia
     runs-on: self-hosted
-    continue-on-error: true
+    continue-on-error: false
     if: |
       github.event_name == 'pull_request' &&
       (

--- a/.github/workflows/azure-e2e.yaml
+++ b/.github/workflows/azure-e2e.yaml
@@ -21,7 +21,7 @@ jobs:
         buildConfig:
         - "basic"
     runs-on: self-hosted
-    continue-on-error: true
+    continue-on-error: false
     if: |
       github.event_name == 'pull_request' &&
       (

--- a/.github/workflows/gcp-e2e.yaml
+++ b/.github/workflows/gcp-e2e.yaml
@@ -22,7 +22,7 @@ jobs:
         buildConfig:
         - "basic"
     runs-on: self-hosted
-    continue-on-error: true
+    continue-on-error: false
     if: |
       github.event_name == 'pull_request' &&
       (

--- a/.github/workflows/release-ami.yaml
+++ b/.github/workflows/release-ami.yaml
@@ -45,7 +45,7 @@ jobs:
             buildConfig: "nvidia"
 
     runs-on: self-hosted
-    continue-on-error: true
+    continue-on-error: false
     steps:
       - name: Checkout konvoy-image-builder repository
         uses: actions/checkout@v3

--- a/.github/workflows/release-azure.yaml
+++ b/.github/workflows/release-azure.yaml
@@ -22,7 +22,7 @@ jobs:
             buildConfig: "basic"
 
     runs-on: self-hosted
-    continue-on-error: true
+    continue-on-error: false
     steps:
       - name: Checkout konvoy-image-builder repository
         uses: actions/checkout@v3

--- a/.github/workflows/release-gcp-template.yaml
+++ b/.github/workflows/release-gcp-template.yaml
@@ -20,7 +20,7 @@ jobs:
           - os: "ubuntu 20.04"
             buildConfig: "basic"
     runs-on: self-hosted
-    continue-on-error: true
+    continue-on-error: false
     steps:
       - name: Checkout konvoy-image-builder repository
         uses: actions/checkout@v3

--- a/.github/workflows/release-vsphere-template.yaml
+++ b/.github/workflows/release-vsphere-template.yaml
@@ -22,7 +22,7 @@ jobs:
           - os: "rocky 9.1"
             buildConfig: "offline"
     runs-on: self-hosted
-    continue-on-error: true
+    continue-on-error: false
     steps:
       - name: Checkout konvoy-image-builder repository
         uses: actions/checkout@v3

--- a/.github/workflows/vsphere-e2e.yaml
+++ b/.github/workflows/vsphere-e2e.yaml
@@ -30,7 +30,7 @@ jobs:
         - os: "ubuntu 20.04"
           buildConfig: offline-fips
     runs-on: self-hosted
-    continue-on-error: true
+    continue-on-error: false
     if: |
       github.event_name == 'pull_request' &&
       (


### PR DESCRIPTION
**What problem does this PR solve?**:
We want:
1. Run all jobs in parallel (`strategy.max-parallel: N`)
2. Let all jobs complete (`strategy.fail-fast: false`)
3. Fail the run if any job fails (do not use `continue-on-error` in any job)

We already have (1) and (2). With this commit, we get (3). Previously, the run would pass, even if some job failed.


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note
```
