### PR TITLE
ci: revert setting github token in devkit container for release-2.4

### DIFF
--- a/.github/workflows/release-kib.yaml
+++ b/.github/workflows/release-kib.yaml
@@ -35,9 +35,6 @@ jobs:
           username: mesosphereci
           password: ${{ secrets.DOCKER_PASS }}
 
-      - name: Setup buildkit
-        uses: docker/setup-buildx-action@v2
-
       - name: Release
         run: make release
         env:

--- a/Dockerfile.devkit
+++ b/Dockerfile.devkit
@@ -137,9 +137,8 @@ RUN mkdir -p /usr/share/ansible/collections && ansible-galaxy collection install
 
 
 # hadolint ignore=DL3059
-RUN --mount=type=secret,id=githubtoken PACKER_GITHUB_API_TOKEN="$(cat /run/secrets/githubtoken)" export PACKER_GITHUB_API_TOKEN && \
-    packer plugins install github.com/hashicorp/googlecompute ">=1.0.0" && \
-    packer plugins install github.com/hashicorp/azure ">=1.3.1"
+RUN packer plugins install github.com/hashicorp/googlecompute ">=1.0.0" \
+    && packer plugins install github.com/hashicorp/azure ">=1.3.1"
 # Non-trivial bash scripting like e.g. the Makefile require bash instead of
 # plain sh, in order to function.
 CMD ["/bin/bash"]


### PR DESCRIPTION
**What problem does this PR solve?**:
Revert Dockerfile.devkit changes back to release-2.4 head.
