### PR TITLE
fix: fallback to ansible_user_id when using root user

### DIFF
--- a/ansible/roles/sysprep/tasks/main.yml
+++ b/ansible/roles/sysprep/tasks/main.yml
@@ -146,7 +146,7 @@
     path: "{{ item.path }}"
   loop:
     - path: /root/.ssh/authorized_keys
-    - path: "/home/{{ ansible_env.SUDO_USER }}/.ssh/authorized_keys"
+    - path: "/home/{{ ansible_env.SUDO_USER | default(ansible_user_id) }}/.ssh/authorized_keys"
   when: ansible_os_family != "Flatcar"
 
 - name: Remove SSH authorized users for Flatcar
@@ -175,7 +175,7 @@
     path: "{{ item.path }}"
   loop:
     - path: /root/.bash_history
-    - path: "/home/{{ ansible_env.SUDO_USER }}/.bash_history"
+    - path: "/home/{{ ansible_env.SUDO_USER | default(ansible_user_id) }}/.bash_history"
 
 - name: Ensure containterd is started
   systemd:


### PR DESCRIPTION
**What problem does this PR solve?**:
Fix from https://github.com/kubernetes-sigs/image-builder/pull/739/files#diff-2f3020c3867a75d1e2395d10238225e0fa343e8097cb434f647817e446354a88R149

Looks like when using `root` as the SSH user, `ansible_env.SUDO_USER` is not set.
Fallback to using `ansible_user_id` which will in this case already equal the ssh user.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
