### PR TITLE
ci: remove Rocky 9.1 FIPS builds

### DIFF
--- a/.github/workflows/aws-e2e.yaml
+++ b/.github/workflows/aws-e2e.yaml
@@ -85,6 +85,10 @@ jobs:
         - os: "oracle 7.9"
           buildConfig: offline
         - os: "rocky 9.1"
+          buildConfig: fips
+        - os: "rocky 9.1"
+          buildConfig: offline-fips
+        - os: "rocky 9.1"
           buildConfig: nvidia
         - os: "rocky 9.1"
           buildConfig: offline-nvidia

--- a/.github/workflows/release-ami.yaml
+++ b/.github/workflows/release-ami.yaml
@@ -37,8 +37,6 @@ jobs:
             buildConfig: "offline-fips"
           - os: "rocky 9.1"
             buildConfig: "offline"
-          - os: "rocky 9.1"
-            buildConfig: "offline-fips"
           - os: "sles 15"
             buildConfig: "basic"
           - os: "ubuntu 20.04"


### PR DESCRIPTION
**What problem does this PR solve?**:
I noticed the Rocky FIPS offline tests were failing. I was going to try and fix it, but actaully Rocky FIPS is not supported.
Removing the e2e and release GHA configs.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-96173)
-->
* https://d2iq.atlassian.net/browse/D2IQ-96173


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
