### PR TITLE
ci: print output of the goreleaser build hook 

### DIFF
--- a/.github/workflows/release-kib.yaml
+++ b/.github/workflows/release-kib.yaml
@@ -26,7 +26,7 @@ jobs:
           cache: true
 
       - name: Download GoReleaser
-        run: go install github.com/goreleaser/goreleaser@v1.11.5
+        run: go install github.com/goreleaser/goreleaser@v1.15.2
 
       - name: Docker Login
         uses: docker/login-action@v2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -62,7 +62,11 @@ builds:
       - arm64
     hooks:
       pre:
-        - make cmd/konvoy-image-wrapper/image/konvoy-image-builder.tar.gz  DOCKER_DEVKIT_DEFAULT_ARGS="--rm" BUILDARCH={{.Arch }}
+        - cmd: make cmd/konvoy-image-wrapper/image/konvoy-image-builder.tar.gz
+          output: true
+          env:
+            - DOCKER_DEVKIT_DEFAULT_ARGS="--rm"
+            - BUILDARCH={{.Arch }}
 
 archives:
   - id: konvoy-image-bundle

--- a/Makefile
+++ b/Makefile
@@ -415,7 +415,7 @@ dist/konvoy-image_linux_$(BUILDARCH)/konvoy-image: $(shell find $(REPO_ROOT_DIR)
 dist/konvoy-image_linux_$(BUILDARCH)/konvoy-image: $(shell find $(REPO_ROOT_DIR)/pkg -type f -name '*'.tmpl)
 dist/konvoy-image_linux_$(BUILDARCH)/konvoy-image:
 	$(call print-target)
-	goreleaser build --snapshot --rm-dist --id konvoy-image --single-target
+	goreleaser build --snapshot --clean --id konvoy-image --single-target
 
 .PHONY: build
 build: bin/konvoy-image
@@ -515,7 +515,7 @@ build.snapshot:
 	# NOTE (faiq): does anyone use this target?
 	mkdir -p bin
 	cp dist/konvoy-image_linux_$(BUILDARCH)/konvoy-image bin/konvoy-image
-	goreleaser --parallelism=1 --skip-publish --snapshot --rm-dist
+	goreleaser --parallelism=1 --skip-publish --snapshot --clean
 
 .PHONY: diff
 diff: ## git diff

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -10,13 +10,13 @@ function main () {
   make devkit-arm64
   make devkit-amd64
   if  [ "${push}" = false ]; then
-	  DOCKER_BUILDKIT=1 goreleaser --parallelism=1 --rm-dist --snapshot --timeout=2h
+	  DOCKER_BUILDKIT=1 goreleaser --parallelism=1 --clean --snapshot --timeout=2h
     exit 0
   fi
   make docker-build-amd64
   make docker-build-arm64
   make push-manifest
-  DOCKER_BUILDKIT=1 goreleaser release --rm-dist --parallelism=1 --timeout=2h
+  DOCKER_BUILDKIT=1 goreleaser release --clean --parallelism=1 --timeout=2h
   exit 0
 }
 


### PR DESCRIPTION
**What problem does this PR solve?**:
Its very difficult to spot failures in goreleaser build hooks. Even in debug mode goreleaser swallows stdout/stderr of the scripts running in the pre build hooks. This resulted in very time consuming mechanism to figure out actual issue with goreleaser.

Latest go releaser has this fixed with `output:true` https://goreleaser.com/customization/builds/#build-hooks
This PR upgrades go releaser and sets output:true setting.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
