### PR TITLE
ci: stop setting go env for bump-kib in CAPPP github job

### DIFF
--- a/.github/workflows/release-kib.yaml
+++ b/.github/workflows/release-kib.yaml
@@ -56,12 +56,6 @@ jobs:
           path: cluster-api-provider-preprovisioned
           fetch-depth: 0
 
-      - name: Setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: 'cluster-api-provider-preprovisioned/go.mod'
-          cache: true
-
       - name: Track default github workspace as safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 


### PR DESCRIPTION
**What problem does this PR solve?**:
- `make update-kib` in https://github.com/mesosphere/konvoy-image-builder/blob/main/.github/workflows/release-kib.yaml#L69 does not require go to be installed. This PR removes setting up go environment when bumping the kib version in CAPPP
