### PR TITLE
ci: remove devkit from unit tests 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,12 +17,14 @@ jobs:
       - name: Checkout konvoy-image-builder repository
         uses: actions/checkout@v3
 
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
       - name: Build konvoy-image binary
-        run: make devkit.run
-        env:
-          WHAT: make build
+        run: make build
 
       - name: Verify CLI documentation
-        run: make devkit.run
-        env:
-          WHAT: make docs.check
+        run: make docs.check

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -15,21 +15,14 @@ jobs:
       - name: Checkout konvoy-image-builder repository
         uses: actions/checkout@v3
 
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: install go-acc dependency
+        run: go install github.com/ory/go-acc@v0.2.8
+
       - name: Run Unit Tests
-        run: make devkit.run
-        env:
-          WHAT: make test
-
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage
-          path: coverage.xml
-
-      - name: Display the coverage metrics in a GitHub Pull Request comments
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: 5monkeys/cobertura-action@v13
-        with:
-          path: coverage.xml
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          minimum_coverage: 75
+        run: make test

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -21,8 +21,5 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - name: install go-acc dependency
-        run: go install github.com/ory/go-acc@v0.2.8
-
       - name: Run Unit Tests
         run: make test

--- a/Dockerfile.devkit
+++ b/Dockerfile.devkit
@@ -45,29 +45,6 @@ RUN mv /tools/packer-provisioner-goss /tools/packer-provisioner-goss-arm64
 ARG BUILDARCH
 RUN ln -s /tools/packer-provisioner-goss-${BUILDARCH} /tools/packer-provisioner-goss
 
-ARG GO_ACC_VERSION=0.2.6
-# TODO(jkoelker) migrate to binary release for next release:
-#                https://github.com/ory/go-acc/pull/23
-RUN go install "github.com/ory/go-acc@v${GO_ACC_VERSION}" \
-    && mv /go/bin/go-acc /tools
-
-ARG GOCOVER_COBERTURA_VERSION=1.1.0
-ARG GOCOVER_COBERTURA_SHA265=bd4cb244f88b2eee22a868dccb88433cc303d11ffa29e1cae3e772caada1b615
-ARG GOCOVER_COBERTURA_REPO="https://github.com/boumenot/gocover-cobertura"
-ARG GOCOVER_COBERTURA_FILE="gocover-cobertura.linux.x64.7z"
-ARG GOCOVER_COBERTURA_URL="${GOCOVER_COBERTURA_REPO}/releases/download/v${GOCOVER_COBERTURA_VERSION}/${GOCOVER_COBERTURA_FILE}"
-
-# hadolint ignore=DL4001
-RUN wget \
-        --no-verbose \
-        --output-document="/tmp/${GOCOVER_COBERTURA_FILE}" \
-        "${GOCOVER_COBERTURA_URL}" \
-    && echo "${GOCOVER_COBERTURA_SHA265}  /tmp/${GOCOVER_COBERTURA_FILE}" \
-        > "/tmp/${GOCOVER_COBERTURA_FILE}.sha256" \
-    && sha256sum -c "/tmp/${GOCOVER_COBERTURA_FILE}.sha256" \
-    && 7z e -o/tools "/tmp/${GOCOVER_COBERTURA_FILE}" \
-    && chmod +x /tools/gocover-cobertura
-
 # NOTE(jkoelker) From here we care about layers
 FROM golang:1.19.3-alpine3.15
 

--- a/Makefile
+++ b/Makefile
@@ -485,7 +485,7 @@ super-lint-shell: ## open a shell in the super-linter container
 .PHONY: test
 test: ## go test with race detector and code coverage
 	$(call print-target)
-	CGO_ENABLED=1 go-acc --covermode=atomic --output=$(COVERAGE).out --ignore=e2e ./... -- -race -short -v
+	CGO_ENABLED=1 go test $(shell go list ./... | grep -v e2e) -- -race -short -v  
 
 .PHONY: integration-test
 integration-test: ## go test with race detector for integration tests

--- a/Makefile
+++ b/Makefile
@@ -486,12 +486,6 @@ super-lint-shell: ## open a shell in the super-linter container
 test: ## go test with race detector and code coverage
 	$(call print-target)
 	CGO_ENABLED=1 go-acc --covermode=atomic --output=$(COVERAGE).out --ignore=e2e ./... -- -race -short -v
-ifneq ($(CI),)
-	gocover-cobertura -by-files < $(COVERAGE).out > $(COVERAGE).xml
-else
-	go tool cover -html=$(COVERAGE).out -o $(COVERAGE).html
-endif
-
 
 .PHONY: integration-test
 integration-test: ## go test with race detector for integration tests


### PR DESCRIPTION
**What problem does this PR solve?**:
saves us 8 minutes from running a devkit build for our unit tests, it just needs go. also we dont use the codecov report so get rid of that as well

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
