### PR TITLE
ci: execute all e2e tests on PR label with one GHA workflow

### DIFF
--- a/.github/workflows/aws-e2e.yaml
+++ b/.github/workflows/aws-e2e.yaml
@@ -2,8 +2,7 @@
 name: E2E Tests - Build AWS AMI
 on:
   workflow_dispatch:
-  pull_request:
-    types: [labeled, synchronize]
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/aws-e2e.yaml
+++ b/.github/workflows/aws-e2e.yaml
@@ -2,21 +2,7 @@
 name: E2E Tests - Build AWS AMI
 on:
   workflow_dispatch:
-    inputs:
-      run-tests:
-        description: "Run all the tests"
-        type: boolean
-        default: false
-        required: false
   workflow_call:
-    inputs:
-      run-tests:
-        description: "Run all the tests"
-        type: boolean
-        default: false
-        required: false
-  pull_request:
-    types: [labeled, synchronize]
 
 permissions:
   contents: read
@@ -24,13 +10,6 @@ permissions:
 
 jobs:
   rune2e:
-    if: |
-      github.event_name == 'pull_request' &&
-      (
-        (github.event.action == 'labeled' &&  github.event.label.name == 'runs-aws-tests') ||
-        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'runs-aws-tests'))
-      ) ||
-      inputs.run-tests == true
     strategy:
       fail-fast: false
       max-parallel: 10

--- a/.github/workflows/aws-e2e.yaml
+++ b/.github/workflows/aws-e2e.yaml
@@ -2,7 +2,19 @@
 name: E2E Tests - Build AWS AMI
 on:
   workflow_dispatch:
+    inputs:
+      run-tests:
+        description: "Run all the tests"
+        type: boolean
+        default: false
+        required: false
   workflow_call:
+    inputs:
+      run-tests:
+        description: "Run all the tests"
+        type: boolean
+        default: false
+        required: false
   pull_request:
     types: [labeled, synchronize]
 
@@ -18,7 +30,7 @@ jobs:
         (github.event.action == 'labeled' &&  github.event.label.name == 'runs-aws-tests') ||
         (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'runs-aws-tests'))
       ) ||
-      contains(fromJson('["workflow_dispatch", "workflow_call"]'), github.event_name)
+      inputs.run-tests == true
     strategy:
       fail-fast: false
       max-parallel: 10

--- a/.github/workflows/aws-e2e.yaml
+++ b/.github/workflows/aws-e2e.yaml
@@ -3,6 +3,8 @@ name: E2E Tests - Build AWS AMI
 on:
   workflow_dispatch:
   workflow_call:
+  pull_request:
+    types: [labeled, synchronize]
 
 permissions:
   contents: read
@@ -10,6 +12,13 @@ permissions:
 
 jobs:
   rune2e:
+    if: |
+      github.event_name == 'pull_request' &&
+      (
+        (github.event.action == 'labeled' &&  github.event.label.name == 'runs-aws-tests') ||
+        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'runs-aws-tests'))
+      ) ||
+      contains(fromJson('["workflow_dispatch", "workflow_call"]'), github.event_name)
     strategy:
       fail-fast: false
       max-parallel: 10
@@ -93,12 +102,6 @@ jobs:
           buildConfig: offline-nvidia
     runs-on: self-hosted
     continue-on-error: false
-    if: |
-      github.event_name == 'pull_request' &&
-      (
-        (github.event.action == 'labeled' &&  (github.event.label.name == 'runs-e2e-tests' || github.event.label.name == 'runs-aws-tests')) ||
-        (github.event.action == 'synchronize' && (contains(github.event.pull_request.labels.*.name, 'runs-e2e-tests') ||  contains(github.event.pull_request.labels.*.name, 'runs-aws-tests')))
-      )
     steps:
       - name: Checkout konvoy-image-builder repository
         uses: actions/checkout@v3

--- a/.github/workflows/azure-e2e.yaml
+++ b/.github/workflows/azure-e2e.yaml
@@ -2,21 +2,7 @@
 name: E2E Tests - Build Azure Image
 on:
   workflow_dispatch:
-    inputs:
-      run-tests:
-        description: "Run all the tests"
-        type: boolean
-        default: false
-        required: false
   workflow_call:
-    inputs:
-      run-tests:
-        description: "Run all the tests"
-        type: boolean
-        default: false
-        required: false
-  pull_request:
-    types: [labeled, synchronize]
 
 permissions:
   contents: read
@@ -24,13 +10,6 @@ permissions:
 
 jobs:
   rune2e:
-    if: |
-      github.event_name == 'pull_request' &&
-      (
-        (github.event.action == 'labeled' &&  github.event.label.name == 'runs-azure-tests') ||
-        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'runs-azure-tests'))
-      ) ||
-      inputs.run-tests == true
     strategy:
       fail-fast: false
       max-parallel: 10

--- a/.github/workflows/azure-e2e.yaml
+++ b/.github/workflows/azure-e2e.yaml
@@ -2,7 +2,19 @@
 name: E2E Tests - Build Azure Image
 on:
   workflow_dispatch:
+    inputs:
+      run-tests:
+        description: "Run all the tests"
+        type: boolean
+        default: false
+        required: false
   workflow_call:
+    inputs:
+      run-tests:
+        description: "Run all the tests"
+        type: boolean
+        default: false
+        required: false
   pull_request:
     types: [labeled, synchronize]
 
@@ -18,7 +30,7 @@ jobs:
         (github.event.action == 'labeled' &&  github.event.label.name == 'runs-azure-tests') ||
         (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'runs-azure-tests'))
       ) ||
-      contains(fromJson('["workflow_dispatch", "workflow_call"]'), github.event_name)
+      inputs.run-tests == true
     strategy:
       fail-fast: false
       max-parallel: 10

--- a/.github/workflows/azure-e2e.yaml
+++ b/.github/workflows/azure-e2e.yaml
@@ -2,8 +2,7 @@
 name: E2E Tests - Build Azure Image
 on:
   workflow_dispatch:
-  pull_request:
-    types: [labeled, synchronize]
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/azure-e2e.yaml
+++ b/.github/workflows/azure-e2e.yaml
@@ -3,6 +3,8 @@ name: E2E Tests - Build Azure Image
 on:
   workflow_dispatch:
   workflow_call:
+  pull_request:
+    types: [labeled, synchronize]
 
 permissions:
   contents: read
@@ -10,6 +12,13 @@ permissions:
 
 jobs:
   rune2e:
+    if: |
+      github.event_name == 'pull_request' &&
+      (
+        (github.event.action == 'labeled' &&  github.event.label.name == 'runs-azure-tests') ||
+        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'runs-azure-tests'))
+      ) ||
+      contains(fromJson('["workflow_dispatch", "workflow_call"]'), github.event_name)
     strategy:
       fail-fast: false
       max-parallel: 10
@@ -21,12 +30,6 @@ jobs:
         - "basic"
     runs-on: self-hosted
     continue-on-error: false
-    if: |
-      github.event_name == 'pull_request' &&
-      (
-        (github.event.action == 'labeled' &&  (github.event.label.name == 'runs-e2e-tests' || github.event.label.name == 'runs-azure-tests')) ||
-        (github.event.action == 'synchronize' && (contains(github.event.pull_request.labels.*.name, 'runs-e2e-tests') ||  contains(github.event.pull_request.labels.*.name, 'runs-azure-tests')))
-      )
     steps:
       - name: Checkout konvoy-image-builder repository
         uses: actions/checkout@v3

--- a/.github/workflows/build-devkit-image.yaml
+++ b/.github/workflows/build-devkit-image.yaml
@@ -1,0 +1,52 @@
+---
+# Devkit image is created and pushed only if it is not already uploaded on docker registry
+# Devkit image reference: mesosphere/konvoy-image-builder-devkit:<SHA>-<ARCH>
+# Devkit image's tag is created using SHA of the Dockerfile.devkit and other files it dependent on
+name: Build and Push Devkit image
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+  workflow_call:
+  push:
+    branches:
+      - main
+env:
+  GITHUB_TOKEN: "${{ secrets.MESOSPHERECI_USER_TOKEN }}"
+
+# ensure that only a single job or workflow using the same concurrency group will run at a time
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-push-devkit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout konvoy-image-builder repository
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Login to dockerhub Registry
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.NEXUS_USERNAME }}
+          password: ${{ secrets.NEXUS_PASSWORD }}
+
+      - name: Login to D2iQ's Mirror Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ secrets.D2IQ_DOCKER_MIRROR_REGISTRY}}
+          username: ${{ secrets.NEXUS_USERNAME }}
+          password: ${{ secrets.NEXUS_PASSWORD }}
+
+      - name: Setup buildkit
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and Push multi arch devkit image
+        run: make devkit-image-push-manifest

--- a/.github/workflows/gcp-e2e.yaml
+++ b/.github/workflows/gcp-e2e.yaml
@@ -2,6 +2,9 @@
 name: E2E Tests - Build GCP Image
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - shalin/gha-*
   pull_request:
     types: [labeled, synchronize]
 
@@ -10,7 +13,37 @@ permissions:
   id-token: write
 
 jobs:
+  set-global-conditions:
+    runs-on: ubuntu-latest
+    outputs:
+      runs_e2e_tests: ${{ steps.set_runs_e2e_tests.outputs.RUNS_E2E_TESTS }}
+    if: |
+      github.event_name == 'pull_request' &&
+      (
+        (github.event.action == 'labeled' &&  github.event.label.name == 'runs-e2e-tests') ||
+        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'runs-e2e-tests'))
+      ) ||
+      contains(fromJson('["schedule", "workflow_call", "workflow_dispatch"]'), github.event_name)
+    steps:
+      - id: set_runs_e2e_tests
+        name: Set RUNS_E2E_TESTS env
+        run: echo "RUNS_E2E_TESTS=run" >> "$GITHUB_OUTPUT"
+
+  print_env:
+    runs-on: ubuntu-latest
+    needs: set-global-conditions
+    steps:
+      - name: print output
+        run: echo "output = ${{needs.set-global-conditions.outputs.runs_e2e_tests}}"
+  build-devkit-image:
+    needs: set-global-conditions
+    if: ${{ needs.set-global-conditions.outputs.runs_e2e_tests == 'run' }}
+    uses: ./.github/workflows/build-devkit-image.yaml
+    secrets: inherit
+
   rune2e:
+    needs: [set-global-conditions, build-devkit-image]
+    if: ${{ needs.set-global-conditions.outputs.runs_e2e_tests == true }}
     strategy:
       fail-fast: false
       max-parallel: 10

--- a/.github/workflows/gcp-e2e.yaml
+++ b/.github/workflows/gcp-e2e.yaml
@@ -2,14 +2,48 @@
 name: E2E Tests - Build GCP Image
 on:
   workflow_dispatch:
+    inputs:
+      run-tests:
+        description: "Run all the tests"
+        type: boolean
+        default: false
+        required: false
   workflow_call:
+    inputs:
+      run-tests:
+        description: "Run all the tests"
+        type: boolean
+        default: false
+        required: false
+  pull_request:
+    types: [labeled, synchronize]
 
 permissions:
   contents: read
   id-token: write
 
 jobs:
+  printcontext:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump GitHub context for debugging github actions
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        shell: bash
+        run: echo "$GITHUB_CONTEXT"
+      - name: Dump Input context for debugging github actions
+        env:
+          INPUT_CONTEXT: ${{ toJson(inputs) }}
+        shell: bash
+        run: echo "$INPUT_CONTEXT"
   rune2e:
+    if: |
+      github.event_name == 'pull_request' &&
+      (
+        (github.event.action == 'labeled' &&  github.event.label.name == 'runs-gcp-tests') ||
+        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'runs-gcp-tests'))
+      ) ||
+      inputs.run-tests == true
     strategy:
       fail-fast: false
       max-parallel: 10
@@ -22,12 +56,6 @@ jobs:
         - "basic"
     runs-on: self-hosted
     continue-on-error: false
-    if: |
-      github.event_name == 'pull_request' &&
-      (
-        (github.event.action == 'labeled' &&  (github.event.label.name == 'runs-e2e-tests' || github.event.label.name == 'runs-gcp-tests')) ||
-        (github.event.action == 'synchronize' && (contains(github.event.pull_request.labels.*.name, 'runs-e2e-tests') ||  contains(github.event.pull_request.labels.*.name, 'runs-gcp-tests')))
-      )
     steps:
       - name: Checkout konvoy-image-builder repository
         uses: actions/checkout@v3

--- a/.github/workflows/gcp-e2e.yaml
+++ b/.github/workflows/gcp-e2e.yaml
@@ -2,48 +2,14 @@
 name: E2E Tests - Build GCP Image
 on:
   workflow_dispatch:
-    inputs:
-      run-tests:
-        description: "Run all the tests"
-        type: boolean
-        default: false
-        required: false
   workflow_call:
-    inputs:
-      run-tests:
-        description: "Run all the tests"
-        type: boolean
-        default: false
-        required: false
-  pull_request:
-    types: [labeled, synchronize]
 
 permissions:
   contents: read
   id-token: write
 
 jobs:
-  printcontext:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dump GitHub context for debugging github actions
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        shell: bash
-        run: echo "$GITHUB_CONTEXT"
-      - name: Dump Input context for debugging github actions
-        env:
-          INPUT_CONTEXT: ${{ toJson(inputs) }}
-        shell: bash
-        run: echo "$INPUT_CONTEXT"
   rune2e:
-    if: |
-      github.event_name == 'pull_request' &&
-      (
-        (github.event.action == 'labeled' &&  github.event.label.name == 'runs-gcp-tests') ||
-        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'runs-gcp-tests'))
-      ) ||
-      inputs.run-tests == true
     strategy:
       fail-fast: false
       max-parallel: 10

--- a/.github/workflows/gcp-e2e.yaml
+++ b/.github/workflows/gcp-e2e.yaml
@@ -2,48 +2,14 @@
 name: E2E Tests - Build GCP Image
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - shalin/gha-*
-  pull_request:
-    types: [labeled, synchronize]
+  workflow_call:
 
 permissions:
   contents: read
   id-token: write
 
 jobs:
-  set-global-conditions:
-    runs-on: ubuntu-latest
-    outputs:
-      runs_e2e_tests: ${{ steps.set_runs_e2e_tests.outputs.RUNS_E2E_TESTS }}
-    if: |
-      github.event_name == 'pull_request' &&
-      (
-        (github.event.action == 'labeled' &&  github.event.label.name == 'runs-e2e-tests') ||
-        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'runs-e2e-tests'))
-      ) ||
-      contains(fromJson('["schedule", "workflow_call", "workflow_dispatch"]'), github.event_name)
-    steps:
-      - id: set_runs_e2e_tests
-        name: Set RUNS_E2E_TESTS env
-        run: echo "RUNS_E2E_TESTS=run" >> "$GITHUB_OUTPUT"
-
-  print_env:
-    runs-on: ubuntu-latest
-    needs: set-global-conditions
-    steps:
-      - name: print output
-        run: echo "output = ${{needs.set-global-conditions.outputs.runs_e2e_tests}}"
-  build-devkit-image:
-    needs: set-global-conditions
-    if: ${{ needs.set-global-conditions.outputs.runs_e2e_tests == 'run' }}
-    uses: ./.github/workflows/build-devkit-image.yaml
-    secrets: inherit
-
   rune2e:
-    needs: [set-global-conditions, build-devkit-image]
-    if: ${{ needs.set-global-conditions.outputs.runs_e2e_tests == true }}
     strategy:
       fail-fast: false
       max-parallel: 10

--- a/.github/workflows/run-all-e2e-tests.yaml
+++ b/.github/workflows/run-all-e2e-tests.yaml
@@ -31,6 +31,8 @@ jobs:
     if: ${{ needs.set-global-conditions.outputs.runs_e2e_tests == 'true' }}
     uses: ./.github/workflows/build-devkit-image.yaml
     secrets: inherit
+    with:
+      run-tests: true
 
   gcp-e2e-tests:
     needs: [set-global-conditions, build-devkit-image]
@@ -45,15 +47,21 @@ jobs:
     if: ${{ needs.set-global-conditions.outputs.runs_e2e_tests == 'true' }}
     uses: ./.github/workflows/aws-e2e.yaml
     secrets: inherit
+    with:
+      run-tests: true
 
   vsphere-e2e-tests:
     needs: [set-global-conditions, build-devkit-image]
     if: ${{ needs.set-global-conditions.outputs.runs_e2e_tests == 'true' }}
     uses: ./.github/workflows/vsphere-e2e.yaml
     secrets: inherit
+    with:
+      run-tests: true
 
   azure-e2e-tests:
     needs: [set-global-conditions, build-devkit-image]
     if: ${{ needs.set-global-conditions.outputs.runs_e2e_tests == 'true' }}
     uses: ./.github/workflows/azure-e2e.yaml
     secrets: inherit
+    with:
+      run-tests: true

--- a/.github/workflows/run-all-e2e-tests.yaml
+++ b/.github/workflows/run-all-e2e-tests.yaml
@@ -1,5 +1,5 @@
 # Runs Azure tests when pull request opened, repopened or synchronized
-name: E2E Tests - Run all tests on PR
+name: E2E Tests - Run all the tests on PR
 on:
   workflow_dispatch:
   pull_request:
@@ -10,58 +10,61 @@ permissions:
   id-token: write
 
 jobs:
-  set-global-conditions:
-    runs-on: ubuntu-latest
-    outputs:
-      runs_e2e_tests: ${{ steps.set_runs_e2e_tests.outputs.RUNS_E2E_TESTS }}
+  build-devkit-image:
     if: |
       github.event_name == 'pull_request' &&
       (
-        (github.event.action == 'labeled' &&  github.event.label.name == 'runs-e2e-tests-temp') ||
-        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'runs-e2e-tests-temp'))
+        (contains(fromJson('["labeled", "synchronize"]'), github.event.action)) &&
+        (contains(toJson(github.event.pull_request.labels.*.name), '-tests'))
       ) ||
       contains(fromJson('["workflow_dispatch"]'), github.event_name)
-    steps:
-      - id: set_runs_e2e_tests
-        name: Set RUNS_E2E_TESTS env
-        run: echo "RUNS_E2E_TESTS=true" >> "$GITHUB_OUTPUT"
-
-  build-devkit-image:
-    needs: set-global-conditions
-    if: ${{ needs.set-global-conditions.outputs.runs_e2e_tests == 'true' }}
     uses: ./.github/workflows/build-devkit-image.yaml
     secrets: inherit
-    with:
-      run-tests: true
 
   gcp-e2e-tests:
-    needs: [set-global-conditions, build-devkit-image]
-    if: ${{ needs.set-global-conditions.outputs.runs_e2e_tests == 'true' }}
+    needs: [build-devkit-image]
+    if: |
+      github.event_name == 'pull_request' &&
+      (
+        (github.event.action == 'labeled' &&  (github.event.label.name == 'runs-e2e-tests-temp' || github.event.label.name == 'runs-gcp-tests')) ||
+        (github.event.action == 'synchronize' && (contains(github.event.pull_request.labels.*.name, 'runs-e2e-tests-temp') ||  contains(github.event.pull_request.labels.*.name, 'runs-gcp-tests')))
+      ) ||
+      contains(fromJson('["workflow_dispatch"]'), github.event_name)
     uses: ./.github/workflows/gcp-e2e.yaml
     secrets: inherit
-    with:
-      run-tests: true
   
   aws-e2e-tests:
-    needs: [set-global-conditions, build-devkit-image]
-    if: ${{ needs.set-global-conditions.outputs.runs_e2e_tests == 'true' }}
+    needs: [build-devkit-image]
+    if: |
+      github.event_name == 'pull_request' &&
+      (
+        (github.event.action == 'labeled' &&  (github.event.label.name == 'runs-e2e-tests-temp' || github.event.label.name == 'runs-aws-tests')) ||
+        (github.event.action == 'synchronize' && (contains(github.event.pull_request.labels.*.name, 'runs-e2e-tests-temp') ||  contains(github.event.pull_request.labels.*.name, 'runs-aws-tests')))
+      ) ||
+      contains(fromJson('["workflow_dispatch"]'), github.event_name)
     uses: ./.github/workflows/aws-e2e.yaml
     secrets: inherit
-    with:
-      run-tests: true
 
   vsphere-e2e-tests:
-    needs: [set-global-conditions, build-devkit-image]
-    if: ${{ needs.set-global-conditions.outputs.runs_e2e_tests == 'true' }}
+    needs: [build-devkit-image]
+    if: |
+      github.event_name == 'pull_request' &&
+      (
+        (github.event.action == 'labeled' &&  (github.event.label.name == 'runs-e2e-tests-temp' || github.event.label.name == 'runs-vsphere-tests')) ||
+        (github.event.action == 'synchronize' && (contains(github.event.pull_request.labels.*.name, 'runs-e2e-tests-temp') ||  contains(github.event.pull_request.labels.*.name, 'runs-vsphere-tests')))
+      ) ||
+      contains(fromJson('["workflow_dispatch"]'), github.event_name)
     uses: ./.github/workflows/vsphere-e2e.yaml
     secrets: inherit
-    with:
-      run-tests: true
 
   azure-e2e-tests:
-    needs: [set-global-conditions, build-devkit-image]
-    if: ${{ needs.set-global-conditions.outputs.runs_e2e_tests == 'true' }}
+    needs: [build-devkit-image]
+    if: |
+      github.event_name == 'pull_request' &&
+      (
+        (github.event.action == 'labeled' &&  (github.event.label.name == 'runs-e2e-tests-temp' || github.event.label.name == 'runs-azure-tests')) ||
+        (github.event.action == 'synchronize' && (contains(github.event.pull_request.labels.*.name, 'runs-e2e-tests-temp') ||  contains(github.event.pull_request.labels.*.name, 'runs-azure-tests')))
+      ) ||
+      contains(fromJson('["workflow_dispatch"]'), github.event_name)
     uses: ./.github/workflows/azure-e2e.yaml
     secrets: inherit
-    with:
-      run-tests: true

--- a/.github/workflows/run-all-e2e-tests.yaml
+++ b/.github/workflows/run-all-e2e-tests.yaml
@@ -37,6 +37,8 @@ jobs:
     if: ${{ needs.set-global-conditions.outputs.runs_e2e_tests == 'true' }}
     uses: ./.github/workflows/gcp-e2e.yaml
     secrets: inherit
+    with:
+      run-tests: true
   
   aws-e2e-tests:
     needs: [set-global-conditions, build-devkit-image]

--- a/.github/workflows/run-all-e2e-tests.yaml
+++ b/.github/workflows/run-all-e2e-tests.yaml
@@ -1,0 +1,57 @@
+# Runs Azure tests when pull request opened, repopened or synchronized
+name: E2E Tests - Run all tests on PR
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [labeled, synchronize]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  set-global-conditions:
+    runs-on: ubuntu-latest
+    outputs:
+      runs_e2e_tests: ${{ steps.set_runs_e2e_tests.outputs.RUNS_E2E_TESTS }}
+    if: |
+      github.event_name == 'pull_request' &&
+      (
+        (github.event.action == 'labeled' &&  github.event.label.name == 'runs-e2e-tests-temp') ||
+        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'runs-e2e-tests-temp'))
+      ) ||
+      contains(fromJson('["workflow_dispatch"]'), github.event_name)
+    steps:
+      - id: set_runs_e2e_tests
+        name: Set RUNS_E2E_TESTS env
+        run: echo "RUNS_E2E_TESTS=true" >> "$GITHUB_OUTPUT"
+
+  build-devkit-image:
+    needs: set-global-conditions
+    if: ${{ needs.set-global-conditions.outputs.runs_e2e_tests == 'true' }}
+    uses: ./.github/workflows/build-devkit-image.yaml
+    secrets: inherit
+
+  gcp-e2e-tests:
+    needs: [set-global-conditions, build-devkit-image]
+    if: ${{ needs.set-global-conditions.outputs.runs_e2e_tests == 'true' }}
+    uses: ./.github/workflows/gcp-e2e.yaml
+    secrets: inherit
+  
+  aws-e2e-tests:
+    needs: [set-global-conditions, build-devkit-image]
+    if: ${{ needs.set-global-conditions.outputs.runs_e2e_tests == 'true' }}
+    uses: ./.github/workflows/aws-e2e.yaml
+    secrets: inherit
+
+  vsphere-e2e-tests:
+    needs: [set-global-conditions, build-devkit-image]
+    if: ${{ needs.set-global-conditions.outputs.runs_e2e_tests == 'true' }}
+    uses: ./.github/workflows/vsphere-e2e.yaml
+    secrets: inherit
+
+  azure-e2e-tests:
+    needs: [set-global-conditions, build-devkit-image]
+    if: ${{ needs.set-global-conditions.outputs.runs_e2e_tests == 'true' }}
+    uses: ./.github/workflows/azure-e2e.yaml
+    secrets: inherit

--- a/.github/workflows/vsphere-e2e.yaml
+++ b/.github/workflows/vsphere-e2e.yaml
@@ -2,7 +2,19 @@
 name: E2E Tests - Build Vsphere template
 on:
   workflow_dispatch:
+    inputs:
+      run-tests:
+        description: "Run all the tests"
+        type: boolean
+        default: false
+        required: false
   workflow_call:
+    inputs:
+      run-tests:
+        description: "Run all the tests"
+        type: boolean
+        default: false
+        required: false
   pull_request:
     types: [labeled, synchronize]
 
@@ -18,7 +30,7 @@ jobs:
         (github.event.action == 'labeled' &&  github.event.label.name == 'runs-vsphere-tests') ||
         (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'runs-vsphere-tests'))
       ) ||
-      contains(fromJson('["workflow_dispatch", "workflow_call"]'), github.event_name)
+      inputs.run-tests == true
     strategy:
       fail-fast: false
       max-parallel: 3

--- a/.github/workflows/vsphere-e2e.yaml
+++ b/.github/workflows/vsphere-e2e.yaml
@@ -2,8 +2,7 @@
 name: E2E Tests - Build Vsphere template
 on:
   workflow_dispatch:
-  pull_request:
-    types: [labeled, synchronize]
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/vsphere-e2e.yaml
+++ b/.github/workflows/vsphere-e2e.yaml
@@ -2,21 +2,7 @@
 name: E2E Tests - Build Vsphere template
 on:
   workflow_dispatch:
-    inputs:
-      run-tests:
-        description: "Run all the tests"
-        type: boolean
-        default: false
-        required: false
   workflow_call:
-    inputs:
-      run-tests:
-        description: "Run all the tests"
-        type: boolean
-        default: false
-        required: false
-  pull_request:
-    types: [labeled, synchronize]
 
 permissions:
   contents: read
@@ -24,13 +10,6 @@ permissions:
 
 jobs:
   rune2e:
-    if: |
-      github.event_name == 'pull_request' &&
-      (
-        (github.event.action == 'labeled' &&  github.event.label.name == 'runs-vsphere-tests') ||
-        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'runs-vsphere-tests'))
-      ) ||
-      inputs.run-tests == true
     strategy:
       fail-fast: false
       max-parallel: 3

--- a/.github/workflows/vsphere-e2e.yaml
+++ b/.github/workflows/vsphere-e2e.yaml
@@ -3,6 +3,8 @@ name: E2E Tests - Build Vsphere template
 on:
   workflow_dispatch:
   workflow_call:
+  pull_request:
+    types: [labeled, synchronize]
 
 permissions:
   contents: read
@@ -10,6 +12,13 @@ permissions:
 
 jobs:
   rune2e:
+    if: |
+      github.event_name == 'pull_request' &&
+      (
+        (github.event.action == 'labeled' &&  github.event.label.name == 'runs-vsphere-tests') ||
+        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'runs-vsphere-tests'))
+      ) ||
+      contains(fromJson('["workflow_dispatch", "workflow_call"]'), github.event_name)
     strategy:
       fail-fast: false
       max-parallel: 3
@@ -32,12 +41,6 @@ jobs:
           buildConfig: offline-fips
     runs-on: self-hosted
     continue-on-error: false
-    if: |
-      github.event_name == 'pull_request' &&
-      (
-        (github.event.action == 'labeled' &&  (github.event.label.name == 'runs-e2e-tests' || github.event.label.name == 'runs-vsphere-tests')) ||
-        (github.event.action == 'synchronize' && (contains(github.event.pull_request.labels.*.name, 'runs-e2e-tests') ||  contains(github.event.pull_request.labels.*.name, 'runs-vsphere-tests')))
-      )
     steps:
       - uses: actions/checkout@v3
         with:

--- a/Dockerfile.devkit
+++ b/Dockerfile.devkit
@@ -87,10 +87,10 @@ RUN apk add --no-cache \
 RUN mkdir -p /usr/share/ansible/collections \
     && ansible-galaxy \
     collection install \
-    community.general \
-    ansible.netcommon \
-    ansible.posix \
-    ansible.utils \
+    community.general:==6.4.0 \
+    ansible.netcommon:==5.0.0 \
+    ansible.posix:==1.5.1 \
+    ansible.utils:==2.9.0 \
     -p /usr/share/ansible/collections
 
 # hadolint ignore=DL4006

--- a/Makefile
+++ b/Makefile
@@ -215,16 +215,6 @@ devkit-image-push-manifest: devkit-image-amd64 devkit-image-arm64
 	--amend $(DEVKIT_IMAGE_NAME):$(DEVKIT_IMAGE_TAG)-arm64
 	docker manifest push $(DEVKIT_IMAGE_NAME):$(DEVKIT_IMAGE_TAG)
 
-# TODO: Deprecate this target
-.PHONY: devkit.run
-devkit.run: ## run $(WHAT) in devkit
-devkit.run: devkit-image
-	docker run \
-		$(DOCKER_DEVKIT_DEFAULT_ARGS) \
-		$(DOCKER_DEVKIT_ARGS) \
-		$(DEVKIT_IMAGE_NAME):$(DEVKIT_IMAGE_TAG) \
-		$(WHAT)
-
 ##### Build KIB container image
 export DOCKER_REPOSITORY ?= mesosphere/konvoy-image-builder
 export DOCKER_IMG ?= $(DOCKER_REPOSITORY):$(REPO_REV)-$(BUILDARCH)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ See [`konvoy-image`](docs/cli/konvoy-image.md)
 * [Docker](https://docs.docker.com/get-docker/)
 * [Docker Buildx](https://docs.docker.com/build/install-buildx/)
 * [goreleaser](https://goreleaser.com/install/)
+* [magefile](https://magefile.org/)
 
 ### Linting
 
@@ -70,18 +71,12 @@ will fail under `super-linter`, and is skipped for
 
 ### Testing
 
-To run a specific end-to-end test, use a subset of the commands used to run the complete set of end-to-end tests in CI.
+[Magefile](https://magefile.org/) tool is used to run konvoy image builder e2e tests.
 
-In this example, we run the end-to-end test against the latest version of Flatcar Linux:
-
+In this example, we run the end-to-end test against the Centos 7.9 with air-gapped and fips configuration in AWS
 ```sh
-WHAT="make flatcar-version.yaml" make devkit.run
-make devkit.run \
-    WHAT="./bin/konvoy-image build images/ami/flatcar.yaml --overrides flatcar-version.yaml -v 5" \
-    INTERACTIVE=""
-make docker.clean-latest-ami
+runE2e "centos 7.9" "offline-fips" aws false
 ```
-
 ### Building
 
 To build the CLI command run:


### PR DESCRIPTION
**What problem does this PR solve?**:
- Simplifies conditions to execute e2e jobs
- One job to control execution of all the e2e tests on a PR label
- Ensure devkit image is available on dockerhub before running tests
- Make it easy to navigate all e2e tests for current PR in one place in GHA UI

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
