### PR TITLE
build: cache ansible collections in devkit image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,15 +25,6 @@ RUN apk add --no-cache \
         py3-wheel \
     && pip3 install --no-cache-dir --requirement /tmp/requirements.txt \
     && rm -rf /root/.cache
-# Managing the below ansible dependencies is covered in docs/dev/ansible-modules.md
-RUN mkdir -p /usr/share/ansible/collections \
-    && ansible-galaxy \
-    collection install \
-    community.general \
-    ansible.netcommon \
-    ansible.posix \
-    ansible.utils \
-    -p /usr/share/ansible/collections
 
 ARG BUILDARCH
 # we copy this to remote hosts to execute GOSS
@@ -45,6 +36,7 @@ COPY --from=devkit /usr/local/bin/packer-${BUILDARCH} /usr/local/bin/packer
 COPY --from=devkit /usr/local/bin/packer-provisioner-goss-${BUILDARCH} /usr/local/bin/packer-provisioner-goss
 COPY --from=devkit /usr/local/bin/govc /usr/local/bin/
 COPY --from=devkit /root/.config/packer/plugins/ ${PACKER_PLUGIN_PATH}
+COPY --from=devkit /usr/share/ansible/collections/ansible_collections/ /usr/share/ansible/collections/ansible_collections/
 COPY bin/konvoy-image-${BUILDARCH} /usr/local/bin/konvoy-image
 COPY images /root/images
 COPY ansible /root/ansible

--- a/Dockerfile.devkit
+++ b/Dockerfile.devkit
@@ -82,6 +82,15 @@ RUN apk add --no-cache \
         --requirement /tmp/requirements-devkit.txt \
     && rm -rf \
         /root/.cache
+# Managing the below ansible dependencies is covered in docs/dev/ansible-modules.md
+RUN mkdir -p /usr/share/ansible/collections \
+    && ansible-galaxy \
+    collection install \
+    community.general \
+    ansible.netcommon \
+    ansible.posix \
+    ansible.utils \
+    -p /usr/share/ansible/collections
 
 # hadolint ignore=DL4006
 RUN  curl -Lf https://github.com/mesosphere/mindthegap/releases/download/v"${MINDTHEGAP_VERSION}"/mindthegap_v"${MINDTHEGAP_VERSION}"_linux_amd64.tar.gz |tar xzf - -C /usr/local/bin


### PR DESCRIPTION
**What problem does this PR solve?**:
Installing ansible collection is the most time consuming step when building KIB container image. Caching it in devkit container should save around `1m30s` when building the image.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
Tested locally.
```bash
❯ docker run --entrypoint '/bin/sh' -it --rm mesosphere/konvoy-image-builder:v2.2.1-15-ge02168df3248-amd64
~ # ls
ansible  images   packer
~ # ls /usr/share/ansible/collections/ansible_collections/
ansible                       ansible.posix-1.5.1.info      community
ansible.netcommon-5.0.0.info  ansible.utils-2.9.0.info      community.general-6.4.0.info
~ # ansible-galaxy collection list

# /usr/share/ansible/collections/ansible_collections
Collection        Version
----------------- -------
ansible.netcommon 5.0.0
ansible.posix     1.5.1
ansible.utils     2.9.0
community.general 6.4.0
```
E2E tests are passing too.

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
