### PR TITLE
fix: set correct compute_gallery_image_id

### DIFF
--- a/pkg/packer/manifests/azure/packer.pkr.hcl
+++ b/pkg/packer/manifests/azure/packer.pkr.hcl
@@ -485,7 +485,7 @@ build {
       distribution_version   = "${var.distribution_version}"
       kubernetes_cni_version = "${var.kubernetes_cni_semver}"
       kubernetes_version     = "${var.kubernetes_full_version}"
-      compute_gallery_image_id = "/subscriptions/${var.subscription_id}}/resourceGroups/${var.resource_group_name}/providers/Microsoft.Compute/galleries/${var.shared_image_gallery_name}/images/${var.gallery_image_name}/versions/${local.shared_image_gallery_image_version}"
+      compute_gallery_image_id = "/subscriptions/${var.subscription_id}/resourceGroups/${var.resource_group_name}/providers/Microsoft.Compute/galleries/${var.shared_image_gallery_name}/images/${var.gallery_image_name}/versions/${local.shared_image_gallery_image_version}"
     }
     output = "${var.manifest_output}"
   }


### PR DESCRIPTION
**What problem does this PR solve?**:
The `compute_gallery_image_id` in the manifest contains an extra `}` what makes CAPZ to fail to find this image.

This commit removes the extra wrong character.

**Which issue(s) does this PR fix?**:
https://jira.d2iq.com/browse/D2IQ-DIDNCREATEONE


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->

**Does this PR introduce a user-facing change?**:
```release-note
fixes the azure `compute_gallery_image_id` on the `manifest.json` file
```