### PR TITLE
feat: do not copy stdin and set tty to false 

### DIFF
--- a/cmd/konvoy-image-wrapper/cmd/wrapper.go
+++ b/cmd/konvoy-image-wrapper/cmd/wrapper.go
@@ -289,7 +289,6 @@ func (r *Runner) setupSSHAgent() {
 }
 
 func (r *Runner) dockerRun(args []string) error {
-	//nolint:gosec // running docker is inherently insecure
 	cmd := exec.Command(
 		"docker", "run",
 		"--interactive",

--- a/cmd/konvoy-image-wrapper/cmd/wrapper.go
+++ b/cmd/konvoy-image-wrapper/cmd/wrapper.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 
 	"github.com/mitchellh/go-homedir"
-	terminal "golang.org/x/term"
 
 	"github.com/mesosphere/konvoy-image-builder/cmd/konvoy-image-wrapper/image"
 	"github.com/mesosphere/konvoy-image-builder/pkg/app"
@@ -73,7 +72,6 @@ func EnvError(o string) error {
 
 type Runner struct {
 	version string
-	tty     bool
 
 	usr                   *user.User
 	usrGroup              *user.Group
@@ -99,7 +97,6 @@ func NewRunner() *Runner {
 	}
 
 	return &Runner{
-		tty:                   terminal.IsTerminal(int(os.Stdout.Fd())),
 		homeDir:               home,
 		supplementaryGroupIDs: []int{},
 		env:                   map[string]string{},
@@ -296,7 +293,7 @@ func (r *Runner) dockerRun(args []string) error {
 	cmd := exec.Command(
 		"docker", "run",
 		"--interactive",
-		"--tty="+strconv.FormatBool(r.tty),
+		"--tty=false",
 		"--rm",
 		"--net=host",
 		"-w", containerWorkingDir,
@@ -335,7 +332,6 @@ func (r *Runner) dockerRun(args []string) error {
 
 	cmd.Args = append(cmd.Args, image.Tag())
 	cmd.Args = append(cmd.Args, args...)
-	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 


### PR DESCRIPTION
**What problem does this PR solve?**:
This commit removes the instruction to copy the stdin in the docker wrapper and set tty to true is some cases. We don't need that since we don't expect KIB to read from stdin.


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NOTCREATED

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```