### PR TITLE
[backport release-1.24] fix: Retry containerd yum/rpm tasks up to 30s 

### DIFF
--- a/ansible/roles/containerd/tasks/redhat.yaml
+++ b/ansible/roles/containerd/tasks/redhat.yaml
@@ -24,7 +24,7 @@
   register: result
   until: result is success
   retries: 5
-  delay: 3
+  delay: 6
 
 # Oracle Linux does not have 'tar' or 'gtar' installed
 - name: install tar rpm package
@@ -34,8 +34,8 @@
     update_cache: true
   register: result
   until: result is success
-  retries: 3
-  delay: 3
+  retries: 5
+  delay: 6
   when:
     - ansible_distribution == 'OracleLinux'
 
@@ -46,8 +46,8 @@
     key: "{{ docker_rpm_container_selinux_gpg_key_url }}"
   register: result
   until: result is success
-  retries: 3
-  delay: 3
+  retries: 5
+  delay: 6
   when:
     - ansible_distribution == 'RedHat'
     - ansible_distribution_major_version|int == 7
@@ -65,8 +65,8 @@
     disablerepo: "{{ '*' if offline_mode_enabled else '' }}"
   register: result
   until: result is success
-  retries: 3
-  delay: 3
+  retries: 5
+  delay: 6
 
 - name: install libseccomp rpm package
   yum:
@@ -77,5 +77,5 @@
     disablerepo: "{{ '*' if offline_mode_enabled else '' }}"
   register: result
   until: result is success
-  retries: 3
-  delay: 3
+  retries: 5
+  delay: 6


### PR DESCRIPTION
**What problem does this PR solve?**:
We found that some network failures lasted longer than 9s.


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://d2iq.atlassian.net/browse/D2IQ-93681


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
