### PR TITLE
[backport 1.24] ci: update vsphere base template defaults

### DIFF
--- a/hack/vsphere/main.tf
+++ b/hack/vsphere/main.tf
@@ -16,7 +16,7 @@ variable "datacenter_name" {
 
 variable "datastore_name" {
   description = "The datastore name"
-  default     = "ovh-nfs"
+  default     = "tmp-iscsi-ovh"
 }
 
 variable "resource_pool_name" {
@@ -36,13 +36,13 @@ variable "network_name_public" {
 
 variable "bastion_vm_template" {
   description = "The VM template name for the bastion machine"
-  default     = "kib-builder-template"
+  default     = "base-centos-7"
 }
 
 
 variable "root_user" {
   description = "The root user"
-  default     = "builder"
+  default     = "centos"
 }
 
 data "vsphere_datacenter" "dc" {
@@ -81,7 +81,7 @@ resource "vsphere_virtual_machine" "konvoy-e2e-bastion" {
 
   num_cpus = 4
   memory   = 6144
-  guest_id = "centos7_64Guest"
+  guest_id = "centos64Guest"
 
 
   network_interface {

--- a/images/ova/rhel-79.yaml
+++ b/images/ova/rhel-79.yaml
@@ -13,7 +13,7 @@ packer:
   insecure_connection: "false"
   network: ""
   resource_pool: ""
-  template: "base-rhel-7.9"
+  template: "os-qualification-templates/d2iq-base-RHEL-79"
   vsphere_guest_os_type: "rhel7_64Guest"
   guest_os_type: "rhel7-64"
   # goss params

--- a/images/ova/rhel-84.yaml
+++ b/images/ova/rhel-84.yaml
@@ -13,7 +13,7 @@ packer:
   insecure_connection: "false"
   network: ""
   resource_pool: ""
-  template: "base-rhel-8.4" # change default value with your base template name
+  template: "os-qualification-templates/d2iq-base-RHEL-84" # change default value with your base template name
   vsphere_guest_os_type: "rhel8_64Guest"
   guest_os_type: "rhel8-64"
   # goss params

--- a/images/ova/rhel-86.yaml
+++ b/images/ova/rhel-86.yaml
@@ -13,7 +13,7 @@ packer:
   insecure_connection: "false"
   network: ""
   resource_pool: ""
-  template: "base-rhel-8.6" # change default value with your base template name
+  template: "os-qualification-templates/d2iq-base-RHEL-86" # change default value with your base template name
   vsphere_guest_os_type: "rhel8_64Guest"
   guest_os_type: "rhel8-64"
   # goss params


### PR DESCRIPTION
* ci: update vsphere bastion base template defaults

* fix: change location of base template

* fix: use OS qualification templates for KIB e2e tests

* fix: ubuntu template

---------

**What problem does this PR solve?**:


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
