### PR TITLE
test: excluded unsupported rocky 9.1 offline-fips test

### DIFF
--- a/.github/workflows/vsphere-e2e.yaml
+++ b/.github/workflows/vsphere-e2e.yaml
@@ -29,6 +29,8 @@ jobs:
           buildConfig: fips
         - os: "ubuntu 20.04"
           buildConfig: offline-fips
+        - os: "rocky 9.1"
+          buildConfig: offline-fips
     runs-on: self-hosted
     continue-on-error: false
     if: |


### PR DESCRIPTION
**What problem does this PR solve?**:
Rocky 9.1 does not have FIPS support. This PR excludes it from the e2e test.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
