### PR TITLE
FIX: cloud init on EL7

### DIFF
--- a/ansible/roles/providers/files/cloud-init-vmware.sh
+++ b/ansible/roles/providers/files/cloud-init-vmware.sh
@@ -16,7 +16,10 @@ fi
 # PYTHON_VERSION may be 2 or 3 and indicates which version of Python
 # is used by cloud-init. This variable is not set until PY_MOD_CLOUD_INIT
 # is resolved.
-PYTHON_VERSION=
+CLOUD_INIT_PYTHON=$(head -1 $(command -v cloud-init || echo /dev/null)  | cut -c 3-)
+echo "cloud-init python: ${CLOUD_INIT_PYTHON}"
+PYTHON_VERSION=$(${CLOUD_INIT_PYTHON} -c 'import sys;print(sys.version_info.major)' || echo "")
+
 get_py_mod_dir() {
   _script='import os; import '"${1-}"'; print(os.path.dirname('"${1-}"'.__file__));'
   case "${PYTHON_VERSION}" in

--- a/ansible/roles/providers/tasks/vmware-cloudinit.yml
+++ b/ansible/roles/providers/tasks/vmware-cloudinit.yml
@@ -1,0 +1,110 @@
+- name: Install cloud-init packages
+  apt:
+    name: "{{ packages }}"
+    state: present
+    force_apt_get: true
+  vars:
+    packages:
+      - cloud-init
+      - cloud-guest-utils
+      - cloud-initramfs-copymods
+      - cloud-initramfs-dyn-netconf
+  when: ansible_os_family == "Debian"
+
+- name: Install cloud-init packages
+  yum:
+    name: "{{ packages }}"
+    state: present
+    enablerepo: "{{ 'offline' if offline_mode_enabled else '' }}"
+    disablerepo: "{{ '*' if offline_mode_enabled else '' }}"
+  vars:
+    packages:
+      - cloud-init
+      - cloud-utils-growpart
+      - "python{{ '3' if ansible_distribution_major_version|int >= 9 else '2'}}-pip"
+  when: ansible_os_family == "RedHat"
+
+- name: Install cloud-init packages
+  zypper:
+    name: "{{ packages }}"
+    state: present
+  vars:
+    packages:
+      - cloud-init
+      - cloud-init-vmware-guestinfo
+  when: ansible_os_family == "Suse"
+  register: result
+  until: result is success
+  retries: 15
+  delay: 60
+
+- name: Install cloud-init and tools for VMware Photon OS
+  command: tdnf install {{ packages }} -y
+  vars:
+    packages: "cloud-init cloud-utils python3-netifaces"
+  when: ansible_os_family == "VMware Photon OS"
+
+# pip on CentOS needs to be upgraded, but since it's still
+# Python 2.7, need < 21.0
+- name: Upgrade pip
+  pip:
+    name: pip<21.0
+    extra_args: "{{ '--no-index --find-links=' + pip_packages_remote_filesystem_repo_path if offline_mode_enabled }}"
+    state: forcereinstall
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'
+
+- name: Copy vmware guestinfo datasource
+  copy:
+    src: "{{ item }}"
+    dest: /tmp/
+    owner: root
+    group: root
+    mode: 0755
+  with_items:
+    - cloud-init-vmware.sh
+    - DataSourceVMwareGuestInfo.py
+
+- name: Copy cloud-init config file for vmware
+  copy:
+    src: files/etc/cloud/cloud.cfg.d/99-DataSourceVMwareGuestInfo.cfg
+    dest: /etc/cloud/cloud.cfg.d/99-DataSourceVMwareGuestInfo.cfg
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Remove subiquity-disable-cloudinit-networking.cfg
+  file:
+    path: /etc/cloud/cloud.cfg.d/subiquity-disable-cloudinit-networking.cfg
+    state: absent
+
+- name: Remove 99-installer.cfg
+  file:
+    path: /etc/cloud/cloud.cfg.d/99-installer.cfg
+    state: absent
+
+# this program used by ds-identify to determine whether or not the
+# VMwareGuestInfo datasource is useable.
+- name: Create ds-check program to verify VMwareGuestInfo datasource
+  copy:
+    src: files/dscheck_VMwareGuestInfo.sh
+    dest: /usr/bin/dscheck_VMwareGuestInfo
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Execute cloud-init-vmware.sh
+  shell: bash -o errexit -o pipefail /tmp/cloud-init-vmware.sh
+  environment:
+    VMWARE_DS_PATH: '/tmp/DataSourceVMwareGuestInfo.py'
+
+- name: Remove cloud-init-vmware.sh
+  file:
+    path: /tmp/cloud-init-vmware.sh
+    state: absent
+
+- name: >-
+    Remove cloud-init /etc/cloud/cloud.cfg.d/99-disable-networking-config.cfg
+  file:
+    path: /etc/cloud/cloud.cfg.d/99-disable-networking-config.cfg
+    state: absent
+  when: ansible_os_family == "VMware Photon OS"

--- a/ansible/roles/providers/tasks/vmware.yml
+++ b/ansible/roles/providers/tasks/vmware.yml
@@ -12,122 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-- name: Install cloud-init packages
-  apt:
-    name: "{{ packages }}"
-    state: present
-    force_apt_get: true
-  vars:
-    packages:
-      - cloud-init
-      - cloud-guest-utils
-      - cloud-initramfs-copymods
-      - cloud-initramfs-dyn-netconf
-  when: ansible_os_family == "Debian"
+- name: Get cloud-init version when in path
+  shell: command -v cloud-init 2>&1 >/dev/null && cloud-init --version 2>&1 | cut -d' ' -f2
+  register: cloud_init_version_cmd
+  changed_when: false
 
-- name: Install cloud-init packages
-  yum:
-    name: "{{ packages }}"
-    state: present
-    enablerepo: "{{ 'offline' if offline_mode_enabled else '' }}"
-    disablerepo: "{{ '*' if offline_mode_enabled else '' }}"
-  vars:
-    packages:
-      - cloud-init
-      - cloud-utils-growpart
-      - "python{{ '3' if ansible_distribution_major_version|int >= 9 else '2'}}-pip"
-  when: ansible_os_family == "RedHat"
+- name: Set cloud-init version fact
+  set_fact:
+    cloud_init_version: cloud_init_version_cmd.stdout
 
-- name: Install cloud-init packages
-  zypper:
-    name: "{{ packages }}"
-    state: present
-  vars:
-    packages:
-      - cloud-init
-      - cloud-init-vmware-guestinfo
-  when: ansible_os_family == "Suse"
-  register: result
-  until: result is success
-  retries: 15
-  delay: 60
-
-- name: Install cloud-init and tools for VMware Photon OS
-  command: tdnf install {{ packages }} -y
-  vars:
-    packages: "cloud-init cloud-utils python3-netifaces"
-  when: ansible_os_family == "VMware Photon OS"
-
-# pip on CentOS needs to be upgraded, but since it's still
-# Python 2.7, need < 21.0
-- name: Upgrade pip
-  pip:
-    name: pip<21.0
-    extra_args: "{{ '--no-index --find-links=' + pip_packages_remote_filesystem_repo_path if offline_mode_enabled }}"
-    state: forcereinstall
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'
-
-- name: Copy vmware guestinfo datasource
-  copy:
-    src: "{{ item }}"
-    dest: /tmp/
-    owner: root
-    group: root
-    mode: 0755
-  with_items:
-    - cloud-init-vmware.sh
-    - DataSourceVMwareGuestInfo.py
-
-- name: Copy cloud-init config file for vmware
-  copy:
-    src: files/etc/cloud/cloud.cfg.d/99-DataSourceVMwareGuestInfo.cfg
-    dest: /etc/cloud/cloud.cfg.d/99-DataSourceVMwareGuestInfo.cfg
-    owner: root
-    group: root
-    mode: 0644
-
-- name: Remove subiquity-disable-cloudinit-networking.cfg
-  file:
-    path: /etc/cloud/cloud.cfg.d/subiquity-disable-cloudinit-networking.cfg
-    state: absent
-
-- name: Remove 99-installer.cfg
-  file:
-    path: /etc/cloud/cloud.cfg.d/99-installer.cfg
-    state: absent
-
-# this program used by ds-identify to determine whether or not the
-# VMwareGuestInfo datasource is useable.
-- name: Create ds-check program to verify VMwareGuestInfo datasource
-  copy:
-    src: files/dscheck_VMwareGuestInfo.sh
-    dest: /usr/bin/dscheck_VMwareGuestInfo
-    owner: root
-    group: root
-    mode: 0755
-
-- name: Execute cloud-init-vmware.sh
-  shell: bash -o errexit -o pipefail /tmp/cloud-init-vmware.sh
-  environment:
-    VMWARE_DS_PATH: '/tmp/DataSourceVMwareGuestInfo.py'
-
-- name: Remove cloud-init-vmware.sh
-  file:
-    path: /tmp/cloud-init-vmware.sh
-    state: absent
-
-- name: >-
-    Remove cloud-init /etc/cloud/cloud.cfg.d/99-disable-networking-config.cfg
-  file:
-    path: /etc/cloud/cloud.cfg.d/99-disable-networking-config.cfg
-    state: absent
-  when: ansible_os_family == "VMware Photon OS"
-
-# - name: Unlock password
-#   replace:
-#     path: /etc/cloud/cloud.cfg
-#     regexp: '(?i)lock_passwd: True'
-#     replace: 'lock_passwd: False'
+# when cloud-init 21.3 or higher is installed to not touch it
+- name: Cloud-init patches for cloud-init versions <21.3
+  include_tasks: vmware-cloudinit.yml
+  when: ( cloud_init_version == "" ) or (cloud_init_version is version('21.3', '<'))
 
 - name: Get a list of services
   service_facts:


### PR DESCRIPTION
**What problem does this PR solve?**:
When EL7 images come with cloud-init or have python3 installed KIB either overrides cloud-init files or uses the wrong python and sometimes even both.

This is due to missing guards in ansible.

The patch script also does not check which python cloud-init uses but will use python3 if its installed which is wrong in the case of cloud-init 19 on EL7

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-96572


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
