### PR TITLE
fix: pin ansible collection versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,15 +25,6 @@ RUN apk add --no-cache \
         py3-wheel \
     && pip3 install --no-cache-dir --requirement /tmp/requirements.txt \
     && rm -rf /root/.cache
-# Managing the below ansible dependencies is covered in docs/dev/ansible-modules.md
-RUN mkdir -p /usr/share/ansible/collections \
-    && ansible-galaxy \
-    collection install \
-    community.general \
-    ansible.netcommon \
-    ansible.posix \
-    ansible.utils \
-    -p /usr/share/ansible/collections
 
 ARG BUILDARCH
 # we copy this to remote hosts to execute GOSS
@@ -45,6 +36,7 @@ COPY --from=devkit /usr/local/bin/packer-${BUILDARCH} /usr/local/bin/packer
 COPY --from=devkit /usr/local/bin/packer-provisioner-goss-${BUILDARCH} /usr/local/bin/packer-provisioner-goss
 COPY --from=devkit /usr/local/bin/govc /usr/local/bin/
 COPY --from=devkit /root/.config/packer/plugins/ ${PACKER_PLUGIN_PATH}
+COPY --from=devkit /usr/share/ansible/collections/ansible_collections/ /usr/share/ansible/collections/ansible_collections/
 COPY bin/konvoy-image-${BUILDARCH} /usr/local/bin/konvoy-image
 COPY images /root/images
 COPY ansible /root/ansible

--- a/Dockerfile.devkit
+++ b/Dockerfile.devkit
@@ -91,10 +91,10 @@ RUN apk add --no-cache \
 RUN mkdir -p /usr/share/ansible/collections \
     && ansible-galaxy \
     collection install \
-    community.general \
-    ansible.netcommon \
-    ansible.posix \
-    ansible.utils \
+    community.general:==6.4.0 \
+    ansible.netcommon:==5.0.0 \
+    ansible.posix:==1.5.1 \
+    ansible.utils:==2.9.0 \
     -p /usr/share/ansible/collections
 
 # hadolint ignore=DL4006


### PR DESCRIPTION
**What problem does this PR solve?**:
The latest ansible plugin `community.general` `6.5.0` breaks existing behavior of the `redhat_subscription` module. Issue: https://github.com/ansible-collections/community.general/issues/6258
As a result kib jobs fails when running RHEL builds in non-airgapped mode.
As a workaround, this PR pins ansible plugin versions.
