### PR TITLE
fix: install epel repo in RHEL 7 using static repo file

### DIFF
--- a/ansible/roles/repo/defaults/main.yaml
+++ b/ansible/roles/repo/defaults/main.yaml
@@ -1,3 +1,0 @@
-# set epel defaults
-epel_centos_7_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-epel_centos_7_rpm_gpg_key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7

--- a/ansible/roles/repo/files/etc/yum.repos.d/epel-7.repo
+++ b/ansible/roles/repo/files/etc/yum.repos.d/epel-7.repo
@@ -1,0 +1,26 @@
+[epel]
+name=Extra Packages for Enterprise Linux 7 - $basearch
+#baseurl=http://download.fedoraproject.org/pub/epel/7/$basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
+failovermethod=priority
+enabled=1
+gpgcheck=1
+gpgkey=https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+
+[epel-debuginfo]
+name=Extra Packages for Enterprise Linux 7 - $basearch - Debug
+#baseurl=http://download.fedoraproject.org/pub/epel/7/$basearch/debug
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-debug-7&arch=$basearch
+failovermethod=priority
+enabled=0
+gpgkey=https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+gpgcheck=1
+
+[epel-source]
+name=Extra Packages for Enterprise Linux 7 - $basearch - Source
+#baseurl=http://download.fedoraproject.org/pub/epel/7/SRPMS
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-source-7&arch=$basearch
+failovermethod=priority
+enabled=0
+gpgkey=https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+gpgcheck=1

--- a/ansible/roles/repo/tasks/redhat.yaml
+++ b/ansible/roles/repo/tasks/redhat.yaml
@@ -99,21 +99,12 @@
   when:
     - ansible_distribution_major_version == '8'
 
-- name: add epel gpg key for centos 7
-  rpm_key:
-    state: present
-    key: "{{ epel_centos_7_rpm_gpg_key }}"
-  when:
-    - ansible_distribution_major_version == '7'
-
 - name: install epel-release for centos 7
-  yum:
-    name: "{{ epel_centos_7_rpm }}"
-    state: present
+  copy:
+    src: files/etc/yum.repos.d/epel-7.repo
+    dest: /etc/yum.repos.d/epel.repo
   when:
     - ansible_distribution_major_version == '7'
-  retries: 5
-  delay: 6
 
 # RPM
 - name: add Konvoy Kubernetes rpm repository

--- a/ansible/roles/repo/tasks/redhat.yaml
+++ b/ansible/roles/repo/tasks/redhat.yaml
@@ -99,7 +99,7 @@
   when:
     - ansible_distribution_major_version == '8'
 
-- name: install epel-release for centos 7
+- name: add EPEL rpm repository
   copy:
     src: files/etc/yum.repos.d/epel-7.repo
     dest: /etc/yum.repos.d/epel.repo

--- a/images/common.yaml
+++ b/images/common.yaml
@@ -3,9 +3,6 @@ kubernetes_version: "1.26.3"
 
 download_images: true
 
-epel_centos_7_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-epel_centos_7_rpm_gpg_key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
-
 packer:
   goss_arch: amd64
   goss_entry_file: goss/goss.yaml


### PR DESCRIPTION
**What problem does this PR solve?**:
This PR is stacked on https://github.com/mesosphere/konvoy-image-builder/pull/781
Installs epel release for RHEL/Centos 7.9 using static repo files
