### PR TITLE
fix: set SSH_PRIVATE_KEY_FILE env variable for docker  wrapper

### DIFF
--- a/cmd/konvoy-image-wrapper/cmd/wrapper.go
+++ b/cmd/konvoy-image-wrapper/cmd/wrapper.go
@@ -201,6 +201,7 @@ func (r *Runner) setVSphereEnv() error {
 		envRedHatSubscriptionManagerOrgID,
 		envVSphereSSHUserName,
 		envVSphereSSHPassword,
+		envVsphereSSHPrivatekeyFile,
 	} {
 		value, found := os.LookupEnv(env)
 		if found {


### PR DESCRIPTION
**What problem does this PR solve?**:
set SSH_PRIVATE_KEY_FILE env variable for docker  wrapper

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-93836)
-->
* https://d2iq.atlassian.net/browse/D2IQ-93836


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
Tested the fix manually. The CI jobs uses SSH agent to add private key to the GHA runner's ssh agent. 
