### PR TITLE
fix: remove packer directory from goreleaser configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -81,7 +81,6 @@ archives:
       - goss
       - images
       - overrides
-      - packer
       - LICENSE
       - README.md
 


### PR DESCRIPTION
**What problem does this PR solve?**:
The packer directory removed in recent refactoring. But I didnt realized to remove it from `.goreleaser.yaml` file. 
This was caught when creating release. https://github.com/mesosphere/konvoy-image-builder/actions/runs/4863493893/jobs/8671278222#step:8:3080
