### PR TITLE
fix: backport mindthegap bump to release-2.2

### DIFF
--- a/Dockerfile.devkit
+++ b/Dockerfile.devkit
@@ -58,7 +58,7 @@ ARG USER_ID=0
 ARG GROUP_NAME=root
 ARG GROUP_ID=0
 ARG DOCKER_GID=0
-ARG MINDTHEGAP_VERSION=1.0.0
+ARG MINDTHEGAP_VERSION=1.7.3
 
 COPY requirements.txt /tmp/
 COPY requirements-devkit.txt /tmp/


### PR DESCRIPTION
**What problem does this PR solve?**:
backport mindthegap bump to release-2.2

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-96732)
-->
* https://d2iq.atlassian.net/browse/D2IQ-96732