### PR TITLE
ci: changed runner labels 

### DIFF
--- a/.github/workflows/aws-e2e.yaml
+++ b/.github/workflows/aws-e2e.yaml
@@ -91,7 +91,9 @@ jobs:
           buildConfig: nvidia
         - os: "rocky 9.1"
           buildConfig: offline-nvidia
-    runs-on: self-hosted
+    runs-on: 
+    - self-hosted
+    - small
     continue-on-error: false
     steps:
       - name: Checkout konvoy-image-builder repository

--- a/.github/workflows/azure-e2e.yaml
+++ b/.github/workflows/azure-e2e.yaml
@@ -19,7 +19,9 @@ jobs:
         - "rocky 9.1"
         buildConfig:
         - "basic"
-    runs-on: self-hosted
+    runs-on: 
+    - self-hosted
+    - small
     continue-on-error: false
     steps:
       - name: Checkout konvoy-image-builder repository

--- a/.github/workflows/build-devkit-image.yaml
+++ b/.github/workflows/build-devkit-image.yaml
@@ -21,7 +21,9 @@ concurrency:
 
 jobs:
   build-push-devkit:
-    runs-on: ubuntu-latest
+    runs-on: 
+    - self-hosted
+    - small
     steps:
       - name: Checkout konvoy-image-builder repository
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,9 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: 
+    - self-hosted
+    - small
     steps:
       - name: Checkout konvoy-image-builder repository
         uses: actions/checkout@v3

--- a/.github/workflows/conventional-label.yaml
+++ b/.github/workflows/conventional-label.yaml
@@ -8,6 +8,8 @@ on:
       - edited
 jobs:
   label:
-    runs-on: ubuntu-latest
+    runs-on: 
+    - self-hosted
+    - micro
     steps:
       - uses: bcoe/conventional-release-labels@v1

--- a/.github/workflows/gcp-e2e.yaml
+++ b/.github/workflows/gcp-e2e.yaml
@@ -20,7 +20,9 @@ jobs:
         - "centos 7.9"
         buildConfig:
         - "basic"
-    runs-on: self-hosted
+    runs-on: 
+    - self-hosted
+    - small
     continue-on-error: false
     steps:
       - name: Checkout konvoy-image-builder repository

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   super-linter:
     runs-on: 
-    - self-hosted§
+    - self-hosted
     - small
     steps:
       - name: Checkout konvoy-image-builder repository

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,9 @@ permissions:
 
 jobs:
   super-linter:
-    runs-on: ubuntu-latest
+    runs-on: 
+    - self-hosted§
+    - small
     steps:
       - name: Checkout konvoy-image-builder repository
         uses: actions/checkout@v3

--- a/.github/workflows/next-release-version.yml
+++ b/.github/workflows/next-release-version.yml
@@ -12,7 +12,9 @@ on:
 name: Determine next release version
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: 
+    - self-hosted
+    - small
     outputs:
       release_created: ${{ steps.release-please.outputs.release_created }}
       release_tag_name: ${{ steps.release-please.outputs.tag_name }}

--- a/.github/workflows/release-ami.yaml
+++ b/.github/workflows/release-ami.yaml
@@ -42,7 +42,9 @@ jobs:
           - os: "ubuntu 20.04"
             buildConfig: "nvidia"
 
-    runs-on: self-hosted
+    runs-on: 
+    - self-hosted
+    - small
     continue-on-error: false
     steps:
       - name: Checkout konvoy-image-builder repository

--- a/.github/workflows/release-azure.yaml
+++ b/.github/workflows/release-azure.yaml
@@ -21,7 +21,9 @@ jobs:
           - os: "ubuntu 20.04"
             buildConfig: "basic"
 
-    runs-on: self-hosted
+    runs-on: 
+    - self-hosted
+    - small
     continue-on-error: false
     steps:
       - name: Checkout konvoy-image-builder repository

--- a/.github/workflows/release-gcp-template.yaml
+++ b/.github/workflows/release-gcp-template.yaml
@@ -19,7 +19,9 @@ jobs:
         include:
           - os: "ubuntu 20.04"
             buildConfig: "basic"
-    runs-on: self-hosted
+    runs-on: 
+    - self-hosted
+    - small
     continue-on-error: false
     steps:
       - name: Checkout konvoy-image-builder repository

--- a/.github/workflows/release-kib.yaml
+++ b/.github/workflows/release-kib.yaml
@@ -12,7 +12,9 @@ on:
 name: Release konvoy-image-builder
 jobs:
   release-to-github:
-    runs-on: self-hosted
+    runs-on: 
+    - self-hosted
+    - small
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/release-vsphere-template.yaml
+++ b/.github/workflows/release-vsphere-template.yaml
@@ -21,7 +21,9 @@ jobs:
             buildConfig: "offline"
           - os: "rocky 9.1"
             buildConfig: "offline"
-    runs-on: self-hosted
+    runs-on: 
+    - self-hosted
+    - small
     continue-on-error: false
     steps:
       - name: Checkout konvoy-image-builder repository

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -11,7 +11,9 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecards analysis
-    runs-on: ubuntu-latest
+    runs-on: 
+    - self-hosted
+    - small
     permissions:
       security-events: write
       id-token: write

--- a/.github/workflows/sync-cli-docs.yaml
+++ b/.github/workflows/sync-cli-docs.yaml
@@ -9,7 +9,9 @@ on:
 
 jobs:
   sync-cli-docs:
-    runs-on: ubuntu-latest
+    runs-on: 
+    - self-hosted
+    - small
     name: Sync CLI docs to Confluence
     steps:
       - name: Checkout konvoy-image-builder repository

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -10,7 +10,9 @@ on:
 
 jobs:
   unit-test:
-    runs-on: ubuntu-latest
+    runs-on: 
+    - self-hosted
+    - small
     steps:
       - name: Checkout konvoy-image-builder repository
         uses: actions/checkout@v3

--- a/.github/workflows/vsphere-e2e.yaml
+++ b/.github/workflows/vsphere-e2e.yaml
@@ -31,8 +31,8 @@ jobs:
         - os: "rocky 9.1"
           buildConfig: offline-fips
     runs-on: 
-- self-hosted
-- small
+    - self-hosted
+    - small
     continue-on-error: false
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/vsphere-e2e.yaml
+++ b/.github/workflows/vsphere-e2e.yaml
@@ -30,7 +30,9 @@ jobs:
           buildConfig: offline-fips
         - os: "rocky 9.1"
           buildConfig: offline-fips
-    runs-on: self-hosted
+    runs-on: 
+- self-hosted
+- small
     continue-on-error: false
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
There were some workflows that still had the wrong labelled runners or were using githubs runners, we need to change them to org-wire-runners so we have a more coherent understanding of our infrastructure. This pr will be used to understand which workflows require which size or if they need kind cluster. Please check the the runners in the change made and use [this](https://github.com/mesosphere/github-action-runners-deployment#how-to-add-an-org-wide-runner-to-your-repos-workflow) as a criteria. Once the sizes have been confirmed the pr we can merge.

Which issue(s) does this PR fix?:

https://jira.d2iq.com/browse/D2IQ-97191


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
