### PR TITLE
fix: update references to no-update-flatcar.sh scripts

### DIFF
--- a/ansible/molecule/ec2_full/converge.yml
+++ b/ansible/molecule/ec2_full/converge.yml
@@ -6,10 +6,10 @@
   tasks:
     - name: Flatcar no update
       changed_when: false
-      script: ../../../packer/files/no-update-flatcar.sh
+      script: ../../files/no-update-flatcar.sh
     - name: exec bootstrap python
       changed_when: false
-      script: ../../../packer/files/bootstrap-flatcar.sh
+      script: ../../files/bootstrap-flatcar.sh
     - name: check for flatcar python
       raw: stat /opt/bin/.bootstrapped
       changed_when: false

--- a/ansible/molecule/ec2_gpu/converge.yaml
+++ b/ansible/molecule/ec2_gpu/converge.yaml
@@ -6,10 +6,10 @@
   tasks:
     - name: Flatcar no update
       changed_when: false
-      script: ../../../packer/files/no-update-flatcar.sh
+      script: ../../files/no-update-flatcar.sh
     - name: exec bootstrap python
       changed_when: false
-      script: ../../../packer/files/bootstrap-flatcar.sh
+      script: ../../files/bootstrap-flatcar.sh
     - name: check for flatcar python
       raw: stat /opt/bin/.bootstrapped
       changed_when: false

--- a/ansible/upload-artifacts.yaml
+++ b/ansible/upload-artifacts.yaml
@@ -6,10 +6,10 @@
   tasks:
     - name: Flatcar no update
       changed_when: false
-      script: ../packer/files/no-update-flatcar.sh
+      script: files/no-update-flatcar.sh
     - name: exec bootstrap python
       changed_when: false
-      script: ../packer/files/bootstrap-flatcar.sh
+      script: files/bootstrap-flatcar.sh
     - name: check for flatcar python
       raw: stat /opt/bin/.bootstrapped
       changed_when: false


### PR DESCRIPTION
**What problem does this PR solve?**:
Some of the references to `no-flatcar-update.sh` scripts was not refactored when they moved out of `packer` directory.
This PR fixes those references.
