### PR TITLE
ci: use Flatcar LTS version in e2e tests

### DIFF
--- a/images/ami/flatcar.yaml
+++ b/images/ami/flatcar.yaml
@@ -2,10 +2,8 @@ download_images: true
 
 packer:
   # Selectors for source AMI:
-  ami_filter_name: "Flatcar*stable*"
+  ami_filter_name: "Flatcar-lts-3033.3.x"
   ami_filter_owners: "075585003325"
-  # Flatcar-lts-3033.3.7-hvm
-  source_ami: "ami-0f9a215a1195261ca" 
   # Tags applied to generated AMI:
   distribution: "Flatcar"
   distribution_version: "Stable"

--- a/images/ami/flatcar.yaml
+++ b/images/ami/flatcar.yaml
@@ -2,7 +2,7 @@ download_images: true
 
 packer:
   # Selectors for source AMI:
-  ami_filter_name: "Flatcar-lts-3033.3.x"
+  ami_filter_name: "Flatcar-lts-3033.3.*"
   ami_filter_owners: "075585003325"
   # Tags applied to generated AMI:
   distribution: "Flatcar"


### PR DESCRIPTION
**What problem does this PR solve?**:
In DKP 2.5 DKP switched to supporting the Flatcar LTS version, switching the TF lookup vars to find the [latest LTS version](https://d2iq.slack.com/archives/C04DTKTM6N6/p1686065076613979?thread_ts=1686056418.770459&cid=C04DTKTM6N6).

Removed `source_ami` as `ami_filter_name` takes precedence. 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-97410)
-->
* https://d2iq.atlassian.net/browse/D2IQ-97410


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
