### PR TITLE
ci: use new depguard config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,12 +8,11 @@ issues:
 
 linters-settings:
   depguard:
-    list-type: blacklist
-    packages:
-      - k8s.io/kubernetes
-    packages-with-error-message:
-      - k8s.io/kubernetes: >-
-          Avoid k8s.io/kubernetes if possible to reduce transitive dependencies
+    rules:
+      main:
+        deny:
+          - pkg: "k8s.io/kubernetes"
+            desc: "Avoid if possible to reduce transitive dependencies"
   dupl:
     threshold: 100
   exhaustive:


### PR DESCRIPTION
**What problem does this PR solve?**:
New version of golangci-lint pulled in a new version of depguard that changed the API, see https://github.com/golangci/golangci-lint/issues/3877

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
