### PR TITLE
fix: upgrade docker in flatcar 3033.3.x LTS for k8s 1.26 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ authorized_keys
 github-token.txt
 .local
 /overrides/release.yaml
+ansible-runs

--- a/Makefile
+++ b/Makefile
@@ -493,7 +493,7 @@ go-clean: ## go clean build, test and modules caches
 
 .PHONY: help
 help:
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[.0-9A-Za-z_-]+:.*?##/ { printf "  \033[36m%-45s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 define print-target
     @printf "Executing target: \033[36m$@\033[0m\n"

--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -61,6 +61,7 @@ extra_images: []
 containerd_supplementary_images: ["ghcr.io/mesosphere/toml-merge:v0.2.0", "ghcr.io/mesosphere/dynamic-credential-provider:v0.2.0"]
 
 containerd_base_url: https://packages.d2iq.com/dkp/containerd
+docker_base_url: https://download.docker.com/linux/static/stable
 kubernetes_http_source: https://dl.k8s.io/release
 kubernetes_cni_semver: v{{ kubernetes_cni_version }}
 kubernetes_cni_http_checksum: sha256:https://storage.googleapis.com/k8s-artifacts-cni/release/{{ kubernetes_cni_semver }}/cni-plugins-linux-amd64-{{ kubernetes_cni_semver }}.tgz.sha256

--- a/ansible/roles/containerd/files/3033.3.x-flatcar-lts/etc/systemd/system/containerd.service
+++ b/ansible/roles/containerd/files/3033.3.x-flatcar-lts/etc/systemd/system/containerd.service
@@ -1,0 +1,27 @@
+[Unit]
+Requires=torcx.target
+After=torcx.target
+Description=containerd container runtime
+After=network.target prepare-docker.service
+Requires=prepare-docker.service
+
+[Service]
+EnvironmentFile=/run/metadata/torcx
+Environment=TORCX_IMAGEDIR=/docker
+Delegate=yes
+Environment=PATH=${PATH}:/opt/bin
+ExecStartPre=mkdir -p /run/docker/libcontainerd
+ExecStartPre=ln -fs /run/containerd/containerd.sock /run/docker/libcontainerd/docker-containerd.sock
+Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
+ExecStart=/opt/bin/containerd --config ${CONTAINERD_CONFIG}
+KillMode=process
+Restart=always
+
+# (lack of) limits from the upstream docker service unit
+LimitNOFILE=1048576
+LimitNPROC=infinity
+LimitCORE=infinity
+TasksMax=infinity
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/containerd/files/3033.3.x-flatcar-lts/etc/systemd/system/docker.service
+++ b/ansible/roles/containerd/files/3033.3.x-flatcar-lts/etc/systemd/system/docker.service
@@ -1,0 +1,40 @@
+[Unit]
+Requires=torcx.target
+After=torcx.target
+Description=Docker Application Container Engine
+After=containerd.service docker.socket network-online.target prepare-docker.service
+Wants=network-online.target
+Requires=containerd.service docker.socket prepare-docker.service
+StartLimitBurst=3
+StartLimitIntervalSec=60s
+
+[Service]
+EnvironmentFile=/run/metadata/torcx
+Environment=TORCX_IMAGEDIR=/docker
+Type=notify
+EnvironmentFile=-/run/flannel/flannel_docker_opts.env
+Environment=DOCKER_SELINUX=--selinux-enabled=true
+# the default is not to use systemd for cgroups because the delegate issues still
+# exists and systemd currently does not support the cgroup feature set required
+# for containers run by docker
+Environment=PATH=/opt/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+ExecStart=/opt/bin/dockerd --host=fd:// --containerd=/run/docker/libcontainerd/docker-containerd.sock $DOCKER_SELINUX $DOCKER_OPTS $DOCKER_CGROUPS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
+ExecReload=/bin/kill -s HUP $MAINPID
+LimitNOFILE=1048576
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNPROC=infinity
+LimitCORE=infinity
+# Uncomment TasksMax if your systemd version supports it.
+# Only systemd 226 and above support this version.
+TasksMax=infinity
+TimeoutStartSec=0
+# set delegate yes so that systemd does not reset the cgroups of docker containers
+Delegate=yes
+# kill only the docker process, not all processes in the cgroup
+KillMode=process
+# restart the docker process if it exits prematurely
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/containerd/files/3033.3.x-flatcar-lts/etc/systemd/system/docker.socket
+++ b/ansible/roles/containerd/files/3033.3.x-flatcar-lts/etc/systemd/system/docker.socket
@@ -1,0 +1,14 @@
+[Unit]
+Requires=torcx.target
+After=torcx.target
+PartOf=docker.service
+Description=Docker Socket for the API
+
+[Socket]
+ListenStream=/var/run/docker.sock
+SocketMode=0660
+SocketUser=root
+SocketGroup=docker
+
+[Install]
+WantedBy=sockets.target

--- a/ansible/roles/containerd/files/3033.3.x-flatcar-lts/etc/systemd/system/prepare-docker.service
+++ b/ansible/roles/containerd/files/3033.3.x-flatcar-lts/etc/systemd/system/prepare-docker.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Unpack docker binaries to /opt/bin
+ConditionPathExists=!/opt/bin/docker
+# Needs to be downloaded prior to execution (either by user or by kib job)
+ConditionPathExists=/opt/docker.tgz
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+Restart=on-failure
+ExecStartPre=/usr/bin/mkdir -p /opt/bin
+ExecStartPre=/usr/bin/tar -v --extract --file /opt/docker.tgz --directory /opt/ --no-same-owner
+ExecStartPre=/usr/bin/rm /opt/docker.tgz
+ExecStartPre=/usr/bin/sh -c "mv /opt/docker/* /opt/bin/"
+ExecStart=/usr/bin/rmdir /opt/docker
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/containerd/tasks/install-flatcar.yaml
+++ b/ansible/roles/containerd/tasks/install-flatcar.yaml
@@ -5,6 +5,41 @@
     src: etc/systemd/system/containerd-flatcar.service
     mode: 0600
 
+- name: Download docker for 3033.3.x flatcar LTS to /opt/docker.tgz
+  when:
+    - ansible_facts['distribution_version'] is version('3033.3.0', '>=', version_type='semver')
+    - ansible_facts['distribution_version'] is version('3033.4.0', '<', version_type='semver')
+  get_url:
+    # Flatcar LTS 3033.3.x is shipped with docker version 20.10.12 - See https://www.flatcar.org/releases#lts-release
+    # Download the least possible docker version that has 1.6.x containerd for k8s 1.26.x compatibility - https://docs.docker.com/engine/release-notes/20.10/#201015
+    # We are bumping docker version by 3 patch versions (least possible delta).
+    url: https://download.docker.com/linux/static/stable/{{ ansible_facts['architecture'] }}/docker-20.10.15.tgz
+    dest: /opt/docker.tgz
+    mode: 0644
+    force: true
+
+- name: Update containerd unit file for flatcar LTS 3033.3.x
+  when:
+    - ansible_facts['distribution_version'] is version('3033.3.0', '>=', version_type='semver')
+    - ansible_facts['distribution_version'] is version('3033.4.0', '<', version_type='semver')
+  copy:
+    src: 3033.3.x-flatcar-lts/etc/systemd/system/
+    dest: /etc/systemd/system/
+    mode: 0644
+
+- name: Download new docker in flatcar LTS 3033.3.x
+  when:
+    - ansible_facts['distribution_version'] is version('3033.3.0', '>=', version_type='semver')
+    - ansible_facts['distribution_version'] is version('3033.4.0', '<', version_type='semver')
+  systemd:
+    name: '{{ item }}'
+    state: restarted
+    enabled: true
+  loop:
+    - prepare-docker
+    - docker
+    - containerd
+
 - name: Create containerd memory pressure drop in file
   template:
     dest: /etc/systemd/system/containerd.service.d/memory-pressure.conf
@@ -26,5 +61,6 @@
 
 - name: add to PATH unpack docker to path
   copy:
-    content: "export PATH=$PATH:/run/torcx/unpack/docker/bin/"
+    # If using Flatcar 3033.3.x LTS then /opt/bin will have the preferred version for docker and containerd binaries
+    content: "export PATH=$PATH:/opt/bin:/run/torcx/unpack/docker/bin/"
     dest: "/etc/profile.d/my_path.sh"

--- a/ansible/roles/containerd/tasks/install-flatcar.yaml
+++ b/ansible/roles/containerd/tasks/install-flatcar.yaml
@@ -1,44 +1,52 @@
 ---
+- name: Check docker version
+  shell: docker version --format {{ '{{' }}.Server.Version{{ '}}' }}
+  register: docker_contents
+
+- name: Calculate docker upgrade eligibility
+  set_fact:
+    dockerUpgradeRequired: true
+  when:
+    # Flatcar LTS 3033.3.x is shipped with docker version 20.10.12 - See https://www.flatcar.org/releases#lts-release
+    # Download the least possible docker version that has 1.6.x containerd for k8s 1.26.x compatibility - https://docs.docker.com/engine/release-notes/20.10/#201015
+    # We are bumping docker version by 3 patch versions (least possible delta).
+    # Following conditionals avoid downgrading docker and also avoid upgrading docker in untested flatcar releases (we only validate 3033.3.x)
+    - docker_contents.stdout is version('20.10.15', '<', version_type='semver')
+    - ansible_facts['distribution_version'] is version('3033.3.0', '>=', version_type='semver')
+    - ansible_facts['distribution_version'] is version('3033.4.0', '<', version_type='semver')
+
 - name: Create systemd unit file for containerd
   template:
     dest: /etc/systemd/system/containerd.service
     src: etc/systemd/system/containerd-flatcar.service
     mode: 0600
+  when: dockerUpgradeRequired is not defined
 
-- name: Download docker for 3033.3.x flatcar LTS to /opt/docker.tgz
-  when:
-    - ansible_facts['distribution_version'] is version('3033.3.0', '>=', version_type='semver')
-    - ansible_facts['distribution_version'] is version('3033.4.0', '<', version_type='semver')
-  get_url:
-    # Flatcar LTS 3033.3.x is shipped with docker version 20.10.12 - See https://www.flatcar.org/releases#lts-release
-    # Download the least possible docker version that has 1.6.x containerd for k8s 1.26.x compatibility - https://docs.docker.com/engine/release-notes/20.10/#201015
-    # We are bumping docker version by 3 patch versions (least possible delta).
-    url: https://download.docker.com/linux/static/stable/{{ ansible_facts['architecture'] }}/docker-20.10.15.tgz
-    dest: /opt/docker.tgz
-    mode: 0644
-    force: true
+- name: Download, Update and Restart docker for 3033.3.x flatcar LTS
+  when: dockerUpgradeRequired is true
+  block:
+  - name: Download docker for 3033.3.x flatcar LTS to /opt/docker.tgz
+    get_url:
+      url: "{{ docker_base_url }}/{{ ansible_facts['architecture'] }}/docker-20.10.15.tgz"
+      dest: /opt/docker.tgz
+      mode: 0644
+      force: true
 
-- name: Update containerd unit file for flatcar LTS 3033.3.x
-  when:
-    - ansible_facts['distribution_version'] is version('3033.3.0', '>=', version_type='semver')
-    - ansible_facts['distribution_version'] is version('3033.4.0', '<', version_type='semver')
-  copy:
-    src: 3033.3.x-flatcar-lts/etc/systemd/system/
-    dest: /etc/systemd/system/
-    mode: 0644
+  - name: Update docker and containerd unit files for flatcar LTS 3033.3.x
+    copy:
+      src: 3033.3.x-flatcar-lts/etc/systemd/system/
+      dest: /etc/systemd/system/
+      mode: 0644
 
-- name: Download new docker in flatcar LTS 3033.3.x
-  when:
-    - ansible_facts['distribution_version'] is version('3033.3.0', '>=', version_type='semver')
-    - ansible_facts['distribution_version'] is version('3033.4.0', '<', version_type='semver')
-  systemd:
-    name: '{{ item }}'
-    state: restarted
-    enabled: true
-  loop:
-    - prepare-docker
-    - docker
-    - containerd
+  - name: Restart Docker systemd services
+    systemd:
+      name: '{{ item }}'
+      state: restarted
+      enabled: true
+    loop:
+      - prepare-docker
+      - docker
+      - containerd
 
 - name: Create containerd memory pressure drop in file
   template:


### PR DESCRIPTION
**What problem does this PR solve?**:

Flatcar 3033.3.x LTS ships with docker version [20.10.12](https://docs.docker.com/engine/release-notes/20.10/#201012) which is shipped with 1.5.x of containerd that is [incomaptible with k8s 1.26](https://kubernetes.io/blog/2022/12/09/kubernetes-v1-26-release/#cri-v1alpha2-removed).

In order to workaround above, this change adds support to upgrade the docker version in flatcar lts 3033.3.x to [20.10.15](https://docs.docker.com/engine/release-notes/20.10/#201015) - which is three patch versions ahead compared to upstream - and thus ensures that 1.6.x of containerd is available for kubelet to start successfully. 

References:
- https://www.flatcar.org/docs/latest/container-runtimes/use-a-custom-docker-or-containerd-version/
- https://kubernetes.slack.com/archives/C03GQ8B5XNJ/p1684991183065489?thread_ts=1684958025.683769&cid=C03GQ8B5XNJ

I ran the following against https://us-west-2.console.aws.amazon.com/ec2/home?region=us-west-2#ImageDetails:imageId=ami-05da1e709666308a1

```
./bin/konvoy-image provision --inventory-file inventory.yaml --overrides kube-override.yaml
.
.
.
.

TASK [containerd : Create systemd unit file for containerd] ********************
changed: [34.214.189.233]

TASK [containerd : Download docker for 3033.3.x flatcar LTS to /opt/docker.tgz] ***
changed: [34.214.189.233]

TASK [containerd : Update containerd unit file for flatcar LTS 3033.3.x] *******
changed: [34.214.189.233]

TASK [containerd : Download new docker in flatcar LTS 3033.3.x] ****************
changed: [34.214.189.233] => (item=prepare-docker)
changed: [34.214.189.233] => (item=docker)
changed: [34.214.189.233] => (item=containerd)

TASK [containerd : Create containerd memory pressure drop in file] *************
ok: [34.214.189.233]

TASK [containerd : Create containerd max tasks drop in file] *******************
ok: [34.214.189.233]

TASK [containerd : Create containerd http proxy conf file if needed] ***********
skipping: [34.214.189.233]

TASK [containerd : add to PATH unpack docker to path] **************************
changed: [34.214.189.233]
.
.
.
.
```


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-97410)
-->
* https://d2iq.atlassian.net/browse/D2IQ-97410


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
