### PR TITLE
fix: force update the offline repo metadata cache

### DIFF
--- a/ansible/roles/repo/tasks/redhat-offline.yaml
+++ b/ansible/roles/repo/tasks/redhat-offline.yaml
@@ -4,3 +4,14 @@
     src: rpm-offline.repo
     dest: /etc/yum.repos.d/offline.repo
   when: offline_mode_enabled
+
+# Force update the repo metadata to avoid an issue when upgrading from an older version that was built after the newer version.
+#
+# Not using downloaded offline/repomd.xml because it is older than what we have:
+#   Current   : Wed Mar 22 00:42:58 2023
+#   Downloaded: Mon Mar 20 16:25:47 2023
+- name: clean metadata for offline repository
+  command: yum clean metadata --disablerepo "*" --enablerepo offline
+
+- name: update the cache for offline repository
+  command: yum makecache --disablerepo "*" --enablerepo offline


### PR DESCRIPTION
**What problem does this PR solve?**:
This an issue thats wasn't caught in KIB tests because there are no upgrade tests here (as there shouldn't be).

This did not fail in Konvoy's e2e air-gapped preprovisioned upgrad tests [because the package there was rebuilt more recently](https://teamcity.mesosphere.io/buildConfiguration/MesosphereOnly_ClosedSource_DkpReleases_OsPackagesBundles_CentOS7nonFips?branch=v1.26.3&buildTypeTab=overview&mode=builds), but the [FIPS packages were not](https://teamcity.mesosphere.io/buildConfiguration/MesosphereOnly_ClosedSource_DkpReleases_OsPackagesBundles_CentOS7fips?branch=v1.26.3&mode=builds).

I'm going to add a Konvoy FIPS preprovisioned upgrade test that would have caught this kind of issue in future. I ran the test with a customer KIB image built with this fix and it got updated:

```
  STEP: Upgrading the control-plane nodes @ 06/08/23 11:19:21.748
  /home/rocky/konvoy [update controlplane preprovisioned -c e2e-preprov-fips-upgrade-16862466 --kubeconfig /home/rocky/e2e-preprov-fips-upgrade-16862466.conf --kubernetes-version 1.26.3+fips.0]
  2023-06-08 18:19:21 INF  • Updating the control plane...
  2023-06-08 18:19:21 INF Updating control plane resource controlplane.cluster.x-k8s.io/v1beta1, Kind=KubeadmControlPlane default/e2e-preprov-fips-upgrade-16862466-control-plane
  2023-06-08 18:19:21 INF Waiting for control plane update to finish.
  2023-06-08 18:47:31 INF  ✓ Updating the control plane
  STEP: Upgrading the nodepool nodes @ 06/08/23 11:47:31.833
  /home/rocky/konvoy [update nodepool preprovisioned -c e2e-preprov-fips-upgrade-16862466 --kubeconfig /home/rocky/e2e-preprov-fips-upgrade-16862466.conf --kubernetes-version 1.26.3+fips.0 e2e-preprov-fips-upgrade-16862466-md-0]
  2023-06-08 18:47:32 INF  • Updating the e2e-preprov-fips-upgrade-16862466-md-0 node pool...
  2023-06-08 18:47:32 INF Updating node pool resource cluster.x-k8s.io/v1beta1, Kind=MachineDeployment default/e2e-preprov-fips-upgrade-16862466-md-0
  2023-06-08 18:47:32 INF Waiting for node pool update to finish.
  2023-06-08 18:59:22 INF  ✓ Updating the e2e-preprov-fips-upgrade-16862466-md-0 node pool
```

New tasks in KIB job:
```
TASK [repo : clean metadata for offline repository] ****************************
changed: [10.0.132.5]

TASK [repo : update the cache for offline repository] **************************
changed: [10.0.132.5]
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-97376)
-->
* https://d2iq.atlassian.net/browse/D2IQ-97376


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
