### PR TITLE
chore: Trigger version updates in Confluence

### DIFF
--- a/.github/workflows/confluence-docs.yaml
+++ b/.github/workflows/confluence-docs.yaml
@@ -1,0 +1,21 @@
+name: Publish component version updates in Confluence
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    name: Repository dispatch
+    if: ${{ startsWith(github.ref_name, 'v') }}
+    runs-on:
+    - self-hosted
+    - small
+    steps:
+      - run: |
+          curl -L -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.MESOSPHERECI_USER_TOKEN }}"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/mesosphere/dkp-infra-tools/dispatches \
+            -d '{"event_type":"confluence-docs","client_payload":{"docs_type":"kib","ref":"${{ github.ref_name }}"}}'


### PR DESCRIPTION
<!--
If you want to run e2e tests against this PR, apply the runs-e2e-tests label. The tests will run when the label is applied, and when the PR is updated.
If your PR changes an artifact included in the e2e bastion image, apply the rebuilds-e2e-image label. The image is built when the label is applied, and when the PR is updated.
-->
**What problem does this PR solve?**:
Adds a Github workflow to trigger Confluence version updates whenever there is a new release.

See https://github.com/mesosphere/dkp-infra-tools/pull/178 for test run

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-91592)
-->
* https://jira.d2iq.com/browse/D2IQ-91592


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
Depends on https://github.com/mesosphere/dkp-infra-tools/pull/178

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
