### PR TITLE
[release-2.2] ci: use vsphere base templates from d2iq-base-templates vsphere folder

### DIFF
--- a/images/ova/rhel-79.yaml
+++ b/images/ova/rhel-79.yaml
@@ -13,7 +13,7 @@ packer:
   insecure_connection: "false"
   network: ""
   resource_pool: ""
-  template: "os-qualification-templates/d2iq-base-RHEL-79"
+  template: "d2iq-base-templates/d2iq-base-RHEL-79"
   vsphere_guest_os_type: "rhel7_64Guest"
   guest_os_type: "rhel7-64"
   # goss params

--- a/images/ova/rhel-84.yaml
+++ b/images/ova/rhel-84.yaml
@@ -13,7 +13,7 @@ packer:
   insecure_connection: "false"
   network: ""
   resource_pool: ""
-  template: "os-qualification-templates/d2iq-base-RHEL-84" # change default value with your base template name
+  template: "d2iq-base-templates/d2iq-base-RHEL-84" # change default value with your base template name
   vsphere_guest_os_type: "rhel8_64Guest"
   guest_os_type: "rhel8-64"
   # goss params

--- a/images/ova/rhel-86.yaml
+++ b/images/ova/rhel-86.yaml
@@ -13,7 +13,7 @@ packer:
   insecure_connection: "false"
   network: ""
   resource_pool: ""
-  template: "os-qualification-templates/d2iq-base-RHEL-86" # change default value with your base template name
+  template: "d2iq-base-templates/d2iq-base-RHEL-86" # change default value with your base template name
   vsphere_guest_os_type: "rhel8_64Guest"
   guest_os_type: "rhel8-64"
   # goss params

--- a/images/ova/rocky-91.yaml
+++ b/images/ova/rocky-91.yaml
@@ -13,7 +13,7 @@ packer:
   insecure_connection: "false"
   network: ""
   resource_pool: ""
-  template: "os-qualification-templates/d2iq-base-RockyLinux-9.1" # change default value with your base template name
+  template: "d2iq-base-templates/d2iq-base-RockyLinux-9.1" # change default value with your base template name
   vsphere_guest_os_type: "other4xLinux64Guest"
   guest_os_type: "rocky9-64"
   # goss params

--- a/images/ova/ubuntu-2004.yaml
+++ b/images/ova/ubuntu-2004.yaml
@@ -13,7 +13,7 @@ packer:
   insecure_connection: "false"
   network: ""
   resource_pool: ""
-  template: "os-qualification-templates/d2iq-base-Ubuntu-20.04" # change default value with your base template name
+  template: "d2iq-base-templates/d2iq-base-Ubuntu-20.04" # change default value with your base template name
   vsphere_guest_os_type: "other4xLinux64Guest"
   guest_os_type: "ubuntu2004-64"
   # goss params

--- a/test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl
+++ b/test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl
@@ -15,6 +15,4 @@ packer:
   folder: "cluster-api"
   network: "Airgapped"
   resource_pool: "Users"
-  # ssh authentication with base template VM.
-  ssh_username: "builder"
-  ssh_agent_auth: true
+  ssh_username: "kib"


### PR DESCRIPTION
**What problem does this PR solve?**:
uses d2iq base templates to build KIB OVA.
When we disable the ssh_agent based authentication, the packer code uses temporary keypair generated during provisioning.
Existing logic that manages this is at: https://github.com/mesosphere/konvoy-image-builder/blob/main/pkg/packer/manifests/vsphere/packer.pkr.hcl#L378-L405