### PR TITLE
[release-2.2] chore: update gitignore for vsphere-bastion.pub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ flatcar-version.yaml
 packer-custom-vpc-override.yaml
 .env
 packer-vsphere-airgap.yaml
+vsphere-bastion.pub
 vsphere-tests.pem
 authorized_keys
 github-token.txt


### PR DESCRIPTION
**What problem does this PR solve?**:
adding `vsphere-bastion.pub` to `.gitignore` to fix https://github.com/mesosphere/konvoy-image-builder/actions/runs/5904447936/job/16016530437#step:8:4425

> Please check in your pipeline what can be changing the following files:
> ?? vsphere-bastion.pub

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
