### PR TITLE
chore: git ignore  vsphere-bastion.pub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ packer-custom-vpc-override.yaml
 .env
 packer-vsphere-airgap.yaml
 vsphere-tests.pem
+vsphere-bastion.pub
 authorized_keys
 github-token.txt
 .local


### PR DESCRIPTION
**What problem does this PR solve?**:
Release builds are failing because it detects new file `vsphere-bastion.pub` in root directory.
https://github.com/mesosphere/konvoy-image-builder/actions/runs/6005402723/job/16288896553#step:8:18
This PR will ignore it so that release can go through.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
We should re-tag v2.6.0 after this is merged in. 
