### PR TITLE
fix: start usr-libexec.mount to also support pre-provisioned

### DIFF
--- a/ansible/roles/packages/tasks/flatcar.yaml
+++ b/ansible/roles/packages/tasks/flatcar.yaml
@@ -45,8 +45,9 @@
     group: root
     mode: "0644"
 
-- name: Enable usr-libexec.mount unit
+- name: Start usr-libexec.mount unit
   systemd:
+    state: started
     daemon_reload: yes
     enabled: yes
     name: usr-libexec.mount


### PR DESCRIPTION
**What problem does this PR solve?**:
A pre-provisioned machine never gets restarted after running KIB, so this systemd unit never gets started.
Saw that `kube-controller-manager` in Konvoy e2e test was failing to start because `/user/libexec/kubernetes` was still read only.
Tested locally and with this change the pre-provisioned cluster came up.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-98654)
-->
* https://d2iq.atlassian.net/browse/D2IQ-98654


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
