### PR TITLE
feat: Upgrade Kubernetes version to 1.27.5

### DIFF
--- a/.github/workflows/aws-e2e.yaml
+++ b/.github/workflows/aws-e2e.yaml
@@ -12,7 +12,7 @@ jobs:
   rune2e:
     strategy:
       fail-fast: false
-      max-parallel: 10
+      max-parallel: 30
       matrix:
         include:
           # CentoOS 7.9

--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -5,7 +5,7 @@ python_path: ""
 # If it's not there, the kubernetes_full_version will have "None" for a version number.
 #
 # IMPORTANT When you update kubernetes_version, also update crictl_version.
-kubernetes_version: "1.26.6"
+kubernetes_version: "1.27.5"
 kubernetes_semver: "v{{ kubernetes_version }}"
 
 kubernetes_cni_version: "0.9.1"

--- a/ansible/roles/version/templates/kubeadm-conf.yaml.tmpl
+++ b/ansible/roles/version/templates/kubeadm-conf.yaml.tmpl
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration
 dns:
   imageRepository: {{ k8s_image_registry_for_coredns }}

--- a/images/common.yaml
+++ b/images/common.yaml
@@ -1,5 +1,5 @@
 ---
-kubernetes_version: "1.26.6"
+kubernetes_version: "1.27.5"
 
 download_images: true
 

--- a/test/infra/vsphere/variables.tf
+++ b/test/infra/vsphere/variables.tf
@@ -5,7 +5,7 @@ variable "datastore_name" {
 
 variable "bastion_base_template" {
   description = "base template name"
-  default     = "os-qualification-templates/d2iq-base-RockyLinux-9.1"
+  default     = "d2iq-base-templates/d2iq-base-RockyLinux-9.1"
 }
 
 variable "resource_pool_name" {


### PR DESCRIPTION
**What problem does this PR solve?**:
K8s upgrade

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-97979)
-->
* https://d2iq.atlassian.net/browse/D2IQ-97979


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
According to https://github.com/kubernetes/kubernetes/blob/v1.27.5/cluster/gce/gci/configure.sh#L35, K8s 1.27.5 is still using crictl 1.26.0, so no need to upgrade.

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
