### PR TITLE
fix: force redownload of Kubelet and kubectl binaries for Flatcar

### DIFF
--- a/ansible/roles/packages/tasks/url.yaml
+++ b/ansible/roles/packages/tasks/url.yaml
@@ -31,9 +31,9 @@
       checksum: "{{ kubernetes_cni_http_checksum }}"
       dest: /tmp/cni.tar.gz
       mode: 0755
-      force: true
       owner: root
       group: root
+      force: true
 
   - name: Install CNI
     unarchive:
@@ -57,6 +57,7 @@
     mode: 0755
     owner: root
     group: root
+    force: true
   loop: "{{ kubernetes_bins }}"
 
 - name: Create Kubernetes manifests directory


### PR DESCRIPTION
**What problem does this PR solve?**:
Force redownload the Kubelet and kubectl binaries for Flatcar.
Without this fix, upgraded Nodes ended up not actually upgrading the Kubelet version.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-98984)
-->
* https://d2iq.atlassian.net/browse/D2IQ-98984


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
