### PR TITLE
fix: don't override Docker systemd unit file for Flatcar

### DIFF
--- a/ansible/roles/containerd/tasks/install-flatcar.yaml
+++ b/ansible/roles/containerd/tasks/install-flatcar.yaml
@@ -15,15 +15,7 @@
     - ansible_facts['distribution_version'] is version('3033.3.0', '>=', version_type='semver')
     - ansible_facts['distribution_version'] is version('3033.4.0', '<', version_type='semver')
 
-- name: Create systemd unit file for containerd
-  template:
-    dest: /etc/systemd/system/containerd.service
-    src: etc/systemd/system/containerd-flatcar.service
-    mode: 0600
-  when: dockerUpgradeRequired is not defined
-
-- name: Download, Update and Restart docker for 3033.3.x flatcar LTS
-  when: dockerUpgradeRequired is true
+- when: dockerUpgradeRequired is true
   block:
   - name: Download docker for 3033.3.x flatcar LTS to /opt/docker.tgz
     get_url:
@@ -47,6 +39,20 @@
       - prepare-docker
       - docker
       - containerd
+
+- name: Check if /opt/bin/dockerd binary exists
+  changed_when: false
+  stat:
+    path: "/opt/bin/dockerd"
+  register: dockerd_binary_exists
+
+# Only run this task if not using the downloaded Docker binary
+- name: Create systemd unit file for containerd
+  template:
+    dest: /etc/systemd/system/containerd.service
+    src: etc/systemd/system/containerd-flatcar.service
+    mode: 0600
+  when: not dockerd_binary_exists.stat.exists
 
 - name: Create containerd memory pressure drop in file
   template:


### PR DESCRIPTION
**What problem does this PR solve?**:
Don't revert Docker and Containerd systemd unit files when running KIB for a second time after downloading a new version of Docker.

Tested manually by running a pre-provisioned Kubernetes cluster upgrade with a dev image.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-98979)
-->
* https://d2iq.atlassian.net/browse/D2IQ-98979


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
