### PR TITLE
[release-1.19] fix: force redownload of Kubelet and kubectl binaries for Flatcar

### DIFF
--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -55,7 +55,7 @@ aws_images: []
 extra_images: []
 
 containerd_base_url: https://packages.d2iq.com/dkp/containerd
-kubernetes_http_source: https://storage.googleapis.com/kubernetes-release/release
+kubernetes_http_source: https://dl.k8s.io/release
 kubernetes_cni_semver: v{{ kubernetes_cni_version }}
 kubernetes_cni_http_checksum: sha256:https://storage.googleapis.com/k8s-artifacts-cni/release/{{ kubernetes_cni_semver }}/cni-plugins-linux-amd64-{{ kubernetes_cni_semver }}.tgz.sha256
 kubernetes_cni_http_source: https://github.com/containernetworking/plugins/releases/download

--- a/ansible/roles/containerd/tasks/install.yaml
+++ b/ansible/roles/containerd/tasks/install.yaml
@@ -20,6 +20,7 @@
     url: "{{ containerd_base_url }}/{{ containerd_tar_file }}"
     dest: "{{ containerd_remote_bundle_path }}/{{ containerd_tar_file }}"
     mode: 0600
+    force: true
   when:
     - not containerd_tar_file_exists.stat.exists
 

--- a/ansible/roles/gpu/tasks/nvidia-gpu-RHEL7.yaml
+++ b/ansible/roles/gpu/tasks/nvidia-gpu-RHEL7.yaml
@@ -61,6 +61,7 @@
     url: "{{ nvidia_runfile_installer_url }}"
     dest: "{{ runfile_dir.path }}/{{ nvidia_runfile_installer }}"
     mode: 0755
+    force: true
   retries: 3
   delay: 3
 

--- a/ansible/roles/gpu/tasks/nvidia-gpu-RHEL8.yaml
+++ b/ansible/roles/gpu/tasks/nvidia-gpu-RHEL8.yaml
@@ -39,6 +39,7 @@
     url: "{{ nvidia_runfile_installer_url }}"
     dest: "{{ runfile_dir.path }}/{{ nvidia_runfile_installer }}"
     mode: 0755
+    force: true
   retries: 3
   delay: 3
 

--- a/ansible/roles/gpu/tasks/nvidia-gpu-Ubuntu20.yaml
+++ b/ansible/roles/gpu/tasks/nvidia-gpu-Ubuntu20.yaml
@@ -20,6 +20,7 @@
     url: https://developer.download.nvidia.com/compute/cuda/repos/{{ distribution }}/x86_64/cuda-{{ distribution }}.pin
     dest: /etc/apt/preferences.d/cuda-repository-pin-600
     mode: '0644'
+    force: true
   retries: 3
   delay: 3
 
@@ -66,6 +67,7 @@
     url: https://nvidia.github.io/nvidia-docker/{{ ansible_distribution | lower }}{{ ansible_distribution_version }}/nvidia-docker.list
     dest: /etc/apt/sources.list.d/nvidia-docker.list
     mode: '0644'
+    force: true
   retries: 3
   delay: 3
 

--- a/ansible/roles/kubeadm/tasks/flatcar.yaml
+++ b/ansible/roles/kubeadm/tasks/flatcar.yaml
@@ -6,3 +6,4 @@
     mode: 0755
     owner: root
     group: root
+    force: true

--- a/ansible/roles/packages/tasks/crictl-url.yaml
+++ b/ansible/roles/packages/tasks/crictl-url.yaml
@@ -7,6 +7,7 @@
     checksum: "sha256:{{ crictl_sha256 }}"
     dest: /tmp/crictl.tar.gz
     mode: 0600
+    force: true
 
 - name: Create "{{ sysusrlocal_prefix }}/bin" directory
   changed_when: False

--- a/ansible/roles/packages/tasks/url.yaml
+++ b/ansible/roles/packages/tasks/url.yaml
@@ -34,6 +34,7 @@
       force: true
       owner: root
       group: root
+      force: true
 
   - name: Install CNI
     unarchive:
@@ -57,6 +58,7 @@
     mode: 0755
     owner: root
     group: root
+    force: true
   loop: "{{ kubernetes_bins }}"
 
 - name: Create Kubernetes manifests directory

--- a/ansible/roles/packages/tasks/url.yaml
+++ b/ansible/roles/packages/tasks/url.yaml
@@ -31,6 +31,7 @@
       checksum: "{{ kubernetes_cni_http_checksum }}"
       dest: /tmp/cni.tar.gz
       mode: 0755
+      force: true
       owner: root
       group: root
 

--- a/ansible/roles/providers/tasks/googlecompute.yml
+++ b/ansible/roles/providers/tasks/googlecompute.yml
@@ -16,6 +16,7 @@
   get_url:
     url: https://sdk.cloud.google.com/
     dest: /tmp/install-gcloud.sh
+    force: true
     mode: 0700
 
 - name: Clean existing gcloud SDK content & directory

--- a/ansible/roles/setup_versionlock/tasks/redhat.yaml
+++ b/ansible/roles/setup_versionlock/tasks/redhat.yaml
@@ -35,6 +35,7 @@
   get_url:
     url: 'https://rhelimage.blob.core.windows.net/repositories/rhui-microsoft-azure-rhel{{ ansible_distribution_major_version }}.config'
     dest: '/tmp/rhel{{ ansible_distribution_major_version }}.config'
+    force: true
   when:
     - packer_builder_type.startswith('azure')
     - ansible_distribution_major_version == '8'


### PR DESCRIPTION
**What problem does this PR solve?**:
Force redownload the Kubelet and kubectl binaries for Flatcar.
Without this fix, upgraded Nodes ended up not actually upgrading the Kubelet version.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-98984)
-->
* https://d2iq.atlassian.net/browse/D2IQ-98984


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
