### PR TITLE
fix: bump alpine from 3.15.4 to 3.15.6

### DIFF
--- a/.github/workflows/vsphere-e2e.yaml
+++ b/.github/workflows/vsphere-e2e.yaml
@@ -86,7 +86,6 @@ jobs:
         env:
           SSH_BASTION_KEY_CONTENTS: ${{ secrets.SSH_BASTION_KEY_CONTENTS }}
           SSH_BASTION_PUBLIC_KEY_CONTENTS: ${{ secrets.SSH_BASTION_PUBLIC_KEY_CONTENTS }}
-          SSH_PUBLIC_KEY: ${{ secrets.SSH_BASTION_PUBLIC_KEY_CONTENTS}}
           VSPHERE_USERNAME: ${{ secrets.VSPHERE_USERNAME }}
           VSPHERE_USER: ${{ secrets.VSPHERE_USERNAME }} # required for terraform
           VSPHERE_PASSWORD: ${{ secrets.VSPHERE_PASSWORD }}

--- a/.github/workflows/vsphere-e2e.yaml
+++ b/.github/workflows/vsphere-e2e.yaml
@@ -86,6 +86,7 @@ jobs:
         env:
           SSH_BASTION_KEY_CONTENTS: ${{ secrets.SSH_BASTION_KEY_CONTENTS }}
           SSH_BASTION_PUBLIC_KEY_CONTENTS: ${{ secrets.SSH_BASTION_PUBLIC_KEY_CONTENTS }}
+          SSH_PUBLIC_KEY: ${{ secrets.SSH_BASTION_PUBLIC_KEY_CONTENTS}}
           VSPHERE_USERNAME: ${{ secrets.VSPHERE_USERNAME }}
           VSPHERE_USER: ${{ secrets.VSPHERE_USERNAME }} # required for terraform
           VSPHERE_PASSWORD: ${{ secrets.VSPHERE_PASSWORD }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apk add --no-cache \
         py3-cryptography \
         py3-pip \
         py3-wheel \
+        xorriso \
     && pip3 install --no-cache-dir --requirement /tmp/requirements.txt \
     && rm -rf /root/.cache
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM ${BASE} as devkit
 
 ARG TARGETPLATFORM
 # hadolint ignore=DL3029
-FROM --platform=${TARGETPLATFORM} alpine:3.15.4
+FROM --platform=${TARGETPLATFORM} alpine:3.15.6
 
 ENV ANSIBLE_PATH=/usr
 ENV PYTHON_PATH=/usr

--- a/Dockerfile.devkit
+++ b/Dockerfile.devkit
@@ -139,7 +139,8 @@ RUN --mount=type=secret,id=githubtoken PACKER_GITHUB_API_TOKEN="$(cat /run/secre
     packer-${BUILDARCH} plugins install github.com/hashicorp/azure ">=1.3.1" && \
     packer-${BUILDARCH} plugins install github.com/hashicorp/amazon ">=1.1.3" && \
     packer-${BUILDARCH} plugins install github.com/hashicorp/ansible ">=1.0.3" && \
-    packer-${BUILDARCH} plugins install github.com/hashicorp/vsphere ">=1.0.8"
+    packer-${BUILDARCH} plugins install github.com/hashicorp/vsphere ">=1.0.8" && \
+    packer-${BUILDARCH} plugins install github.com/ivoronin/sshkey ">=1.0.1"
 
 # Non-trivial bash scripting like e.g. the Makefile require bash instead of
 # plain sh, in order to function.

--- a/cmd/konvoy-image-wrapper/cmd/wrapper.go
+++ b/cmd/konvoy-image-wrapper/cmd/wrapper.go
@@ -50,9 +50,10 @@ const (
 	envRedHatSubscriptionManagerActivationKey = "RHSM_ACTIVATION_KEY"
 	envRedHatSubscriptionManagerOrgID         = "RHSM_ORG_ID"
 
-	envVSphereSSHUserName       = "SSH_USERNAME"
-	envVSphereSSHPassword       = "SSH_PASSWORD"
-	envVsphereSSHPrivatekeyFile = "SSH_PRIVATE_KEY_FILE"
+	envVSphereSSHUserName          = "SSH_USERNAME"
+	envVSphereSSHPassword          = "SSH_PASSWORD"
+	envVsphereSSHPrivatekeyFile    = "SSH_PRIVATE_KEY_FILE"
+	envVsphereSSHPublicKeyContents = "SSH_PUBLIC_KEY"
 
 	//nolint:gosec // environment var set by user
 	envGCPApplicationCredentials = "GOOGLE_APPLICATION_CREDENTIALS"
@@ -216,6 +217,8 @@ func (r *Runner) setVSphereEnv() error {
 		envRedHatSubscriptionManagerOrgID,
 		envVSphereSSHUserName,
 		envVSphereSSHPassword,
+		envVsphereSSHPrivatekeyFile,
+		envVsphereSSHPublicKeyContents,
 	} {
 		value, found := os.LookupEnv(env)
 		if found {

--- a/images/ova/rhel-79.yaml
+++ b/images/ova/rhel-79.yaml
@@ -13,7 +13,7 @@ packer:
   insecure_connection: "false"
   network: ""
   resource_pool: ""
-  template: "os-qualification-templates/d2iq-base-RHEL-79"
+  template: "d2iq-base-templates/d2iq-base-RHEL-79"
   vsphere_guest_os_type: "rhel7_64Guest"
   guest_os_type: "rhel7-64"
   # goss params

--- a/images/ova/rhel-84.yaml
+++ b/images/ova/rhel-84.yaml
@@ -13,7 +13,7 @@ packer:
   insecure_connection: "false"
   network: ""
   resource_pool: ""
-  template: "os-qualification-templates/d2iq-base-RHEL-84" # change default value with your base template name
+  template: "d2iq-base-templates/d2iq-base-RHEL-84" # change default value with your base template name
   vsphere_guest_os_type: "rhel8_64Guest"
   guest_os_type: "rhel8-64"
   # goss params

--- a/images/ova/rhel-86.yaml
+++ b/images/ova/rhel-86.yaml
@@ -13,7 +13,7 @@ packer:
   insecure_connection: "false"
   network: ""
   resource_pool: ""
-  template: "os-qualification-templates/d2iq-base-RHEL-86" # change default value with your base template name
+  template: "d2iq-base-templates/d2iq-base-RHEL-86" # change default value with your base template name
   vsphere_guest_os_type: "rhel8_64Guest"
   guest_os_type: "rhel8-64"
   # goss params

--- a/images/ova/rocky-91.yaml
+++ b/images/ova/rocky-91.yaml
@@ -13,7 +13,7 @@ packer:
   insecure_connection: "false"
   network: ""
   resource_pool: ""
-  template: "os-qualification-templates/d2iq-base-RockyLinux-9.1" # change default value with your base template name
+  template: "d2iq-base-templates/d2iq-base-RockyLinux-9.1" # change default value with your base template name
   vsphere_guest_os_type: "other4xLinux64Guest"
   guest_os_type: "rocky9-64"
   # goss params

--- a/images/ova/ubuntu-2004.yaml
+++ b/images/ova/ubuntu-2004.yaml
@@ -13,7 +13,7 @@ packer:
   insecure_connection: "false"
   network: ""
   resource_pool: ""
-  template: "os-qualification-templates/d2iq-base-Ubuntu-20.04" # change default value with your base template name
+  template: "d2iq-base-templates/d2iq-base-Ubuntu-20.04" # change default value with your base template name
   vsphere_guest_os_type: "other4xLinux64Guest"
   guest_os_type: "ubuntu2004-64"
   # goss params

--- a/pkg/packer/manifests/vsphere/packer.pkr.hcl
+++ b/pkg/packer/manifests/vsphere/packer.pkr.hcl
@@ -366,6 +366,81 @@ locals {
   ssh_bastion_private_key_file = var.ssh_bastion_private_key_file
   ssh_bastion_username         = var.ssh_bastion_username
   vm_name                      = "konvoy-${var.build_name}-${var.kubernetes_full_version}-${local.build_timestamp}"
+
+  # if only a public key is given we expect the private key to be loaded into ssh-agent
+  ssh_agent_auth = var.ssh_agent_auth  != "false" ? true : var.ssh_private_key_file == "" && var.ssh_public_key != ""
+  # inject generated key if no agent auth or private key is given
+  ssh_private_key_file = var.ssh_private_key_file != "" ? var.ssh_private_key_file : local.ssh_agent_auth ? "" : data.sshkey.kibkey.private_key_path
+  # when ssh_private_key_file uses the generated key inject its public key
+  ssh_public_key = local.ssh_private_key_file == data.sshkey.kibkey.private_key_path ? data.sshkey.kibkey.public_key : chomp(var.ssh_public_key)
+  ssh_password_hash = bcrypt(var.ssh_password)
+  # prepare cloud-init
+  cloud_init = <<EOF
+#cloud-config
+users:
+  - name: ${var.ssh_username}
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: sudo, wheel
+    lock_passwd: true
+    ssh_authorized_keys:
+      - ${local.ssh_public_key}
+EOF
+  ignition_config = <<EOF
+{
+  "ignition": {
+    "config": {},
+    "security": {
+      "tls": {}
+    },
+    "timeouts": {},
+    "version": "2.3.0"
+  },
+  "networkd": {},
+  "passwd": {
+    "users": [
+      {
+        "groups": [
+          "wheel",
+          "sudo",
+          "docker"
+        ],
+        "name": "${var.ssh_username}",
+        "passwordHash": "${local.ssh_password_hash}",
+        "sshAuthorizedKeys": [
+          "${local.ssh_public_key}"
+        ]
+      }
+    ]
+  },
+  "systemd": {
+    "units": [
+      {
+        "enabled": true,
+        "name": "docker.service"
+      },
+      {
+        "mask": true,
+        "name": "update-engine.service"
+      },
+      {
+        "mask": true,
+        "name": "locksmithd.service"
+      }
+    ]
+  }
+}
+EOF
+  configuration_parameters_cloud_init = local.ssh_public_key != "" ? {
+    "guestinfo.userdata" = base64encode(local.cloud_init),
+    "guestinfo.userdata.encoding" = "base64",
+    "guestinfo.metadata" = ""
+    "guestinfo.metadata.encoding" = "base64"
+  } : {}
+  configuration_parameters_ignition = {
+    "guestinfo.ignition.config.data" = base64encode(local.ignition_config),
+    "guestinfo.ignition.config.data.encoding" = "base64",
+  }
+  configuration_parameters = var.distribution == "flatcar" ? local.configuration_parameters_ignition : local.configuration_parameters_cloud_init
 }
 
 # source blocks are generated from your builders; a source can be referenced in

--- a/pkg/packer/manifests/vsphere/packer.pkr.hcl
+++ b/pkg/packer/manifests/vsphere/packer.pkr.hcl
@@ -8,6 +8,10 @@ packer {
       version = ">= 1.0.2"
       source  = "github.com/hashicorp/ansible"
     }
+    sshkey = {
+      version = ">= 1.0.1"
+      source  = "github.com/ivoronin/sshkey"
+    }
   }
 }
 
@@ -351,6 +355,10 @@ variable "remote_folder" {
   default = "/tmp"
 }
 
+data "sshkey" "kibkey" {
+  name = "konvoy-image-builder-tmpkey"
+}
+
 # "timestamp" template function replacement
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
@@ -369,11 +377,12 @@ locals {
 
   # if only a public key is given we expect the private key to be loaded into ssh-agent
   ssh_agent_auth = var.ssh_agent_auth  != "false" ? true : var.ssh_private_key_file == "" && var.ssh_public_key != ""
+
   # inject generated key if no agent auth or private key is given
   ssh_private_key_file = var.ssh_private_key_file != "" ? var.ssh_private_key_file : local.ssh_agent_auth ? "" : data.sshkey.kibkey.private_key_path
   # when ssh_private_key_file uses the generated key inject its public key
   ssh_public_key = local.ssh_private_key_file == data.sshkey.kibkey.private_key_path ? data.sshkey.kibkey.public_key : chomp(var.ssh_public_key)
-  ssh_password_hash = bcrypt(var.ssh_password)
+  ssh_password_hash = var.ssh_password != "" ? bcrypt(var.ssh_password): ""
   # prepare cloud-init
   cloud_init = <<EOF
 #cloud-config
@@ -430,6 +439,7 @@ EOF
   }
 }
 EOF
+
   configuration_parameters_cloud_init = local.ssh_public_key != "" ? {
     "guestinfo.userdata" = base64encode(local.cloud_init),
     "guestinfo.userdata.encoding" = "base64",
@@ -469,7 +479,7 @@ source "vsphere-clone" "kib_image" {
   ssh_bastion_username         = local.ssh_bastion_username
   ssh_key_exchange_algorithms  = ["curve25519-sha256@libssh.org", "ecdh-sha2-nistp256", "ecdh-sha2-nistp384", "ecdh-sha2-nistp521", "diffie-hellman-group14-sha1", "diffie-hellman-group1-sha1"]
   ssh_password                 = var.ssh_password
-  ssh_private_key_file         = var.ssh_private_key_file
+  ssh_private_key_file         = local.ssh_private_key_file
   ssh_timeout                  = "4h"
   ssh_username                 = var.ssh_username
   template                     = var.template
@@ -477,6 +487,16 @@ source "vsphere-clone" "kib_image" {
   vcenter_server               = var.vcenter_server
   vm_name                      = local.vm_name
   resource_pool                = var.resource_pool
+
+  cd_label = "cidata"
+  cd_content = {
+    "/user-data"       = local.cloud_init,
+    "/user-data.txt"       = local.cloud_init,
+    "/meta-data"       = "",
+  }
+
+  // try injecting cloud-init via guestinfo
+  configuration_parameters = local.configuration_parameters
 
   create_snapshot     = !var.dry_run
   convert_to_template = !var.dry_run
@@ -570,9 +590,9 @@ build {
   post-processor "shell-local" {
     inline = [ "if ${var.dry_run}; then echo 'destroying VM ${local.vm_name} with command: govc vm.destroy -dc=${var.vsphere_datacenter} ${local.vm_name}'; govc vm.destroy -dc=${var.vsphere_datacenter} ${local.vm_name}; fi"]
     environment_vars =[
-        "GOVC_URL=${var.vcenter_server}",
-        "GOVC_USERNAME=${var.vsphere_username}",
-        "GOVC_PASSWORD=${var.vsphere_password}"
+      "GOVC_URL=${var.vcenter_server}",
+      "GOVC_USERNAME=${var.vsphere_username}",
+      "GOVC_PASSWORD=${var.vsphere_password}"
     ]
   }
 }

--- a/pkg/packer/manifests/vsphere/packer.pkr.hcl
+++ b/pkg/packer/manifests/vsphere/packer.pkr.hcl
@@ -147,6 +147,12 @@ variable "ssh_private_key_file" {
   sensitive = true
 }
 
+variable "ssh_public_key" {
+  type    = string
+  default = env("SSH_PUBLIC_KEY")
+  sensitive = true
+}
+
 variable "ssh_timeout" {
   type    = string
   default = "60m"

--- a/test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl
+++ b/test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl
@@ -15,6 +15,4 @@ packer:
   folder: "cluster-api"
   network: "Airgapped"
   resource_pool: "Users"
-  # ssh authentication with base template VM.
-  ssh_username: "builder"
-  ssh_agent_auth: true
+  ssh_username: "kib"

--- a/test/infra/vsphere/variables.tf
+++ b/test/infra/vsphere/variables.tf
@@ -5,7 +5,7 @@ variable "datastore_name" {
 
 variable "bastion_base_template" {
   description = "base template name"
-  default     = "os-qualification-templates/d2iq-base-RockyLinux-9.1"
+  default     = "d2iq-base-templates/d2iq-base-RockyLinux-9.1"
 }
 
 variable "resource_pool_name" {


### PR DESCRIPTION
**What problem does this PR solve?**:
Bumps alpine to 3.15.6, the oldest possible version with zlib CVE patch: https://gitlab.alpinelinux.org/alpine/aports/-/commit/41216b729e439cc0ba91320e82962b51f163591e

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-99081)
-->
* https://jira.d2iq.com/browse/D2IQ-99081

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
