### PR TITLE
fix: remove deprecated cmdline argument

### DIFF
--- a/ansible/roles/config/templates/kubelet-drop-in.conf
+++ b/ansible/roles/config/templates/kubelet-drop-in.conf
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix://{{ containerd_cri_socket }}"
+Environment="KUBELET_EXTRA_ARGS=--runtime-request-timeout=15m --container-runtime-endpoint=unix://{{ containerd_cri_socket }}"


### PR DESCRIPTION
**What problem does this PR solve?**:
https://kubernetes.io/blog/2023/03/17/upcoming-changes-in-kubernetes-v1-27/#removal-of-container-runtime-command-line-argument removes deprecated command line argument. entirely unclear why some tests are passing. I found this error on an azure machine

```
Sep 12 00:39:45 faiq-test15-control-plane-gsphw kubelet[2392]: E0912 00:39:45.346378    2392 run.go:74] "command failed" err="failed to parse kubelet flag: unknown flag: --container-runtime"
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
