### PR TITLE
fix: bump alpine from 3.15.4 to 3.15.6 to patch zlib CVE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE=mesosphere/konvoy-image-builder:latest-devkit
 # hadolint ignore=DL3006
 FROM ${BASE} as devkit
 
-FROM alpine:3.15.4
+FROM alpine:3.15.6
 
 ENV ANSIBLE_PATH=/usr
 ENV PYTHON_PATH=/usr


### PR DESCRIPTION
**What problem does this PR solve?**:
Bumps alpine to 3.15.6, the oldest possible version with zlib CVE patch: https://gitlab.alpinelinux.org/alpine/aports/-/commit/41216b729e439cc0ba91320e82962b51f163591e

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
