### PR TITLE
fix: skip building podman binary on release

### DIFF
--- a/.github/workflows/podman-aws-e2e.yaml
+++ b/.github/workflows/podman-aws-e2e.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Build snapshot
         run:  |-
           make build-for-podman
-          goreleaser build --id konvoy-image-wrapper-for-podman --clean --skip-validate
+          goreleaser build --config=.goreleaser-podman-e2e.yml --clean --skip-validate
 
       - name: Run E2E test for AWS centos 7.9 using podman
         run: |-

--- a/.goreleaser-podman-e2e.yml
+++ b/.goreleaser-podman-e2e.yml
@@ -1,0 +1,25 @@
+---
+before:
+  hooks:
+    - go mod download
+    - go mod tidy
+
+builds:
+  - main: ./cmd/konvoy-image-wrapper/main.go
+    id: konvoy-image-wrapper-for-podman
+    binary: konvoy-image
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    tags:
+      - EMBED_DOCKER_IMAGE
+    ldflags:
+      - -s -w
+      - -X {{ .ModulePath }}/pkg/version.version={{ .FullCommit }}
+      - -X {{ .ModulePath }}/pkg/version.builtBy=goreleaser
+    goos:
+      - linux
+    goarch:
+      - amd64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,25 +35,6 @@ builds:
       - arm64
 
   - main: ./cmd/konvoy-image-wrapper/main.go
-    id: konvoy-image-wrapper-for-podman
-    binary: konvoy-image
-    mod_timestamp: "{{ .CommitTimestamp }}"
-    env:
-      - CGO_ENABLED=0
-    flags:
-      - -trimpath
-    tags:
-      - EMBED_DOCKER_IMAGE
-    ldflags:
-      - -s -w
-      - -X {{ .ModulePath }}/pkg/version.version={{ .FullCommit }}
-      - -X {{ .ModulePath }}/pkg/version.builtBy=goreleaser
-    goos:
-      - linux
-    goarch:
-      - amd64
-
-  - main: ./cmd/konvoy-image-wrapper/main.go
     id: konvoy-image-wrapper
     binary: konvoy-image
     mod_timestamp: "{{ .CommitTimestamp }}"


### PR DESCRIPTION
**What problem does this PR solve?**:
The release job [was failing here](https://github.com/mesosphere/konvoy-image-builder/actions/runs/6552028990/job/17796325263). I suspect its due the recent changes in [.goreleaser.yaml](https://github.com/mesosphere/konvoy-image-builder/pull/930/files#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689R38) and its overriding the same `konvoy-image` binary. Since this new build spec is only needed in a specific e2e test I moved it out to a different (non-default) config file and reverted .goreleaser.yaml to what it was before.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
