### PR TITLE
fix: downgrade cloud-init package for ubuntu OS 

### DIFF
--- a/ansible/roles/packages/tasks/debian.yaml
+++ b/ansible/roles/packages/tasks/debian.yaml
@@ -31,6 +31,32 @@
   retries: 3
   delay: 3
 
+# The latest cloud-init version '23.3.1-0ubuntu1~20.04.1 is unable to run #boothook created by CAPA
+# https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/0bf78b04b305a77aec37a68c107102231faa7a16/pkg/cloud/services/secretsmanager/secret_fetch_script.go#L20
+# This is a workaround to downgrade to older cloud-init version. 
+# Once the fix is available in cloud-init and base ubuntu AMI are built with the fixed cloud-init,
+# we can revert to using cloud-init version provided by the base AMI. 
+- name: Install specific cloud-init version 23.2.1-0ubuntu0~20.04.2
+  apt:
+    deb: https://launchpad.net/ubuntu/+source/cloud-init/23.2.1-0ubuntu0~20.04.2/+build/26374992/+files/cloud-init_23.2.1-0ubuntu0~20.04.2_all.deb
+    state: present
+    force_apt_get: true
+    allow_downgrade: true
+  when: ansible_os_family == "Debian"
+
+- name: Install cloud-init packages
+  apt:
+    name: "{{ packages }}"
+    state: present
+    force_apt_get: true
+  vars:
+    packages:
+      - cloud-guest-utils
+      - cloud-initramfs-copymods
+      - cloud-initramfs-dyn-netconf
+      - cloud-initramfs-growroot
+  when: ansible_os_family == "Debian"
+
 - name: remove version hold for kubelet and kubectl packages
   command: apt-mark unhold {{ item }}
   with_items:


### PR DESCRIPTION
**What problem does this PR solve?**:
The latest cloud-init version `23.3.1-0ubuntu1~20.04.1` is unable to run `boothook` https://cloudinit.readthedocs.io/en/latest/explanation/format.html#cloud-boothook provided by CAPA, https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/0bf78b04b305a77aec37a68c107102231faa7a16/pkg/cloud/services/secretsmanager/secret_fetch_script.go#L20
As a result the VMs are not initializing as expected. 
This is workaround until we have a fix available in cloud-init.


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-99614)
-->
* https://d2iq.atlassian.net/browse/D2IQ-99614


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
Created AMI `ami-0a2a327f0619dff0e` using the downgraded AMI version and was able to create cluster successfully. 
<img width="1135" alt="image" src="https://github.com/mesosphere/konvoy-image-builder/assets/6110931/fc9c9cf6-10a9-43ff-84b9-b42ff1cea1ce">


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
