### PR TITLE
fix: downgrade cloud-init to 23.1.2-0ubuntu0~20.04.2

### DIFF
--- a/ansible/roles/packages/tasks/debian.yaml
+++ b/ansible/roles/packages/tasks/debian.yaml
@@ -36,9 +36,9 @@
 # This is a workaround to downgrade to older cloud-init version. 
 # Once the fix is available in cloud-init and base ubuntu AMI are built with the fixed cloud-init,
 # we can revert to using cloud-init version provided by the base AMI. 
-- name: Install specific cloud-init version 23.2.1-0ubuntu0~20.04.2
+- name: Install cloud-init version 23.1.2-0ubuntu0~20.04.2
   apt:
-    deb: https://launchpad.net/ubuntu/+source/cloud-init/23.2.1-0ubuntu0~20.04.2/+build/26374992/+files/cloud-init_23.2.1-0ubuntu0~20.04.2_all.deb
+    name: cloud-init=23.1.2-0ubuntu0~20.04.2
     state: present
     force_apt_get: true
     allow_downgrade: true


### PR DESCRIPTION
**What problem does this PR solve?**:
- pin cloud-init version to `23.1.2-0ubuntu0~20.04.2` for ubuntu

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-99614)
-->
* https://d2iq.atlassian.net/browse/D2IQ-99614


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
