### PR TITLE
fix: install pinned cloud-init for only ubuntu 20.04

### DIFF
--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -108,3 +108,5 @@ nvidia_driver_version: "470.82.01"
 nvidia_runfile_installer: "NVIDIA-Linux-x86_64-{{ nvidia_driver_version }}.run"
 nvidia_runfile_installer_url: "https://download.nvidia.com/XFree86/Linux-x86_64/{{ nvidia_driver_version }}/{{ nvidia_runfile_installer }}"
 suse_packagehub_product: PackageHub/{{ ansible_distribution_version }}/{{ ansible_architecture }}
+
+pinned_debs: []

--- a/ansible/roles/packages/tasks/debian.yaml
+++ b/ansible/roles/packages/tasks/debian.yaml
@@ -31,6 +31,19 @@
   retries: 3
   delay: 3
 
+- name: install pinned debs
+  apt:
+    force_apt_get: True
+    name: "{{ item }}"
+    state: present
+    force: yes
+  register: apt_lock_status
+  until: apt_lock_status is not failed
+  retries: 5
+  delay: 10
+  with_items: "{{ pinned_debs }}"
+  when: ansible_os_family == "Debian"
+
 - name: remove version hold for kubelet and kubectl packages
   command: apt-mark unhold {{ item }}
   with_items:

--- a/images/ami/ubuntu-2004.yaml
+++ b/images/ami/ubuntu-2004.yaml
@@ -12,3 +12,8 @@ packer:
 build_name: "ubuntu-20"
 packer_builder_type: "amazon"
 python_path: ""
+# The latest cloud-init version '23.3.1-0ubuntu1~20.04.1 is unable to run #boothook created by CAPA
+# https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/0bf78b04b305a77aec37a68c107102231faa7a16/pkg/cloud/services/secretsmanager/secret_fetch_script.go#L20
+# This is a workaround to downgrade to older cloud-init version.
+# TODO: remove it when base ubuntu AMI has fixed version of cloud-init available. https://d2iq.atlassian.net/browse/D2IQ-99637
+pinned_debs: ["cloud-init=23.1.2-0ubuntu0~20.04.2"]


### PR DESCRIPTION
**What problem does this PR solve?**:
backport of https://github.com/mesosphere/konvoy-image-builder/pull/943
Fix pinned version of the cloud-init.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-99614)
-->
* https://d2iq.atlassian.net/browse/D2IQ-99614

