### PR TITLE
[release-2.5] fix: Install gcloud CLI system package

### DIFF
--- a/ansible/roles/providers/tasks/googlecompute.yml
+++ b/ansible/roles/providers/tasks/googlecompute.yml
@@ -12,75 +12,103 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-- name: Download gcloud SDK
-  get_url:
-    url: https://sdk.cloud.google.com/
-    dest: /tmp/install-gcloud.sh
-    force: true
-    mode: 0700
-
-- name: Clean existing gcloud SDK content & directory
-  file:
-    state: absent
-    path: /google-cloud-sdk/
-
-- name: Execute install-gcloud.sh
-  shell: >-
-    bash -o errexit -o pipefail
-    /tmp/install-gcloud.sh --disable-prompts --install-dir=/
-
-- name: Remove install-gcloud.sh
-  file:
-    path: /tmp/install-gcloud.sh
-    state: absent
-
-- name: Find all files in /google-cloud-sdk/bin/
-  find:
-    paths: /google-cloud-sdk/bin/
-  register: find
-
-- name: Create symlinks to /bin
-  become: true
-  file:
-    src: "{{ item.path }}"
-    path: "/bin/{{ item.path | basename }}"
-    state: link
-  with_items: "{{ find.files }}"
-
-- name: Install cloud-init packages
-  apt:
-    name: "{{ packages }}"
-    state: present
-    force_apt_get: true
-  vars:
-    packages:
-      - cloud-init
-      - cloud-guest-utils
-      - cloud-initramfs-copymods
-      - cloud-initramfs-dyn-netconf
+- name: (Debian) Install gcloud CLI
   when: ansible_os_family == "Debian"
+  block:
+    - name: (Debian) Add gcloud repository key
+      ansible.builtin.get_url:
+        url: "https://packages.cloud.google.com/apt/doc/apt-key.gpg"
+        dest: /usr/share/keyrings/google-cloud-apt-repo.asc
+        mode: '0644'
+        force: true
+      retries: 3
+      delay: 3
+    - name: (Debian) Add gcloud repository
+      ansible.builtin.apt_repository:
+        repo: "deb [signed-by=/usr/share/keyrings/google-cloud-apt-repo.asc] http://packages.cloud.google.com/apt cloud-sdk main"
+        state: present
+        update_cache: true
+      retries: 3
+      delay: 3
+    - name: (Debian) Install gcloud CLI package
+      ansible.builtin.apt:
+        name: google-cloud-cli
+        state: present
+      retries: 3
+      delay: 3
 
-- name: Install cloud-init packages
-  yum:
-    name: "{{ packages }}"
-    state: present
-  vars:
-    packages:
-      - cloud-init
-      - cloud-utils-growpart
-      - python2-pip
+- name: (RedHat) Install gcloud CLI
   when: ansible_os_family == "RedHat"
+  block:
+    - name: (RedHat) Add gcloud repository
+      ansible.builtin.yum_repository:
+        name: Google Cloud SDK
+        description: Google Cloud SDK
+        enabled: true
+        baseurl: https://packages.cloud.google.com/yum/repos/cloud-sdk-el9-x86_64
+        gpgcheck: true
+        repo_gpgcheck: false
+        gpgkey: https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+      retries: 3
+      delay: 3
+    - name: (RedHat) Install gcloud CLI package
+      ansible.builtin.yum:
+        name: google-cloud-cli
+        state: present
+      retries: 3
+      delay: 3
+
+- name: (SUSE) Install gcloud CLI
+  when: ansible_os_family == "Suse"
+  block:
+    - name: (SUSE) Add gcloud repository
+      community.general.zypper_repository:
+        name: Google Cloud SDK
+        repo: https://packages.cloud.google.com/yum/repos/cloud-sdk-el9-x86_64
+        auto_import_keys: true
+      retries: 3
+      delay: 3
+    - name: (SUSE) Install gcloud CLI package
+      community.general.zypper:
+        name: google-cloud-cli
+        state: present
+      retries: 3
+      delay: 3
 
 - name: Install cloud-init packages
-  zypper:
-    name: "{{ packages }}"
-    state: present
-  vars:
-    packages:
-      - cloud-init
-      - cloud-init-guestinfo
-  when: ansible_os_family == "Suse"
-  register: result
-  until: result is success
-  retries: 15
-  delay: 60
+  block:
+    - name: (SUSE) Install cloud-init packages
+      community.general.zypper:
+        name: "{{ packages }}"
+        state: present
+      vars:
+        packages:
+          - cloud-init
+          - cloud-init-guestinfo
+      when: ansible_os_family == "Suse"
+      register: result
+      until: result is success
+      retries: 15
+      delay: 60
+    - name: (RedHat) Install cloud-init packages
+      ansible.builtin.yum:
+        name: "{{ packages }}"
+        state: present
+      vars:
+        packages:
+          - cloud-init
+          - cloud-utils-growpart
+          - python2-pip
+      when: ansible_os_family == "RedHat"
+    - name: (Debian) Install cloud-init packages
+      ansible.builtin.apt:
+        name: "{{ packages }}"
+        state: present
+        force_apt_get: true
+      vars:
+        packages:
+          - cloud-init
+          - cloud-guest-utils
+          - cloud-initramfs-copymods
+          - cloud-initramfs-dyn-netconf
+      when: ansible_os_family == "Debian"

--- a/images/gcp/centos-79.yaml
+++ b/images/gcp/centos-79.yaml
@@ -4,8 +4,8 @@ download_images: true
 packer:
   # The source image to use to create the new image from. source_image = `distribution`-`distribution_version-k8sversion-timestamp`
   distribution: "centos"
-  distribution_version: "7-9-v20220519"
-  source_image: "centos-7-v20220519"
+  distribution_version: "7-v20231212"
+  source_image: "centos-7-v20231212"
   # The source_image_family to use to create the new image from.
   distribution_family: "centos-7"
   # The username to connect to SSH with. Required if using SSH.

--- a/images/gcp/ubuntu-1804.yaml
+++ b/images/gcp/ubuntu-1804.yaml
@@ -4,8 +4,8 @@ download_images: true
 packer:
   # The source image to use to create the new image from. source_image = `distribution`-`distribution_version-k8sversion-timestamp`
   distribution: "ubuntu"
-  distribution_version: "1804-bionic-v20220505"
-  source_image: "ubuntu-1804-bionic-v20220505"
+  distribution_version: "1804-bionic-v20230605"
+  source_image: "ubuntu-1804-bionic-v20230605"
   # The source_image_family to use to create the new image from.
   distribution_family: "ubuntu-1804-lts"
   # The username to connect to SSH with. Required if using SSH.

--- a/images/gcp/ubuntu-2004.yaml
+++ b/images/gcp/ubuntu-2004.yaml
@@ -4,8 +4,8 @@ download_images: true
 packer:
   # The source image to use to create the new image from. source_image = `distribution`-`distribution_version-k8sversion-timestamp`
   distribution: "ubuntu"
-  distribution_version: "2004-focal-v20220419"
-  source_image: "ubuntu-2004-focal-v20220419"
+  distribution_version: "2004-focal-v20231213"
+  source_image: "ubuntu-2004-focal-v20231213"
   # The source_image_family to use to create the new image from.
   distribution_family: "ubuntu-2004-lts"
   # The username to connect to SSH with. Required if using SSH.


### PR DESCRIPTION
**What problem does this PR solve?**:
The system package include a Python interpreter compatible with gcloud.

Ubuntu 18.04 ships a Python interpreter that is not supported by gcloud v448 and newer.

Backport of #967 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
