### PR TITLE
[release-2.5] fix: downgrade vsphere version

### DIFF
--- a/test/infra/vsphere/main.tf
+++ b/test/infra/vsphere/main.tf
@@ -1,3 +1,13 @@
+// FIXME: https://d2iq.atlassian.net/browse/D2IQ-99451
+terraform {
+  required_providers {
+    vsphere = {
+      source  = "hashicorp/vsphere"
+      version = "~> 2.4.0"
+    }
+  }
+}
+
 resource "random_id" "build_id" {
   byte_length = 8
 }


### PR DESCRIPTION
**What problem does this PR solve?**:
I wanted to use new vSphere templates but the [v2.5.3 build failed](https://github.com/mesosphere/konvoy-image-builder/actions/runs/6673475549)

Backport of https://github.com/mesosphere/konvoy-image-builder/pull/928
See vSphere build working https://github.com/mesosphere/konvoy-image-builder/actions/runs/7331572962

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
