### PR TITLE
fix: wrong vsphere config assignment - backport 2.5

### DIFF
--- a/cmd/konvoy-image/cmd/vsphere.go
+++ b/cmd/konvoy-image/cmd/vsphere.go
@@ -123,14 +123,14 @@ func addVSphereArgs(fs *flag.FlagSet, vsphereArgs *app.VSphereArgs) {
 	)
 
 	fs.StringVar(
-		&vsphereArgs.ResourcePool,
+		&vsphereArgs.SSHPrivateKeyFile,
 		"ssh-privatekey-file",
 		"",
 		"Path to ssh private key which will be used to log into the base image template",
 	)
 
 	fs.StringVar(
-		&vsphereArgs.ResourcePool,
+		&vsphereArgs.SSHPublicKey,
 		"ssh-publickey",
 		"",
 		//nolint:lll // a long help line


### PR DESCRIPTION
Backport of #980 

**What problem does this PR solve?**:
When introducing the vsphere subcommand an copy+paste error for two settings arguments where made.
`ssh-privatekey-file` and `ssh-publickey` to override `resource-pool` instead to assign their config value.

This PR fixes this problem.

Backport PRs will follow up

**Which issue(s) does this PR fix?**:
* https://d2iq.atlassian.net/browse/D2IQ-99862


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note
fix: wrong assignment of vsphere arguments `ssh-publickey` and `ssh-privatekey-file` will override resource pool.
```
