### PR TITLE
build: bump critools to 1.28

### DIFF
--- a/.github/workflows/vsphere-e2e.yaml
+++ b/.github/workflows/vsphere-e2e.yaml
@@ -67,7 +67,7 @@ jobs:
           password: ${{ secrets.NEXUS_PASSWORD }}
 
       - name: Setup buildkit
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Setup SSH agent with private key to connect with pre-configured bastion host
         uses: webfactory/ssh-agent@v0.8.0

--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -20,7 +20,7 @@ crictl_version: "1.28.0"
 # The url points to the linux/amd64 release artifact.
 crictl_url: https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{ crictl_version }}/crictl-v{{ crictl_version }}-linux-amd64.tar.gz
 # The sha256 sum verifies the integrity of the release artifact.
-crictl_sha256: cda5e2143bf19f6b548110ffba0fe3565e03e8743fadd625fee3d62fc4134eed
+crictl_sha256: 8dc78774f7cbeaf787994d386eec663f0a3cf24de1ea4893598096cb39ef2508
 
 
 # The critools deb and rpm package versions. While the version derives directly from

--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -45,7 +45,7 @@ package_versions:
   enable_repository_installation: "{{ (spec.osPackages.enableAdditionalRepositories if spec.osPackages is defined else true)|default(true)|bool }}"
   # the version may contain d2iq specific suffix, remove it when downloading packages
   kubernetes_rpm: "{{ kubernetes_version }}-0"
-  kubernetes_deb: "{{ kubernetes_version }}-00"
+  kubernetes_deb: "{{ kubernetes_version }}-1.1"
   kubenode: "{{ kubernetes_version }}"
 
 # variable used for seeding images

--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -14,7 +14,7 @@ kubernetes_cni_version: "0.9.1"
 # The project release closely follows the Kubernetes release cycle, and uses a
 # nearly identical version scheme.
 # IMPORTANT When you update crictl_version, also update crictl_sha256.
-crictl_version: "1.26.0"
+crictl_version: "1.28.0"
 
 # On flatcar Linux, we install crictl from a release artifact, not a system package.
 # The url points to the linux/amd64 release artifact.
@@ -26,7 +26,7 @@ crictl_sha256: cda5e2143bf19f6b548110ffba0fe3565e03e8743fadd625fee3d62fc4134eed
 # The critools deb and rpm package versions. While the version derives directly from
 # the crictl verson, the package revision can change independently.
 # The initial revision is 00.
-critools_deb: "{{ crictl_version }}-00"
+critools_deb: "{{ crictl_version }}-1.1"
 # The initial revision 0.
 critools_rpm: "{{ crictl_version }}-0"
 

--- a/test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl
+++ b/test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl
@@ -16,3 +16,4 @@ packer:
   network: "Airgapped"
   resource_pool: "Users"
   ssh_username: "kib"
+  linked_clone: "false"


### PR DESCRIPTION
**What problem does this PR solve?**:
bump critools to k8s 1.28

Fix E2E Test errors from #985 

**Which issue(s) does this PR fix?**:
https://jira.d2iq.com/browse/D2IQ-99586

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
