### PR TITLE
feat: use 1.28.6 k8s version 

### DIFF
--- a/ansible/roles/config/templates/config.toml.tmpl
+++ b/ansible/roles/config/templates/config.toml.tmpl
@@ -105,9 +105,6 @@ imports = ["/etc/containerd/conf.d/*.toml"]
         [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ registry }}"]
           endpoint = ["{{ mirror }}"{{ ',"https://registry-1.docker.io"' if registry == 'docker.io' else ''}}]
 {% endfor %}
-{% else %}
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-          endpoint = ["https://registry-1.docker.io"]
 {% endif %}
 {% if image_registries_with_auth is defined and image_registries_with_auth is not none and image_registries_with_auth | list | length >0 %}
       [plugins."io.containerd.grpc.v1.cri".registry.configs]


### PR DESCRIPTION
**What problem does this PR solve?**:
Bumping the version to pick up the latest k8s version and to bump `ghcr.io/mesosphere/dynamic-credential-provider:v0.5.0`.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://d2iq.atlassian.net/browse/D2IQ-99578


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
