### PR TITLE
chore: E2E tooling fixes.

### DIFF
--- a/.github/workflows/aws-e2e.yaml
+++ b/.github/workflows/aws-e2e.yaml
@@ -141,7 +141,7 @@ jobs:
           password: ${{ secrets.NEXUS_PASSWORD }}
 
       - name: Setup buildkit
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/azure-e2e.yaml
+++ b/.github/workflows/azure-e2e.yaml
@@ -50,7 +50,7 @@ jobs:
           password: ${{ secrets.NEXUS_PASSWORD }}
 
       - name: Setup buildkit
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Run E2E test for ${{ matrix.os }} with ${{ matrix.buildConfig }} configuration
         uses: magefile/mage-action@v3

--- a/.github/workflows/build-devkit-image.yaml
+++ b/.github/workflows/build-devkit-image.yaml
@@ -48,7 +48,7 @@ jobs:
           password: ${{ secrets.NEXUS_PASSWORD }}
 
       - name: Setup buildkit
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and Push multi arch devkit image
         run: make devkit-image-push-manifest

--- a/.github/workflows/gcp-e2e.yaml
+++ b/.github/workflows/gcp-e2e.yaml
@@ -51,7 +51,7 @@ jobs:
           password: ${{ secrets.NEXUS_PASSWORD }}
 
       - name: Setup buildkit
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Setup GOOGLE_APPLICATION_CREDENTIALS
         run: |-

--- a/.github/workflows/podman-aws-e2e.yaml
+++ b/.github/workflows/podman-aws-e2e.yaml
@@ -39,7 +39,7 @@ jobs:
           password: ${{ secrets.NEXUS_PASSWORD }}
 
       - name: Setup buildkit
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/release-ami.yaml
+++ b/.github/workflows/release-ami.yaml
@@ -81,7 +81,7 @@ jobs:
           password: ${{ secrets.NEXUS_PASSWORD }}
 
       - name: Setup buildkit
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/release-azure.yaml
+++ b/.github/workflows/release-azure.yaml
@@ -52,7 +52,7 @@ jobs:
           password: ${{ secrets.NEXUS_PASSWORD }}
 
       - name: Setup buildkit
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build Image ${{ matrix.os }} with ${{ matrix.buildConfig }} for Azure
         uses: magefile/mage-action@v3

--- a/.github/workflows/release-gcp-template.yaml
+++ b/.github/workflows/release-gcp-template.yaml
@@ -50,7 +50,7 @@ jobs:
           password: ${{ secrets.NEXUS_PASSWORD }}
 
       - name: Setup buildkit
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Setup GOOGLE_APPLICATION_CREDENTIALS
         run: |-

--- a/.github/workflows/release-kib.yaml
+++ b/.github/workflows/release-kib.yaml
@@ -38,7 +38,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASS }}
 
       - name: Setup buildkit
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Release
         run: make release

--- a/.github/workflows/release-vsphere-template.yaml
+++ b/.github/workflows/release-vsphere-template.yaml
@@ -58,7 +58,7 @@ jobs:
           password: ${{ secrets.NEXUS_PASSWORD }}
 
       - name: Setup buildkit
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Setup SSH agent with private key to connect with pre-configured bastion host
         uses: webfactory/ssh-agent@v0.8.0

--- a/.github/workflows/vsphere-e2e.yaml
+++ b/.github/workflows/vsphere-e2e.yaml
@@ -67,7 +67,7 @@ jobs:
           password: ${{ secrets.NEXUS_PASSWORD }}
 
       - name: Setup buildkit
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Setup SSH agent with private key to connect with pre-configured bastion host
         uses: webfactory/ssh-agent@v0.8.0

--- a/test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl
+++ b/test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl
@@ -16,3 +16,4 @@ packer:
   network: "Airgapped"
   resource_pool: "Users"
   ssh_username: "kib"
+  linked_clone: "false"


### PR DESCRIPTION
**What problem does this PR solve?**:
- Fix flaky issues with `docker buildx` not coming up, we're bumping the GHA version here.
- Remove `linked_clone` from VSphere tests, this causes the  Ubuntu images to fail. Discussion threads [here](https://nutanix.slack.com/archives/C069QMDB2QM/p1706462776451489), and [here](https://nutanix.slack.com/archives/C069QMDB2QM/p1706546883620639).

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
- https://d2iq.atlassian.net/browse/D2IQ-99908

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
