### PR TITLE
fix: Update k8s debian package repositories to pkgs.k8s.io, bumps critools to 1.28 

### DIFF
--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -18,19 +18,19 @@ kubernetes_cni_version: "0.9.1"
 # The project release closely follows the Kubernetes release cycle, and uses a
 # nearly identical version scheme.
 # IMPORTANT When you update crictl_version, also update crictl_sha256.
-crictl_version: "1.26.0"
+crictl_version: "{{ kubernetes_major }}.{{ kubernetes_minor }}.0"
 
 # On flatcar Linux, we install crictl from a release artifact, not a system package.
 # The url points to the linux/amd64 release artifact.
 crictl_url: https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{ crictl_version }}/crictl-v{{ crictl_version }}-linux-amd64.tar.gz
 # The sha256 sum verifies the integrity of the release artifact.
-crictl_sha256: cda5e2143bf19f6b548110ffba0fe3565e03e8743fadd625fee3d62fc4134eed
+crictl_sha256: 8dc78774f7cbeaf787994d386eec663f0a3cf24de1ea4893598096cb39ef2508
 
 
 # The critools deb and rpm package versions. While the version derives directly from
 # the crictl verson, the package revision can change independently.
 # The initial revision is 00.
-critools_deb: "{{ crictl_version }}-00"
+critools_deb: "{{ crictl_version }}-1.1"
 # The initial revision 0.
 critools_rpm: "{{ crictl_version }}-0"
 

--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -17,7 +17,7 @@ kubernetes_cni_version: "0.9.1"
 # The project release closely follows the Kubernetes release cycle, and uses a
 # nearly identical version scheme.
 # IMPORTANT When you update crictl_version, also update crictl_sha256.
-crictl_version: "{{ kubernetes_major }}.{{ kubernetes_minor }}.0"
+crictl_version: "{{ (kubernetes_version.split('.') | map('trim'))[:2] | join('.') }}.0"
 
 # On flatcar Linux, we install crictl from a release artifact, not a system package.
 # The url points to the linux/amd64 release artifact.

--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -5,10 +5,8 @@ python_path: ""
 # If it's not there, the kubernetes_full_version will have "None" for a version number.
 #
 # IMPORTANT When you update kubernetes_version, also update crictl_version.
-kubernetes_major: "1"
-kubernetes_minor: "28"
-kubernetes_patch: "6"
 kubernetes_version: "1.28.6"
+kubernetes_major_minor: "{{ (kubernetes_version.split('.') | map('trim'))[:2] | join('.') }}"
 kubernetes_semver: "v{{ kubernetes_version }}"
 
 kubernetes_cni_version: "0.9.1"
@@ -17,7 +15,7 @@ kubernetes_cni_version: "0.9.1"
 # The project release closely follows the Kubernetes release cycle, and uses a
 # nearly identical version scheme.
 # IMPORTANT When you update crictl_version, also update crictl_sha256.
-crictl_version: "{{ (kubernetes_version.split('.') | map('trim'))[:2] | join('.') }}.0"
+crictl_version: "{{ kubernetes_major_minor }}.0"
 
 # On flatcar Linux, we install crictl from a release artifact, not a system package.
 # The url points to the linux/amd64 release artifact.

--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -5,7 +5,11 @@ python_path: ""
 # If it's not there, the kubernetes_full_version will have "None" for a version number.
 #
 # IMPORTANT When you update kubernetes_version, also update crictl_version.
-kubernetes_version: "1.28.5"
+# Using kubernetes v1.28.5, this comment has been added to appear in version searches.
+kubernetes_major: "1"
+kubernetes_minor: "28"
+kubernetes_patch: "5"
+kubernetes_version: "{{ kubernetes_major }}.{{ kubernetes_minor }}.{{ kubernetes_patch }}"
 kubernetes_semver: "v{{ kubernetes_version }}"
 
 kubernetes_cni_version: "0.9.1"

--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -5,11 +5,10 @@ python_path: ""
 # If it's not there, the kubernetes_full_version will have "None" for a version number.
 #
 # IMPORTANT When you update kubernetes_version, also update crictl_version.
-# Using kubernetes v1.28.5, this comment has been added to appear in version searches.
 kubernetes_major: "1"
 kubernetes_minor: "28"
 kubernetes_patch: "5"
-kubernetes_version: "{{ kubernetes_major }}.{{ kubernetes_minor }}.{{ kubernetes_patch }}"
+kubernetes_version: "1.28.5"
 kubernetes_semver: "v{{ kubernetes_version }}"
 
 kubernetes_cni_version: "0.9.1"

--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -7,8 +7,8 @@ python_path: ""
 # IMPORTANT When you update kubernetes_version, also update crictl_version.
 kubernetes_major: "1"
 kubernetes_minor: "28"
-kubernetes_patch: "5"
-kubernetes_version: "1.28.5"
+kubernetes_patch: "6"
+kubernetes_version: "1.28.6"
 kubernetes_semver: "v{{ kubernetes_version }}"
 
 kubernetes_cni_version: "0.9.1"

--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -49,7 +49,7 @@ package_versions:
   enable_repository_installation: "{{ (spec.osPackages.enableAdditionalRepositories if spec.osPackages is defined else true)|default(true)|bool }}"
   # the version may contain d2iq specific suffix, remove it when downloading packages
   kubernetes_rpm: "{{ kubernetes_version }}-0"
-  kubernetes_deb: "{{ kubernetes_version }}-00"
+  kubernetes_deb: "{{ kubernetes_version }}-1.1"
   kubenode: "{{ kubernetes_version }}"
 
 # variable used for seeding images

--- a/ansible/group_vars/all/system.yaml
+++ b/ansible/group_vars/all/system.yaml
@@ -7,9 +7,9 @@ kubernetes_rpm_repository_url: "https://packages.d2iq.com/konvoy/stable/linux/re
 kubernetes_rpm_gpg_key_url: "https://packages.d2iq.com/konvoy/stable/linux/repos/d2iq-sign-authority-gpg-public-key"
 
 ## Debian
-kubernetes_deb_repository_url: "https://packages.cloud.google.com/apt/"
-kubernetes_deb_gpg_key_url: "https://packages.cloud.google.com/apt/doc/apt-key.gpg"
-kubernetes_deb_release_name: "kubernetes-xenial"
+kubernetes_deb_repository_url: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_major }}.{{ kubernetes_minor }}/deb/"
+kubernetes_deb_gpg_key_url: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_major }}.{{ kubernetes_minor }}/deb/Release.key"
+kubernetes_deb_release_name: "/"
 
 # containerd package
 # Appstream is enabled by default in rhel8, so install the package from local repositories in that case

--- a/ansible/group_vars/all/system.yaml
+++ b/ansible/group_vars/all/system.yaml
@@ -7,8 +7,8 @@ kubernetes_rpm_repository_url: "https://packages.d2iq.com/konvoy/stable/linux/re
 kubernetes_rpm_gpg_key_url: "https://packages.d2iq.com/konvoy/stable/linux/repos/d2iq-sign-authority-gpg-public-key"
 
 ## Debian
-kubernetes_deb_repository_url: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_major }}.{{ kubernetes_minor }}/deb/"
-kubernetes_deb_gpg_key_url: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_major }}.{{ kubernetes_minor }}/deb/Release.key"
+kubernetes_deb_repository_url: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_major_minor }}/deb/"
+kubernetes_deb_gpg_key_url: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_major_minor }}/deb/Release.key"
 kubernetes_deb_release_name: "/"
 
 # containerd package

--- a/ansible/roles/repo/tasks/debian.yaml
+++ b/ansible/roles/repo/tasks/debian.yaml
@@ -11,6 +11,6 @@
 
   - name: add Kubernetes deb repository
     apt_repository:
-      repo: 'deb {{ kubernetes_deb_repository_url }} {{ kubernetes_deb_release_name }} main'
+      repo: 'deb {{ kubernetes_deb_repository_url }} {{ kubernetes_deb_release_name }}'
     retries: 3
     delay: 3

--- a/images/common.yaml
+++ b/images/common.yaml
@@ -1,5 +1,5 @@
 ---
-kubernetes_version: "1.28.5"
+kubernetes_version: "1.28.6"
 
 download_images: true
 


### PR DESCRIPTION
**What problem does this PR solve?**:

- Update debian package repositories to use `pkgs.k8s.io`
- Bump critools to v1.28

**Which issue(s) does this PR fix?**:

- https://jira.d2iq.com/browse/D2IQ-99586
- https://jira.d2iq.com/browse/D2IQ-99953

**Special notes for your reviewer**:
- There was an attempt to template `kubernetes_version` via 
`{{ kubernetes_major }}.{{ kubernetes_minor }}.{{ kubernetes_patch}}` but this fails many tests as the templated version is referenced by the Magefile [here](https://github.com/mesosphere/konvoy-image-builder/blob/8773728fb51a83c985d3d1a6e4fbdbb666c1bf88/magefile.go#L375).

<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
