### PR TITLE
feat: bump Containerd to 1.6.28

### DIFF
--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -32,7 +32,7 @@ critools_deb: "{{ crictl_version }}-1.1"
 critools_rpm: "{{ crictl_version }}-0"
 
 # Containerd container runtime version.
-containerd_version: "1.6.24"
+containerd_version: "1.6.28"
 
 # NOTE(jkoelker) `nvidia_cuda_version` is set via an override, it is listed
 #                empty here for documentation.


### PR DESCRIPTION
**What problem does this PR solve?**:

Update contained version to 1.6.28. This resolves CVE-2024-21626. 

**Which issue(s) does this PR fix?**:

https://d2iq.atlassian.net/browse/D2IQ-99943


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
