### PR TITLE
[release-2.5] [backport] fix: Update k8s debian package repositories to pkgs.k8s.io

### DIFF
--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -6,6 +6,7 @@ python_path: ""
 #
 # IMPORTANT When you update kubernetes_version, also update crictl_version.
 kubernetes_version: "1.26.6"
+kubernetes_major_minor: "{{ (kubernetes_version.split('.') | map('trim'))[:2] | join('.') }}"
 kubernetes_semver: "v{{ kubernetes_version }}"
 
 kubernetes_cni_version: "0.9.1"
@@ -14,19 +15,20 @@ kubernetes_cni_version: "0.9.1"
 # The project release closely follows the Kubernetes release cycle, and uses a
 # nearly identical version scheme.
 # IMPORTANT When you update crictl_version, also update crictl_sha256.
-crictl_version: "1.26.0"
+crictl_version: "{{ kubernetes_major_minor }}.0"
 
 # On flatcar Linux, we install crictl from a release artifact, not a system package.
 # The url points to the linux/amd64 release artifact.
 crictl_url: https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{ crictl_version }}/crictl-v{{ crictl_version }}-linux-amd64.tar.gz
-# The sha256 sum verifies the integrity of the release artifact.
+# The sha256 sum verifies the integrity of the release artifact. Obtained from a
+# table in the release notes, https://github.com/kubernetes-sigs/cri-tools/releases/tag/<crictl_version>
 crictl_sha256: cda5e2143bf19f6b548110ffba0fe3565e03e8743fadd625fee3d62fc4134eed
 
 
 # The critools deb and rpm package versions. While the version derives directly from
 # the crictl verson, the package revision can change independently.
 # The initial revision is 00.
-critools_deb: "{{ crictl_version }}-00"
+critools_deb: "{{ crictl_version }}-1.1"
 # The initial revision 0.
 critools_rpm: "{{ crictl_version }}-0"
 
@@ -45,7 +47,7 @@ package_versions:
   enable_repository_installation: "{{ (spec.osPackages.enableAdditionalRepositories if spec.osPackages is defined else true)|default(true)|bool }}"
   # the version may contain d2iq specific suffix, remove it when downloading packages
   kubernetes_rpm: "{{ kubernetes_version }}-0"
-  kubernetes_deb: "{{ kubernetes_version }}-00"
+  kubernetes_deb: "{{ kubernetes_version }}-1.1"
   kubenode: "{{ kubernetes_version }}"
 
 # variable used for seeding images

--- a/ansible/group_vars/all/system.yaml
+++ b/ansible/group_vars/all/system.yaml
@@ -7,9 +7,9 @@ kubernetes_rpm_repository_url: "https://packages.d2iq.com/konvoy/stable/linux/re
 kubernetes_rpm_gpg_key_url: "https://packages.d2iq.com/konvoy/stable/linux/repos/d2iq-sign-authority-gpg-public-key"
 
 ## Debian
-kubernetes_deb_repository_url: "https://packages.cloud.google.com/apt/"
-kubernetes_deb_gpg_key_url: "https://packages.cloud.google.com/apt/doc/apt-key.gpg"
-kubernetes_deb_release_name: "kubernetes-xenial"
+kubernetes_deb_repository_url: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_major_minor }}/deb/"
+kubernetes_deb_gpg_key_url: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_major_minor }}/deb/Release.key"
+kubernetes_deb_release_name: "/"
 
 # containerd package
 # Appstream is enabled by default in rhel8, so install the package from local repositories in that case

--- a/ansible/roles/repo/tasks/debian.yaml
+++ b/ansible/roles/repo/tasks/debian.yaml
@@ -11,6 +11,6 @@
 
   - name: add Kubernetes deb repository
     apt_repository:
-      repo: 'deb {{ kubernetes_deb_repository_url }} {{ kubernetes_deb_release_name }} main'
+      repo: 'deb {{ kubernetes_deb_repository_url }} {{ kubernetes_deb_release_name }}'
     retries: 3
     delay: 3


### PR DESCRIPTION
**What problem does this PR solve?**:
Updates the package repositories and related metadata. Older repositories are deprecated, and packages for newer 1.26 patch versions are unavailable.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
