### PR TITLE
[release-2.5] [backport] fix: cython issue for flatcar

### DIFF
--- a/ansible/roles/providers/tasks/aws.yml
+++ b/ansible/roles/providers/tasks/aws.yml
@@ -19,11 +19,27 @@
   when:
     - ansible_os_family == "Debian"
 
+- name: install cython for flatcar
+  pip:
+    name: "cython<3.0.0"
+    executable: pip3
+    extra_args: "wheel"
+  when:
+    - ansible_distribution == "Flatcar"
+
+- name: install pyyaml
+  pip:
+    name: "pyyaml==5.4.1"
+    executable: pip3
+    extra_args: "--no-build-isolation"
+  when:
+    - ansible_distribution == "Flatcar"
+
 - name: install aws clients
   pip:
     name: "awscli"
     executable: pip3
-    extra_args: "{{ '--no-index --find-links=' + pip_packages_remote_filesystem_repo_path if offline_mode_enabled }}"
+    extra_args: "{{ '--no-cache-dir --no-index --find-links=' + pip_packages_remote_filesystem_repo_path if offline_mode_enabled }}"
   when:
     - ansible_distribution != "Amazon"
     - ansible_os_family != "Suse"

--- a/ansible/roles/providers/tasks/aws.yml
+++ b/ansible/roles/providers/tasks/aws.yml
@@ -19,19 +19,17 @@
   when:
     - ansible_os_family == "Debian"
 
+# solution from: https://stackoverflow.com/a/76721835
+# pinning awscli==1.29.9 fails
+# likely due to the pypy setup
 - name: install cython for flatcar
   pip:
-    name: "cython<3.0.0"
+    name: "{{ item.package }}"
     executable: pip3
-    extra_args: "wheel"
-  when:
-    - ansible_distribution == "Flatcar"
-
-- name: install pyyaml
-  pip:
-    name: "pyyaml==5.4.1"
-    executable: pip3
-    extra_args: "--no-build-isolation"
+    extra_args: "{{ item.extra }}"
+  with_items:
+    - { "package": "cython<3.0.0", "extra": "wheel" }
+    - { "package": "pyyaml==5.4.1", "extra": "--no-build-isolation" }
   when:
     - ansible_distribution == "Flatcar"
 


### PR DESCRIPTION
**What problem does this PR solve?**:
Backport of #866 

Flatcar image fails to build in release-2.5. For example, https://github.com/mesosphere/konvoy-image-builder/actions/runs/7980485399/job/21871361341?pr=1011#step:9:2493

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
