### PR TITLE
fix: minor changes to support CRE

### DIFF
--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -59,7 +59,7 @@ aws_images: []
 
 extra_images: []
 
-containerd_supplementary_images: ["ghcr.io/mesosphere/toml-merge:v0.2.0", "ghcr.io/mesosphere/dynamic-credential-provider:v0.2.0"]
+containerd_supplementary_images: ["ghcr.io/mesosphere/toml-merge:v0.2.0", "ghcr.io/mesosphere/dynamic-credential-provider:v0.2.0", "ghcr.io/mesosphere/dynamic-credential-provider:v0.5.0"]
 
 containerd_base_url: https://packages.d2iq.com/dkp/containerd
 docker_base_url: https://download.docker.com/linux/static/stable

--- a/ansible/roles/config/templates/config.toml.tmpl
+++ b/ansible/roles/config/templates/config.toml.tmpl
@@ -105,9 +105,6 @@ imports = ["/etc/containerd/conf.d/*.toml"]
         [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ registry }}"]
           endpoint = ["{{ mirror }}"{{ ',"https://registry-1.docker.io"' if registry == 'docker.io' else ''}}]
 {% endfor %}
-{% else %}
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-          endpoint = ["https://registry-1.docker.io"]
 {% endif %}
 {% if image_registries_with_auth is defined and image_registries_with_auth is not none and image_registries_with_auth | list | length >0 %}
       [plugins."io.containerd.grpc.v1.cri".registry.configs]


### PR DESCRIPTION
**What problem does this PR solve?**:
Changes to support provisioning clusters with https://github.com/d2iq-labs/capi-runtime-extensions

1. Loads image `"ghcr.io/mesosphere/dynamic-credential-provider:v0.5.0"` into Containerd. The supported Kubelet APIs changed between `v0.2.0` and `v0.5.0`, and to avoid doing a migration during upgrades just loading both images here.
2. Removing the `docker.io` mirror. This configuration is no longer needed and has been removed from upstream image-builder.
```
Feb 27 05:07:07 ip-10-0-128-224.us-west-2.compute.internal containerd[1624]: time="2024-02-27T05:07:07.812061161Z" level=warning msg="failed to load plugin io.containerd.grpc.v1.cri" error="invalid plugin config: `mirrors` cannot be set when `config_path` is provided"
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-99839)
-->
* https://d2iq.atlassian.net/browse/D2IQ-99839


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
I thought that this was already merged as part of v2.9.0, but looks like I never actually opened the PR.

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
