### PR TITLE
ci: set RHSM envs when building vSphere templates

### DIFF
--- a/.github/workflows/release-vsphere-template.yaml
+++ b/.github/workflows/release-vsphere-template.yaml
@@ -85,6 +85,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.MESOSPHERECI_USER_TOKEN }}
           VSPHERE_SERVER: ${{ secrets.VSPHERE_SERVER }}
           VSPHERE_DATASTORE: ${{ secrets.VSPHERE_DATASTORE }}
+          RHSM_USER: ${{ secrets.RHSM_USER }}
+          RHSM_PASS: ${{ secrets.RHSM_PASS }}
 
       - name: Run make destroy to clean up failed tests
         if: ${{ always() }}

--- a/.github/workflows/vsphere-e2e.yaml
+++ b/.github/workflows/vsphere-e2e.yaml
@@ -95,7 +95,9 @@ jobs:
           VSPHERE_SERVER: ${{ secrets.VSPHERE_SERVER }}
           VSPHERE_DATASTORE: ${{ secrets.VSPHERE_DATASTORE }}
           VSPHERE_DATACENTER: ${{ secrets.VSPHERE_DATACENTER }}
-        
+          RHSM_USER: ${{ secrets.RHSM_USER }}
+          RHSM_PASS: ${{ secrets.RHSM_PASS }}
+
       - name: Run make destroy to clean up failed tests
         if: ${{ always() }}
         run: make infra.vsphere.destroy || true


### PR DESCRIPTION
**What problem does this PR solve?**:
Saw a failure with v2.9.4 vSphere [release build job](https://github.com/mesosphere/konvoy-image-builder/actions/runs/8192924748/job/22536461146#step:10:1620)

```
Error: failed to fetch airgap artifacts: failed to fetch OS bundle running "bin/konvoy-image-wrapper create-package-bundle --os=redhat-8.4 --output-directory=artifacts" failed with exit code 1
```

Here is a test run with this fix https://github.com/mesosphere/konvoy-image-builder/actions/runs/8240881511/job/22537114860, its still failing but for a different reason (will have a follow up PR)

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
