### PR TITLE
fix: include python2-pip package for RHEL

### DIFF
--- a/bundles/redhat8.4/packages.txt.gotmpl
+++ b/bundles/redhat8.4/packages.txt.gotmpl
@@ -4,6 +4,7 @@ conntrack-tools
 chrony
 ebtables
 open-vm-tools
+python2-pip
 python3-pip
 python3-netifaces
 socat

--- a/bundles/redhat8.6/packages.txt.gotmpl
+++ b/bundles/redhat8.6/packages.txt.gotmpl
@@ -4,6 +4,7 @@ conntrack-tools
 chrony
 ebtables
 open-vm-tools
+python2-pip
 python3-pip
 socat
 sysstat

--- a/bundles/redhat8.8/packages.txt.gotmpl
+++ b/bundles/redhat8.8/packages.txt.gotmpl
@@ -4,6 +4,7 @@ conntrack-tools
 chrony
 ebtables
 open-vm-tools
+python2-pip
 python3-pip
 socat
 sysstat

--- a/bundles/rocky9.1/packages.txt.gotmpl
+++ b/bundles/rocky9.1/packages.txt.gotmpl
@@ -5,6 +5,7 @@ chrony
 ebtables
 open-vm-tools
 python3-pip
+python-unversioned-command
 socat
 sysstat
 yum-utils


### PR DESCRIPTION
**What problem does this PR solve?**:
These packages may be needed for vSphere templates

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-100208)
-->
* https://d2iq.atlassian.net/browse/D2IQ-100208


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->

Running AWS tests to verify that including these packages doesn't break anything else, the vSphere tests passed in ~https://github.com/mesosphere/konvoy-image-builder/actions/runs/8241197843~ https://github.com/mesosphere/konvoy-image-builder/actions/runs/8250801214

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
