### PR TITLE
ci: set RHSM envs when building AWS AMIs

### DIFF
--- a/.github/workflows/release-ami.yaml
+++ b/.github/workflows/release-ami.yaml
@@ -96,3 +96,5 @@ jobs:
           args: runE2e "${{ matrix.os }}" "${{ matrix.buildConfig }}" aws false
         env:
           GITHUB_TOKEN: ${{ secrets.MESOSPHERECI_USER_TOKEN }}
+          RHSM_USER: ${{ secrets.RHSM_USER }}
+          RHSM_PASS: ${{ secrets.RHSM_PASS }}


### PR DESCRIPTION
**What problem does this PR solve?**:
Similar to https://github.com/mesosphere/konvoy-image-builder/pull/1041, but for AWS.

Builds working https://github.com/mesosphere/konvoy-image-builder/actions/runs/8253869136

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
