### PR TITLE
fix: adds an ubuntu release for kommander tests

### DIFF
--- a/.github/workflows/release-ami.yaml
+++ b/.github/workflows/release-ami.yaml
@@ -47,6 +47,8 @@ jobs:
             buildConfig: "basic"
           - os: "ubuntu 20.04"
             buildConfig: "nvidia"
+          - os: "ubuntu 20.04"
+            buildConfig: "basic"
           - os: "flatcar"
             buildConfig: "basic"
 


### PR DESCRIPTION
**What problem does this PR solve?**:
Fixes an issue with kommander-e2e tests which was previously using upstream AMIs but is no longer. This should unblock @mhrabovcin https://github.com/mesosphere/kommander-e2e/pull/973

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
