### PR TITLE
ci: adds expiration tag for e2e runs

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -160,6 +160,9 @@ func RunE2e(buildOS, buildConfig, buildInfra string, dryRun bool) error {
 	args = append(args, buildPath)
 	// skip creating image
 	if dryRun {
+		overrideFlagForCmd = append(
+			overrideFlagForCmd,
+			fmt.Sprintf("--overrides=%s/%s", overrideDirName, "runtags.yaml"))
 		args = append(args, dryRunFlag)
 	} else {
 		releaseOverrideFile, err := getReleaseOverride(buildConfig)

--- a/overrides/runtags.yaml
+++ b/overrides/runtags.yaml
@@ -1,0 +1,4 @@
+packer:
+  run_tags:
+    expiration: 2h
+    owner: konvoy-e2e


### PR DESCRIPTION
**What problem does this PR solve?**:

Adds an override to make sure there is an expiration for all ec2 instances spawned.


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
