### PR TITLE
fix: clean yum cache after adding repos 

### DIFF
--- a/ansible/roles/repo/tasks/redhat.yaml
+++ b/ansible/roles/repo/tasks/redhat.yaml
@@ -119,3 +119,6 @@
   until: konvoy_repo_installation_rpm is success
   retries: 5
   delay: 6
+
+- name: clean yum caches
+  shell: yum clean all

--- a/ansible/roles/repo/tasks/redhat.yaml
+++ b/ansible/roles/repo/tasks/redhat.yaml
@@ -122,3 +122,4 @@
 
 - name: clean yum caches
   shell: yum clean all
+  when: ansible_distribution_major_version == '7'


### PR DESCRIPTION
**What problem does this PR solve?**:
- Always clean yum cache after adding kubernetes repositories

Once we add a repo to the yum cache, we need to update the yum caches so that the packages from the repo can be downloaded.
when we install ansible packages we do use `update_cache: yes` option. https://docs.ansible.com/ansible/latest/collections/ansible/builtin/yum_module.html#parameter-update_cache
however it will clean the cache only if it is expired. So the new packages are not getting downloaded automatically even after ansible invokes update cache.
This PR forces yum to clean all yum caches including repo mirror list so that package list can be refreshed automatically. 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.nutanix.com/browse/NCN-100851
