### PR TITLE
chore: bump dynamic-credential-provider to v0.5.3

### DIFF
--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -59,7 +59,7 @@ aws_images: []
 
 extra_images: []
 
-containerd_supplementary_images: ["ghcr.io/mesosphere/toml-merge:v0.2.0", "ghcr.io/mesosphere/dynamic-credential-provider:v0.2.0", "ghcr.io/mesosphere/dynamic-credential-provider:v0.5.0"]
+containerd_supplementary_images: ["ghcr.io/mesosphere/toml-merge:v0.2.0", "ghcr.io/mesosphere/dynamic-credential-provider:v0.2.0", "ghcr.io/mesosphere/dynamic-credential-provider:v0.5.3"]
 
 containerd_base_url: https://packages.d2iq.com/dkp/containerd
 docker_base_url: https://download.docker.com/linux/static/stable


### PR DESCRIPTION
**What problem does this PR solve?**:
bumps dynamic credentials provider to v0.5.3

