### PR TITLE
fix: Enable unprivileged ports sysctl in containerd config

### DIFF
--- a/ansible/roles/config/templates/config.toml.tmpl
+++ b/ansible/roles/config/templates/config.toml.tmpl
@@ -71,6 +71,8 @@ imports = ["/etc/containerd/conf.d/*.toml"]
     restrict_oom_score_adj = false
     max_concurrent_downloads = 3
     disable_proc_mount = false
+    enable_unprivileged_ports = true
+    enable_unprivileged_icmp = true
     [plugins."io.containerd.grpc.v1.cri".containerd]
       snapshotter = "overlayfs"
       default_runtime_name = "runc"


### PR DESCRIPTION
**What problem does this PR solve?**:
Spotted this issue again when testing vSphere install/upgrade with Kubernetes v1.29.5.

Similar to https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pull/645, but solving it here to handle the more generic case of so it can be picked up during upgrades without needing to add complicated `preKubeadmCommands` update logic in Konvoy2.

This enabled pods to run as non-root and bind to privileged ports as long as they have the necessary capability, `CAP_NET_BIND_SERVICE` added.

This fixes an issue on AWS when bringing up coredns which binds to port 53 but runs as an unprivileged user.

Overall this is a net security improvement for clusters, meaning users can stop giving too many privileged to pods - see
kubernetes/kubernetes#102612 for discussion.


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (NCN-100169)
-->
* https://jira.nutanix.com/browse/NCN-100169


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
Ran the konvoy2 e2e test https://github.com/mesosphere/konvoy2/actions/runs/9370800641

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
