### PR TITLE
fix: Make image load compatible with podman 4.x

### DIFF
--- a/.github/workflows/podman-aws-e2e.yaml
+++ b/.github/workflows/podman-aws-e2e.yaml
@@ -58,9 +58,9 @@ jobs:
           make build-for-podman
           goreleaser build --config=.goreleaser-podman-e2e.yml --clean --skip-validate
 
-      - name: Run E2E test for AWS centos 7.9 using podman
+      - name: Run E2E test for AWS Rocky 9.1 using podman
         run: |-
-          KIB_CONTAINER_ENGINE=podman dist/konvoy-image-wrapper-for-podman_linux_amd64_v1/konvoy-image build aws images/ami/centos-79.yaml --dry-run
+          KIB_CONTAINER_ENGINE=podman dist/konvoy-image-wrapper-for-podman_linux_amd64_v1/konvoy-image build aws images/ami/rocky-91.yaml --dry-run
         env:
           GITHUB_TOKEN: ${{ secrets.MESOSPHERECI_USER_TOKEN }}
           KIB_CONTAINER_ENGINE: podman

--- a/.github/workflows/podman-aws-e2e.yaml
+++ b/.github/workflows/podman-aws-e2e.yaml
@@ -10,7 +10,10 @@ permissions:
 
 jobs:
   rune2e:
-    runs-on: ubuntu-22.04
+    # According to https://docs.d2iq.com/dkp/2.8/podman, podman >= 4.0.0 is required.
+    # The ubuntu-24.04 runner has podman 4.9.3 (as of https://github.com/actions/runner-images/pull/9828).
+    # The other ubuntu images have podman 3.x, so we cannot use them.
+    runs-on: ubuntu-24.04
     continue-on-error: false
     steps:
       - name: Checkout konvoy-image-builder repository

--- a/cmd/konvoy-image-wrapper/image/image.go
+++ b/cmd/konvoy-image-wrapper/image/image.go
@@ -32,15 +32,5 @@ func LoadImage(containerEngine string) error {
 	if err != nil {
 		return fmt.Errorf("failed to run cmd %s with error %w", cmd.Args, err)
 	}
-	if containerEngine != "podman" {
-		return nil
-	}
-	cmdTag := exec.Command(containerEngine, "tag", fmt.Sprintf("localhost/%s", image), fmt.Sprintf("docker.io/%s", image))
-	cmdTag.Stdout = os.Stdout
-	cmdTag.Stderr = os.Stderr
-	err = cmdTag.Run()
-	if err != nil {
-		return fmt.Errorf("failed to run cmd %s with error %w", cmd.Args, err)
-	}
 	return nil
 }


### PR DESCRIPTION
**What problem does this PR solve?**:
Remove workaround for podman 3.x image load behavior, because the workaround is incompatible with podman 4.x.

Also:
- Use Ubuntu 24.04 runner to run podman e2e test. This runner includes podman 4.x, which we require. 
- Use Rocky 9.1 to run podman e2e test. Previously, we used CentOS 7.9, but we cannot use it, because we dropped support for it recently (#1072), as it went EOL.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.nutanix.com/browse/NCN-101343


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
