### PR TITLE
fix: redhat 8.6 and redhat 8.8 gpu support 

### DIFF
--- a/bundles/redhat8.6/packages.txt.gotmpl
+++ b/bundles/redhat8.6/packages.txt.gotmpl
@@ -31,7 +31,7 @@ elfutils-libelf-devel
 libseccomp
 nfs-utils
 iproute-tc
-kernel-headers-4.18.0-372.93.1.el8_6
-kernel-devel-4.18.0-372.93.1.el8_6
+kernel-headers-4.18.0-372.103.1.el8_6
+kernel-devel-4.18.0-372.103.1.el8_6
 glibc-all-langpacks-2.28
 glibc-devel-2.28

--- a/bundles/redhat8.8/bundle.sh.gotmpl
+++ b/bundles/redhat8.8/bundle.sh.gotmpl
@@ -45,7 +45,6 @@ subscription::defer_unregister() {
 subscription-manager release --set=8.8
 subscription-manager refresh
 subscription::defer_unregister
-subscription-manager repos --enable rhel-8-for-x86_64-baseos-eus-rpms
 subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
 subscription-manager repos --enable rhel-8-for-x86_64-appstream-rpms
 yum -y install gettext yum-utils createrepo dnf-utils modulemd-tools
@@ -59,7 +58,7 @@ sed -i 1d reqs.txt # we need to get rid of the first line
 #shellcheck disable=SC2046
 yumdownloader --archlist=x86_64,noarch --setopt=skip_missing_names_on_install=False -x \*i686 $(< reqs.txt)
 #shellcheck disable=SC2046
-yumdownloader --setopt=skip_missing_names_on_install=False -x \*i686 --archlist=x86_64,noarch --resolve --disablerepo=*  --enablerepo=kubernetes,rhel-8-for-x86_64-baseos-eus-rpms,codeready-builder-for-rhel-8-x86_64-rpms,rhel-8-for-x86_64-appstream-rpms $(< packages.txt)
+yumdownloader --setopt=skip_missing_names_on_install=False -x \*i686 --archlist=x86_64,noarch --resolve --disablerepo=*  --enablerepo=kubernetes,codeready-builder-for-rhel-8-x86_64-rpms,rhel-8-for-x86_64-appstream-rpms $(< packages.txt)
 rm packages.txt reqs.txt
 curl https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm -o amazon-ssm-agent.rpm
 createrepo -v .

--- a/bundles/redhat8.8/packages.txt.gotmpl
+++ b/bundles/redhat8.8/packages.txt.gotmpl
@@ -26,6 +26,7 @@ iptables
 socat
 cri-tools
 gcc
+glibc-devel
 make
 libseccomp
 nfs-utils


### PR DESCRIPTION
**What problem does this PR solve?**:

Updates the default packages we publish for offline builds to be compatible with the latest images of RHEL 8.6 and RHEL 8.8 available from AWS.  It should be noted that a customer's base operating system can use a different base image, so these packages won't necessarily work in every scenario. They are specific to our testing.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
