### PR TITLE
fix: adds base os repo and kernel package

### DIFF
--- a/bundles/redhat8.8/bundle.sh.gotmpl
+++ b/bundles/redhat8.8/bundle.sh.gotmpl
@@ -48,6 +48,12 @@ subscription::defer_unregister
 subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
 subscription-manager repos --enable rhel-8-for-x86_64-appstream-rpms
 subscription-manager repos --enable rhel-8-for-x86_64-baseos-rpms
+
+# EUS rpms used to fetch kernel-headers for redhat 8.8
+# if you don't need kernel headers package for NVIDIA Gpu support, remove this line.
+# and remove kernel-headers-4.18.0-477.58.1.el8_8 from packages.txt.gotmpl
+subscription-manager repos --enable rhel-8-for-x86_64-baseos-eus-rpms
+
 yum -y install gettext yum-utils createrepo dnf-utils modulemd-tools
 yum clean all
 TMP_DIR="$(mktemp -d repodata-XXXX)"
@@ -57,9 +63,13 @@ pushd "${TMP_DIR}"
 repoquery --archlist=x86_64,noarch --resolve --requires --recursive  $(< packages.txt) | grep -v *.i686  >> reqs.txt
 sed -i 1d reqs.txt # we need to get rid of the first line
 #shellcheck disable=SC2046
-yumdownloader --archlist=x86_64,noarch --setopt=skip_missing_names_on_install=False -x \*i686 $(< reqs.txt)
+yumdownloader --archlist=x86_64,noarch \
+  --setopt=skip_missing_names_on_install=False -x \*i686 $(< reqs.txt)
 #shellcheck disable=SC2046
-yumdownloader --setopt=skip_missing_names_on_install=False -x \*i686 --archlist=x86_64,noarch --resolve --disablerepo=*  --enablerepo=kubernetes,codeready-builder-for-rhel-8-x86_64-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-rpms $(< packages.txt)
+yumdownloader --setopt=skip_missing_names_on_install=False -x \*i686 --archlist=x86_64,noarch \
+  --resolve --disablerepo=* --enablerepo="kubernetes,codeready-builder-for-rhel-8-x86_64-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-baseos-eus-rpms" \
+  $(< packages.txt)
+
 rm packages.txt reqs.txt
 curl https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm -o amazon-ssm-agent.rpm
 createrepo -v .

--- a/bundles/redhat8.8/bundle.sh.gotmpl
+++ b/bundles/redhat8.8/bundle.sh.gotmpl
@@ -47,6 +47,7 @@ subscription-manager refresh
 subscription::defer_unregister
 subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
 subscription-manager repos --enable rhel-8-for-x86_64-appstream-rpms
+subscription-manager repos --enable rhel-8-for-x86_64-baseos-rpms
 yum -y install gettext yum-utils createrepo dnf-utils modulemd-tools
 yum clean all
 TMP_DIR="$(mktemp -d repodata-XXXX)"
@@ -58,7 +59,7 @@ sed -i 1d reqs.txt # we need to get rid of the first line
 #shellcheck disable=SC2046
 yumdownloader --archlist=x86_64,noarch --setopt=skip_missing_names_on_install=False -x \*i686 $(< reqs.txt)
 #shellcheck disable=SC2046
-yumdownloader --setopt=skip_missing_names_on_install=False -x \*i686 --archlist=x86_64,noarch --resolve --disablerepo=*  --enablerepo=kubernetes,codeready-builder-for-rhel-8-x86_64-rpms,rhel-8-for-x86_64-appstream-rpms $(< packages.txt)
+yumdownloader --setopt=skip_missing_names_on_install=False -x \*i686 --archlist=x86_64,noarch --resolve --disablerepo=*  --enablerepo=kubernetes,codeready-builder-for-rhel-8-x86_64-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-rpms $(< packages.txt)
 rm packages.txt reqs.txt
 curl https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm -o amazon-ssm-agent.rpm
 createrepo -v .

--- a/bundles/redhat8.8/packages.txt.gotmpl
+++ b/bundles/redhat8.8/packages.txt.gotmpl
@@ -31,8 +31,8 @@ make
 libseccomp
 nfs-utils
 iproute-tc
-kernel-headers
-kernel-devel
+kernel-headers-4.18.0-477.58.1.el8_8
+kernel-devel-4.18.0-477.58.1.el8_8
 gssproxy
 libverto-module-base
 libverto


### PR DESCRIPTION
**What problem does this PR solve?**:
Adds baseos image repo. This is needed in rhel 8.8 for packages such as audit. We saw this error here on the last run https://github.com/mesosphere/konvoy-image-builder/actions/runs/9883918228/job/27299511067#step:9:1712

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
