### PR TITLE
ci: fetch kernel headers only for GPU tests

### DIFF
--- a/bundles/redhat8.6/packages.txt.gotmpl
+++ b/bundles/redhat8.6/packages.txt.gotmpl
@@ -31,7 +31,9 @@ elfutils-libelf-devel
 libseccomp
 nfs-utils
 iproute-tc
-kernel-headers-4.18.0-372.103.1.el8_6
-kernel-devel-4.18.0-372.103.1.el8_6
 glibc-all-langpacks-2.28
 glibc-devel-2.28
+{{ if .FetchKernelHeaders -}}
+kernel-headers-4.18.0-372.103.1.el8_6
+kernel-devel-4.18.0-372.103.1.el8_6
+{{- end }}

--- a/bundles/redhat8.8/packages.txt.gotmpl
+++ b/bundles/redhat8.8/packages.txt.gotmpl
@@ -31,8 +31,10 @@ make
 libseccomp
 nfs-utils
 iproute-tc
-kernel-headers-4.18.0-477.58.1.el8_8
-kernel-devel-4.18.0-477.58.1.el8_8
 gssproxy
 libverto-module-base
 libverto
+{{ if .FetchKernelHeaders -}}
+kernel-headers-4.18.0-477.58.1.el8_8
+kernel-devel-4.18.0-477.58.1.el8_8
+{{- end }}

--- a/cmd/konvoy-image-wrapper/cmd/create-package-bundle.go
+++ b/cmd/konvoy-image-wrapper/cmd/create-package-bundle.go
@@ -82,6 +82,7 @@ func (r *Runner) CreatePackageBundle(args []string) error {
 		eusReposFlag          bool
 		outputDirectoy        string
 		containerImage        string
+		fetchKernelHeaders    bool
 	)
 	flagSet := flag.NewFlagSet(createPackageBundleCmd, flag.ExitOnError)
 	flagSet.StringVar(
@@ -108,9 +109,24 @@ func (r *Runner) CreatePackageBundle(args []string) error {
 		false,
 		"If enabled fetches packages from EUS repositories when creating RHEL package bundles. Disabled by default.",
 	)
-	flagSet.StringVar(&outputDirectoy, "output-directory", "artifacts",
-		"The directory to place the bundle in.")
-	flagSet.StringVar(&containerImage, "container-image", "", "A container image to use for building the package bundles")
+	flagSet.StringVar(
+		&outputDirectoy,
+		"output-directory",
+		"artifacts",
+		"The directory to place the bundle in.",
+	)
+	flagSet.StringVar(
+		&containerImage,
+		"container-image",
+		"",
+		"A container image to use for building the package bundles",
+	)
+	flagSet.BoolVar(
+		&fetchKernelHeaders,
+		"fetch-kernel-headers",
+		false,
+		"If enabled fetches kernel headers for the target operating system. To modify the verison, edit the file at bundles/{OS_NAME}{VERSION}/packages.txt.gotmpl directly eg: bundles/redhat8.8/packages.txt.gotmpl. This is required for operating systems that will use NVIDIA GPU drivers.",
+	)
 	err := flagSet.Parse(args)
 	if err != nil {
 		return err
@@ -141,7 +157,7 @@ func (r *Runner) CreatePackageBundle(args []string) error {
 		dir := r.workingDir
 		absPathToOutput = path.Join(dir, outputDirectoy)
 	}
-	reposList, err := templateObjects(osFlag, kubernetesVersion, absPathToOutput, fipsFlag)
+	reposList, err := templateObjects(osFlag, kubernetesVersion, absPathToOutput, fipsFlag, fetchKernelHeaders)
 	if err != nil {
 		return err
 	}
@@ -156,7 +172,7 @@ func (r *Runner) CreatePackageBundle(args []string) error {
 }
 
 //nolint:gocyclo,funlen // the function is relatively clear
-func templateObjects(targetOS, kubernetesVersion, outputDir string, fips bool) ([]string, error) {
+func templateObjects(targetOS, kubernetesVersion, outputDir string, fips, fetchKernelHeaders bool) ([]string, error) {
 	config, found := osToConfig[targetOS]
 	if !found {
 		return nil, fmt.Errorf("buildOS %s is invalid must be one of %v", targetOS, getKeys(osToConfig))
@@ -251,9 +267,11 @@ func templateObjects(targetOS, kubernetesVersion, outputDir string, fips bool) (
 				return fmt.Errorf("failed to create file: %w", err)
 			}
 			templateInput := struct {
-				KubernetesVersion string
+				KubernetesVersion  string
+				FetchKernelHeaders bool
 			}{
-				KubernetesVersion: kubernetesVersion,
+				KubernetesVersion:  kubernetesVersion,
+				FetchKernelHeaders: fetchKernelHeaders,
 			}
 			err = t.Execute(out, templateInput)
 			if err != nil {

--- a/cmd/konvoy-image-wrapper/cmd/create-package-bundle.go
+++ b/cmd/konvoy-image-wrapper/cmd/create-package-bundle.go
@@ -125,7 +125,8 @@ func (r *Runner) CreatePackageBundle(args []string) error {
 		&fetchKernelHeaders,
 		"fetch-kernel-headers",
 		false,
-		"If enabled fetches kernel headers for the target operating system. To modify the verison, edit the file at bundles/{OS_NAME}{VERSION}/packages.txt.gotmpl directly eg: bundles/redhat8.8/packages.txt.gotmpl. This is required for operating systems that will use NVIDIA GPU drivers.",
+		//nolint:lll // its ok to have long help texts
+		"If enabled fetches kernel headers for the target operating system. To modify the version, edit the file at bundles/{OS_NAME}{VERSION}/packages.txt.gotmpl directly eg: bundles/redhat8.8/packages.txt.gotmpl. This is required for operating systems that will use NVIDIA GPU drivers.",
 	)
 	err := flagSet.Parse(args)
 	if err != nil {


### PR DESCRIPTION
**What problem does this PR solve?**:
Adds a gate around fetching kernel headers with a note about where to modify the file in the help text of the flag. Also updates CI to use this new flag.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
