### PR TITLE
fix: set sysctl settings for fs.inotify 

### DIFF
--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -110,3 +110,7 @@ nvidia_runfile_installer_url: "https://download.nvidia.com/XFree86/Linux-x86_64/
 suse_packagehub_product: PackageHub/{{ ansible_distribution_version }}/{{ ansible_architecture }}
 
 pinned_debs: []
+
+sysctl_conf_file: >-
+  {{ '/etc/sysctl.d/99-sysctl.conf' if ansible_os_family in ['Common Base Linux Mariner', 'Flatcar', 'Microsoft Azure Linux', 'VMware Photon OS']
+    else '/etc/sysctl.conf' }}

--- a/ansible/roles/providers/tasks/misc.yml
+++ b/ansible/roles/providers/tasks/misc.yml
@@ -99,3 +99,15 @@
     packer_builder_type is search('vmware') or
     packer_builder_type is search('vsphere')) and
     ansible_os_family != "Flatcar"
+
+- name: Set and persist kernel params
+  ansible.posix.sysctl:
+    name: "{{ item.param }}"
+    value: "{{ item.val }}"
+    state: present
+    sysctl_set: true
+    sysctl_file: "{{ sysctl_conf_file }}"
+    reload: true
+  loop:
+    - { param: fs.inotify.max_user_instances, val: 8192 }
+    - { param: fs.inotify.max_user_watches, val: 524288 }


### PR DESCRIPTION
**What problem does this PR solve?**:
set sysctl settings for fs.inotify to same as upstream image builder

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (NCN-101967)
-->
*https://jira.nutanix.com/browse/NCN-101967


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
