### PR TITLE
chore: errexit vcd upload script on failure

### DIFF
--- a/test/infra/vcd/bastion.tf
+++ b/test/infra/vcd/bastion.tf
@@ -44,6 +44,7 @@ resource "null_resource" "copy_upload_template_script" {
 resource "null_resource" "execute_upload_template_script" {
   provisioner "remote-exec" {
     inline = [
+      "set -o errexit",
       "export PROD_VSPHERE_URL=${var.vsphere_url}",
       "export PROD_VSPHERE_USERNAME=${var.vsphere_username}",
       "export PROD_VSPHERE_PASSWORD=${var.vsphere_password}",
@@ -53,7 +54,6 @@ resource "null_resource" "execute_upload_template_script" {
       "export PROD_TEMPLATE_NAME=${var.vm_template_name_to_upload}",
       "export VCD_ORG=${var.vcd_org}",
       "export VCD_ORG_CATALOG=${var.vcd_org_catalog}",
-      "set -o errexit",
       "chmod +x /home/${var.ssh_user}/upload-template.sh",
       "/home/${var.ssh_user}/upload-template.sh | tee /home/${var.ssh_user}/upload-template.log"
     ]

--- a/test/infra/vcd/bastion.tf
+++ b/test/infra/vcd/bastion.tf
@@ -55,7 +55,7 @@ resource "null_resource" "execute_upload_template_script" {
       "export VCD_ORG=${var.vcd_org}",
       "export VCD_ORG_CATALOG=${var.vcd_org_catalog}",
       "chmod +x /home/${var.ssh_user}/upload-template.sh",
-      "/home/${var.ssh_user}/upload-template.sh | tee /home/${var.ssh_user}/upload-template.log"
+      "/home/${var.ssh_user}/upload-template.sh > /home/${var.ssh_user}/upload-template.log"
     ]
   }
   provisioner "remote-exec" {

--- a/test/infra/vcd/upload-template.sh
+++ b/test/infra/vcd/upload-template.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+exit 1
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 


### PR DESCRIPTION
**What problem does this PR solve?**:
The VCD script is not failing when upload fails.
https://github.com/mesosphere/konvoy-image-builder/actions/runs/10461957705/job/29011475217#step:7:5730
Terraform [remote-exec documentation](https://developer.hashicorp.com/terraform/language/resources/provisioners/remote-exec)

```
Note: Since inline is implemented by concatenating commands into a script, [on_failure]

(https://developer.hashicorp.com/terraform/language/resources/provisioners/syntax#failure-behavior) 
applies only to the final command in the list. 
In particular, with on_failure = fail (the default behaviour) earlier commands will be allowed to fail,
and later commands will also execute. If this behaviour is not desired, 
consider using "set -o errexit" as the first command.
```


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
