### PR TITLE
[release-2.9] fix: Wait for concurrent apt process to release lock

### DIFF
--- a/ansible/roles/packages/tasks/debian.yaml
+++ b/ansible/roles/packages/tasks/debian.yaml
@@ -4,19 +4,18 @@
     name: apt-transport-https
     state: latest
     update_cache: true
-  register: result
-  until: result is success
-  retries: 3
-  delay: 3
-
+  register: apt_lock_status
+  until: apt_lock_status is not failed
+  retries: 5
+  delay: 10
 
 - name: apt update package management cache
   apt:
     update_cache: true
-  register: result
-  until: result is success
-  retries: 3
-  delay: 3
+  register: apt_lock_status
+  until: apt_lock_status is not failed
+  retries: 5
+  delay: 10
 
 - name: install common debs
   apt:
@@ -26,10 +25,10 @@
       - python3-cryptography
       - python3-pip
     state: present
-  register: result
-  until: result is success
-  retries: 3
-  delay: 3
+  register: apt_lock_status
+  until: apt_lock_status is not failed
+  retries: 5
+  delay: 10
 
 - name: install pinned debs
   apt:
@@ -56,20 +55,20 @@
     name: kubelet={{ package_versions.kubernetes_deb }}
     state: present
     force: true
-  register: kubelet_installation_deb
-  until: kubelet_installation_deb is success
-  retries: 3
-  delay: 3
+  register: apt_lock_status
+  until: apt_lock_status is not failed
+  retries: 5
+  delay: 10
 
 - name: install kubectl deb package
   apt:
     name: kubectl={{ package_versions.kubernetes_deb }}
     state: present
     force: true
-  register: result
-  until: result is success
-  retries: 3
-  delay: 3
+  register: apt_lock_status
+  until: apt_lock_status is not failed
+  retries: 5
+  delay: 10
 
 - name: add version hold for kubelet and kubectl packages
   command: apt-mark hold {{ item }}

--- a/ansible/roles/sysprep/tasks/debian.yml
+++ b/ansible/roles/sysprep/tasks/debian.yml
@@ -57,6 +57,10 @@
     autoclean: true
     autoremove: true
     force_apt_get: true
+  register: apt_lock_status
+  until: apt_lock_status is not failed
+  retries: 5
+  delay: 10
 
 - name: Remove apt package lists
   file:


### PR DESCRIPTION
**What problem does this PR solve?**:
Backport of #1177

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
