### PR TITLE
feat: add Oracle Linux 9.4 vSphere build configuration

### DIFF
--- a/.github/workflows/release-vsphere-template.yaml
+++ b/.github/workflows/release-vsphere-template.yaml
@@ -27,6 +27,10 @@ jobs:
             buildConfig: "basic"
           - os: "rocky 9.1"
             buildConfig: "offline"
+          - os: "oracle 9.4"
+            buildConfig: "basic"
+          - os: "oracle 9.4"
+            buildConfig: "fips"
           - os: "flatcar"
             buildConfig: "basic"
     runs-on:

--- a/.github/workflows/vsphere-e2e.yaml
+++ b/.github/workflows/vsphere-e2e.yaml
@@ -31,6 +31,10 @@ jobs:
           buildConfig: "basic"
         - os: "rocky 9.1"
           buildConfig: "offline"
+        - os: "oracle 9.4"
+          buildConfig: "basic"
+        - os: "oracle 9.4"
+          buildConfig: "fips"
         - os: "flatcar"
           buildConfig: "basic"
     runs-on:

--- a/images/ova/oracle-94.yaml
+++ b/images/ova/oracle-94.yaml
@@ -1,0 +1,25 @@
+---
+build_name: "oracle-94"
+packer_builder_type: "vsphere" 
+guestinfo_datasource_slug: "https://raw.githubusercontent.com/vmware/cloud-init-vmware-guestinfo"
+guestinfo_datasource_ref: "v1.4.0"
+guestinfo_datasource_script: "{{guestinfo_datasource_slug}}/{{guestinfo_datasource_ref}}/install.sh"
+packer:
+  cluster: ""
+  datacenter: ""
+  datastore: ""
+  folder: ""
+  insecure_connection: "false"
+  network: ""
+  resource_pool: ""
+  template: "d2iq-base-templates/d2iq-base-OracleLinux-94" # change default value with your base template name
+  vsphere_guest_os_type: "oracleLinux64Guest"
+  guest_os_type: "oraclelinux-64"
+  # goss params
+  distribution: "Oracle"
+  distribution_version: "9.4"
+# Use following overrides to select the authentication method that can be used with base template
+# ssh_username: ""  # can be exported as environment variable 'SSH_USERNAME'
+# ssh_password: "" # can be exported as environment variable 'SSH_PASSWORD'
+# ssh_private_key_file = "" # can be exported as environment variable 'SSH_PRIVATE_KEY_FILE'
+# ssh_agent_auth: false  # is set to true, ssh_password and ssh_private_key will be ignored

--- a/magefile.go
+++ b/magefile.go
@@ -47,6 +47,7 @@ var (
 		"redhat 8.8",
 		"sles 15",
 		"oracle 8.9",
+		"oracle 9.4",
 		"flatcar",
 		"ubuntu 18.04",
 		"ubuntu 20.04",
@@ -138,7 +139,7 @@ func RunE2e(buildOS, buildConfig, buildInfra string, dryRun bool) error {
 		}
 	}
 
-	if buildConfig == basic && buildInfra == ova {
+	if (buildConfig == basic || buildConfig == fips) && buildInfra == ova {
 		basicOverride := "packer-ova-basic-override.yaml"
 		basicOverrideFlag := fmt.Sprintf("--overrides=%s", basicOverride)
 		overrideFlagForCmd = append(overrideFlagForCmd, basicOverrideFlag)


### PR DESCRIPTION
**What problem does this PR solve?**:
This adds new configuration to build Oracle Linux 9.4 vSphere templates.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (NCN-102630)
-->
* https://jira.nutanix.com/browse/NCN-102630

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
✅ I built a template [here](https://github.com/mesosphere/konvoy-image-builder/actions/runs/11076002535) and then ran an install test [here](https://github.com/mesosphere/konvoy2/actions/runs/11076450767/job/30779936267#step:5:6702).
Will wait for a PR to support building the air-gapped bundle and then we can run the air-gapped tests there.

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
