### PR TITLE
fix: enable installing cri-tools rpm from upstream repo

### DIFF
--- a/ansible/roles/kubeadm/tasks/redhat.yaml
+++ b/ansible/roles/kubeadm/tasks/redhat.yaml
@@ -16,14 +16,22 @@
 
 
 - block:
+  - name: check cri-tools rpm exists locally at '/opt'
+    stat:
+      path: "/opt/{{ 'cri-tools-' + critools_rpm }}{{ '-fips' if fips.enabled else '' }}.rpm"
+    delegate_to: localhost
+    register: haslocalcritools
+    become: false
+
   - name: copy cri-tools rpm
     copy:
       src: "/opt/{{ 'cri-tools-' + critools_rpm }}{{ '-fips' if fips.enabled else '' }}.rpm"
       dest: "/opt/{{ 'cri-tools-' + critools_rpm }}.rpm"
+    when: haslocalcritools.stat.exists
 
   - name: install cri-tools rpm package
     yum:
-      name: "/opt/{{ 'cri-tools-' + critools_rpm }}.rpm"
+      name: "{{ '/opt/'  if haslocalcritools.stat.exists }}{{ 'cri-tools-' + critools_rpm }}{{'.rpm' if haslocalcritools.stat.exists }}"
       state: present
       update_cache: true
       enablerepo: "{{ 'offline' if offline_mode_enabled else '' }}"


### PR DESCRIPTION
**What problem does this PR solve?**:
- enable installing cri-tools from upstream repo.
currently it the cri-tools must be available in Docker image. Enable installing cri-tools for conditions where the cri-tools is not baked in the container image. 
