### PR TITLE
fix(release-2.9): remove using undefined flags in magefile

### DIFF
--- a/bundles/redhat8.4/repo-templates/centos.repo
+++ b/bundles/redhat8.4/repo-templates/centos.repo
@@ -1,8 +1,0 @@
-# this is used to fetch the repo2mod utility which is not availible through rhel repositories
-[appstream-centos]
-name=Centos $releasever - AppStream
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=x86_64&repo=AppStream
-enabled=1
-gpgcheck=1
-gpgkey=https://centos.org/keys/RPM-GPG-KEY-CentOS-Official
-priority=10

--- a/magefile.go
+++ b/magefile.go
@@ -412,12 +412,6 @@ func createOSBundle(osName, kubernetesVersion, downloadDir string, fips, gpu boo
 	if fips {
 		args = append(args, "--fips=true")
 	}
-	if osName == "redhat 8.8" || osName == "redhat 8.6" {
-		args = append(args, "--enable-eus-repos=true")
-	}
-	if gpu {
-		args = append(args, "--fetch-kernel-headers=true")
-	}
 	return sh.RunV(wrapperCmd, args...)
 }
 


### PR DESCRIPTION
**What problem does this PR solve?**:
Incorrect Magefile changes were merged when cherry-picking https://github.com/mesosphere/konvoy-image-builder/pull/1133 to `release-2.9` branch.
This PR removes use of the unused flags.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
