### PR TITLE
[release-2.8] fix: bumps nvidia version to a newer one that no longer uses GPL symbols

### DIFF
--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -106,7 +106,7 @@ nvidia_remote_bundle_path: "/opt/dkp/nvidia"
 
 # NOTE(jkoelker) UEK is the default. Set to RHCK to change to RH kernel.
 oracle_kernel: UEK
-nvidia_driver_version: "470.199.02"
+nvidia_driver_version: "470.256.02"
 nvidia_runfile_installer: "NVIDIA-Linux-x86_64-{{ nvidia_driver_version }}.run"
 nvidia_runfile_installer_url: "https://download.nvidia.com/XFree86/Linux-x86_64/{{ nvidia_driver_version }}/{{ nvidia_runfile_installer }}"
 suse_packagehub_product: PackageHub/{{ ansible_distribution_version }}/{{ ansible_architecture }}


### PR DESCRIPTION
**What problem does this PR solve?**:

With the previous version of the nvidia driver we were seeing an issue with some symbols that we're GPL only. This updates the driver to the latest 470 driver version which avoids that issue

error log below for posterity 
```bash
-> Error.
ERROR: An error occurred while performing the step: "Checking to see whether the nvidia kernel module was successfully built". See /var/log/nvidia-installer.log for details.
-> The command `cd ./kernel; /usr/bin/make -k -j8 NV_KERNEL_MODULES="nvidia" NV_EXCLUDE_KERNEL_MODULES="" SYSSRC="/lib/modules/5.15.0-1070-aws/build" SYSOUT="/lib/modules/5.15.0-1070-aws/build"` failed with the following output:

make[1]: Entering directory '/usr/src/linux-headers-5.15.0-1070-aws'
warning: the compiler differs from the one used to build the kernel
The kernel was built by: gcc (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0
You are using: cc (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0
MODPOST /opt/dkp/nvidia/NVIDIA-Linux-x86_64-470.199.02/kernel/Module.symvers
ERROR: modpost: GPL-incompatible module nvidia.ko uses GPL-only symbol 'rcu_read_unlock_strict'
make[2]: *** [scripts/Makefile.modpost:133: /opt/dkp/nvidia/NVIDIA-Linux-x86_64-470.199.02/kernel/Module.symvers] Error 1
make[2]: *** Deleting file '/opt/dkp/nvidia/NVIDIA-Linux-x86_64-470.199.02/kernel/Module.symvers'
make[2]: Target '__modpost' not remade because of errors.
make[1]: *** [Makefile:1829: modules] Error 2
make[1]: Leaving directory '/usr/src/linux-headers-5.15.0-1070-aws'
make: *** [Makefile:80: modules] Error 2
ERROR: The nvidia kernel module was not created.
ERROR: Installation has failed. Please see the file '/opt/dkp/nvidia/NVIDIA-Linux-x86_64-470.199.02/nvidia-installer.log' for details. You may find suggestions on fixing installation problems in the README available on the Linux driver download page at www.nvidia.com.
```

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note
updates nvidia driver to 470.256.02
```
