### PR TITLE
[release-2.9] fix: bumps nvidia version to a newer one that no longer uses GPL symbols

### DIFF
--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -105,7 +105,7 @@ nvidia_remote_bundle_path: "/opt/dkp/nvidia"
 
 # NOTE(jkoelker) UEK is the default. Set to RHCK to change to RH kernel.
 oracle_kernel: UEK
-nvidia_driver_version: "470.199.02"
+nvidia_driver_version: "470.256.02"
 nvidia_runfile_installer: "NVIDIA-Linux-x86_64-{{ nvidia_driver_version }}.run"
 nvidia_runfile_installer_url: "https://download.nvidia.com/XFree86/Linux-x86_64/{{ nvidia_driver_version }}/{{ nvidia_runfile_installer }}"
 suse_packagehub_product: PackageHub/{{ ansible_distribution_version }}/{{ ansible_architecture }}


### PR DESCRIPTION
**What problem does this PR solve?**:

this one but cherry picked to 2.9 https://github.com/mesosphere/konvoy-image-builder/pull/1200


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
