### PR TITLE
fix: Allow open-vm-tools to wait indefinitely for cloud-init to finish

### DIFF
--- a/ansible/roles/providers/files/etc/vmware-tools/tools.conf
+++ b/ansible/roles/providers/files/etc/vmware-tools/tools.conf
@@ -1,3 +1,5 @@
 [guestinfo]
 exclude-nics=antrea-*,ovs-system,br*,flannel*,veth*,vxlan_sys_*,genev_sys_*,gre_sys_*,stt_sys_*,????????-??????
 
+[deployPkg]
+wait-cloudinit-timeout=0


### PR DESCRIPTION
**What problem does this PR solve?**:
The default timeout is 30s. At that point, open-vm-tools restarts the machine, interrupting the cloud-init bootstrap; the bootstrap does not run on reboot.

Because kubeadm init/join runs as a cloud-init command, and can run over 5m, the timeout is not enough.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.nutanix.com/browse/NCN-103154


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
