### PR TITLE
[release-2.9] fix: hack to load modulemd-tools for rhel 84

### DIFF
--- a/bundles/redhat8.4/bundle.sh.gotmpl
+++ b/bundles/redhat8.4/bundle.sh.gotmpl
@@ -59,7 +59,7 @@ sed -i 1d reqs.txt # we need to get rid of the first line
 #shellcheck disable=SC2046
 yumdownloader --archlist=x86_64,noarch --setopt=skip_missing_names_on_install=False -x \*i686 $(< reqs.txt)
 #shellcheck disable=SC2046
-yumdownloader --setopt=skip_missing_names_on_install=False -x \*i686 --archlist=x86_64,noarch --resolve --disablerepo=*  --enablerepo=kubernetes,rhel-8-for-x86_64-baseos-eus-rpms,codeready-builder-for-rhel-8-x86_64-rpms,rhel-8-for-x86_64-appstream-rpms --disablerepo=appstream-rocky $(< packages.txt)
+yumdownloader --setopt=skip_missing_names_on_install=False -x \*i686 --archlist=x86_64,noarch --resolve --disablerepo=*  --enablerepo=kubernetes,rhel-8-for-x86_64-baseos-eus-rpms,codeready-builder-for-rhel-8-x86_64-rpms,rhel-8-for-x86_64-appstream-rpms $(< packages.txt)
 rm packages.txt reqs.txt
 curl https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm -o amazon-ssm-agent.rpm
 createrepo -v .

--- a/bundles/redhat8.4/bundle.sh.gotmpl
+++ b/bundles/redhat8.4/bundle.sh.gotmpl
@@ -48,18 +48,18 @@ subscription::defer_unregister
 subscription-manager repos --enable rhel-8-for-x86_64-baseos-eus-rpms
 subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
 subscription-manager repos --enable rhel-8-for-x86_64-appstream-rpms
-yum --disablerepo=appstream-centos -y install gettext yum-utils createrepo dnf-utils
+yum --disablerepo=appstream-rocky -y install gettext yum-utils createrepo dnf-utils
 yum clean all
 TMP_DIR="$(mktemp -d repodata-XXXX)"
 cp packages.txt "${TMP_DIR}"
 pushd "${TMP_DIR}"
 #shellcheck disable=SC2046,SC2062,SC2063,SC2035
-repoquery --archlist=x86_64,noarch --resolve --requires --recursive --enablerepo=kubernetes,rhel-8-for-x86_64-baseos-eus-rpms,codeready-builder-for-rhel-8-x86_64-rpms,rhel-8-for-x86_64-appstream-rpms  --disablerepo=appstream-centos $(< packages.txt) | grep -v *.i686  >> reqs.txt
+repoquery --archlist=x86_64,noarch --resolve --requires --recursive --enablerepo=kubernetes,rhel-8-for-x86_64-baseos-eus-rpms,codeready-builder-for-rhel-8-x86_64-rpms,rhel-8-for-x86_64-appstream-rpms  --disablerepo=appstream-rocky $(< packages.txt) | grep -v *.i686  >> reqs.txt
 sed -i 1d reqs.txt # we need to get rid of the first line
 #shellcheck disable=SC2046
 yumdownloader --archlist=x86_64,noarch --setopt=skip_missing_names_on_install=False -x \*i686 $(< reqs.txt)
 #shellcheck disable=SC2046
-yumdownloader --setopt=skip_missing_names_on_install=False -x \*i686 --archlist=x86_64,noarch --resolve --disablerepo=*  --enablerepo=kubernetes,rhel-8-for-x86_64-baseos-eus-rpms,codeready-builder-for-rhel-8-x86_64-rpms,rhel-8-for-x86_64-appstream-rpms --disablerepo=appstream-centos $(< packages.txt)
+yumdownloader --setopt=skip_missing_names_on_install=False -x \*i686 --archlist=x86_64,noarch --resolve --disablerepo=*  --enablerepo=kubernetes,rhel-8-for-x86_64-baseos-eus-rpms,codeready-builder-for-rhel-8-x86_64-rpms,rhel-8-for-x86_64-appstream-rpms --disablerepo=appstream-rocky $(< packages.txt)
 rm packages.txt reqs.txt
 curl https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm -o amazon-ssm-agent.rpm
 createrepo -v .

--- a/bundles/redhat8.4/repo-templates/rocky.repo
+++ b/bundles/redhat8.4/repo-templates/rocky.repo
@@ -1,4 +1,5 @@
-[rocky-appstream]
+# this is used to fetch the repo2mod utility which is not availible through rhel repositories
+[appstream-rocky]
 name=Rocky Linux $releasever - AppStream
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever
 #baseurl=http://dl.rockylinux.org/$contentdir/$releasever/AppStream/$basearch/os/

--- a/bundles/redhat8.4/rocky-appstream.repo
+++ b/bundles/redhat8.4/rocky-appstream.repo
@@ -1,0 +1,6 @@
+[rocky-appstream]
+name=Rocky Linux $releasever - AppStream
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever
+#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/AppStream/$basearch/os/
+gpgcheck=0
+sslverify=0


### PR DESCRIPTION
**What problem does this PR solve?**:
Installing modulemd-tools from Rocky instead of Centos

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-103667

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
n/a, fixing bugs