### PR TITLE
fix: use Rocky 9 without a minor version for Azure

### DIFF
--- a/.github/workflows/azure-e2e.yaml
+++ b/.github/workflows/azure-e2e.yaml
@@ -15,7 +15,7 @@ jobs:
       max-parallel: 10
       matrix:
         os:
-        - "rocky 9.3"
+        - "rocky 9"
         - "ubuntu 20.04"
         buildConfig:
         - "basic"

--- a/.github/workflows/release-azure.yaml
+++ b/.github/workflows/release-azure.yaml
@@ -16,7 +16,7 @@ jobs:
       max-parallel: 10
       matrix:
         include:
-          - os: "rocky 9.3"
+          - os: "rocky 9"
             buildConfig: "basic"
           - os: "ubuntu 20.04"
             buildConfig: "basic"

--- a/images/azure/rocky-9.yaml
+++ b/images/azure/rocky-9.yaml
@@ -1,5 +1,5 @@
 ---
-build_name: "rocky-9-az"
+build_name: "rocky-9"
 packer_builder_type: "azure"
 python_path: ""
 packer:

--- a/images/azure/rocky-9.yaml
+++ b/images/azure/rocky-9.yaml
@@ -1,5 +1,5 @@
 ---
-build_name: "rocky-93-az"
+build_name: "rocky-9-az"
 packer_builder_type: "azure"
 python_path: ""
 packer:
@@ -7,7 +7,7 @@ packer:
   distribution_version: "9-base"    # SKU
   # Azure Rocky linux official image: https://azuremarketplace.microsoft.com/en/marketplace/apps/resf.rockylinux-x86_64?tab=Overview
   image_publisher: "resf"
-  image_version: "9.3.20231113"
+  image_version: "latest"
   ssh_username: "azureuser"
   plan_image_sku: "9-base" # SKU
   plan_image_offer: "rockylinux-x86_64" # offer

--- a/magefile.go
+++ b/magefile.go
@@ -55,7 +55,7 @@ var (
 		"ubuntu 22.04",
 		"rocky 9.0",
 		"rocky 9.1",
-		"rocky 9.3",
+		"rocky 9",
 	}
 
 	validBuildConfig = []string{


### PR DESCRIPTION
**What problem does this PR solve?**:
Rocky deprecates versions as soon as the next minor is released https://wiki.rockylinux.org/rocky/version/#current-supported-releases.
Dropping the minor version in Azure to avoid referencing a removed image in the future. 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
