### PR TITLE
[release-2.8] fix: gpg key expired for v1.27

### DIFF
--- a/ansible/group_vars/all/system.yaml
+++ b/ansible/group_vars/all/system.yaml
@@ -8,7 +8,7 @@ kubernetes_rpm_gpg_key_url: "https://packages.d2iq.com/konvoy/stable/linux/repos
 
 ## Debian
 kubernetes_deb_repository_url: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_major_minor }}/deb/"
-kubernetes_deb_gpg_key_url: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_major_minor }}/deb/Release.key"
+kubernetes_deb_gpg_key_url: "https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key"
 kubernetes_deb_release_name: "/"
 
 # containerd package


### PR DESCRIPTION
**What problem does this PR solve?**:
The gpg key expired for ubuntu releases in Kubernetes version 1.27.
This bumps where the key gets retrieved so we don't get any fails when building KIB images.

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-104032

**Special notes for your reviewer**:
This would resolve this upstream complication for us:
https://github.com/kubernetes/release/issues/3818

**Does this PR introduce a user-facing change?**:
n/a