### PR TITLE
chore: changing gcp image for ubuntu 20.04

### DIFF
--- a/images/gcp/ubuntu-2004.yaml
+++ b/images/gcp/ubuntu-2004.yaml
@@ -5,8 +5,8 @@ python_path: ""
 packer:
   # The source image to use to create the new image from. source_image = `distribution`-`distribution_version-k8sversion-timestamp`
   distribution: "ubuntu"
-  distribution_version: "2004-focal-v20231213"
-  source_image: "ubuntu-2004-focal-v20231213"
+  distribution_version: "2004-focal-v20241115"
+  source_image: "ubuntu-2004-focal-v20241115"
   # The source_image_family to use to create the new image from.
   distribution_family: "ubuntu-2004-lts"
   # The username to connect to SSH with. Required if using SSH.


### PR DESCRIPTION
**What problem does this PR solve?**:
Failed gcp runs for Ubuntu 20.04

**Which issue(s) does this PR fix?**:
NCN-104362

**Special notes for your reviewer**:
Changing the lookup for the gcp image for Ubuntu 20.04

**Does this PR introduce a user-facing change?**:
Solely for creating a GCP Ubuntu 20.04 image