### PR TITLE
feat: create package bundle for ubuntu 22.04

### DIFF
--- a/.github/workflows/aws-e2e.yaml
+++ b/.github/workflows/aws-e2e.yaml
@@ -70,6 +70,8 @@ jobs:
             buildConfig: "basic"
           - os: "ubuntu 22.04"
             buildConfig: "nvidia"
+          - os: "ubuntu 22.04"
+            buildConfig: "offline"
           # Rocky 9.1
           - os: "rocky 9.1"
             buildConfig: "basic"

--- a/.github/workflows/vsphere-e2e.yaml
+++ b/.github/workflows/vsphere-e2e.yaml
@@ -29,6 +29,8 @@ jobs:
           buildConfig: "basic"
         - os: "ubuntu 22.04"
           buildConfig: "basic"
+        - os: "ubuntu 22.04"
+          buildConfig: "offline"
         - os: "rocky 9.1"
           buildConfig: "offline"
         - os: "oracle 9.4"

--- a/bundles/ubuntu22.04/bundle.sh.gotmpl
+++ b/bundles/ubuntu22.04/bundle.sh.gotmpl
@@ -21,9 +21,6 @@ sed -i 's/kubelet/kubelet='"{{ .KubernetesVersion }}-${KUBERNETES_DEB_BUILD_VERS
 sed -i 's/kubectl/kubectl='"{{ .KubernetesVersion }}-${KUBERNETES_DEB_BUILD_VERSION}"'/' /tmp/packages
 sed -i 's/kubeadm/kubeadm='"{{ .KubernetesVersion }}-${KUBERNETES_DEB_BUILD_VERSION}"'/' /tmp/packages
 sed -i 's/cri-tools/cri-tools='"{{ .CRIToolsVersion }}-${CRI_TOOLS_DEB_BUILD_VERSION}"'/' /tmp/packages
-# https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4745 pins version for CAPA
-# enable it back if https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4745, https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5115 are resolved
-echo 'cloud-init=23.1.2-0ubuntu0~22.04.1' >> /tmp/packages
 
 TMP_DIR="$(mktemp -d repodata-XXXX)"
 pushd "${TMP_DIR}"

--- a/bundles/ubuntu22.04/bundle.sh.gotmpl
+++ b/bundles/ubuntu22.04/bundle.sh.gotmpl
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+apt-get update && apt-get install -y --no-install-recommends \
+apt-transport-https software-properties-common dpkg-dev curl gpg
+
+KUBERNETES_DEB_BUILD_VERSION="1.1"
+CRI_TOOLS_DEB_BUILD_VERSION="1.1"
+
+# Install dependencies.
+mkdir -p /etc/apt/keyrings
+curl -fsSL "https://pkgs.k8s.io/core:/stable:/{{ .KubernetesMajorMinorVersion }}/deb/Release.key" | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/{{ .KubernetesMajorMinorVersion }}/deb/ /" | tee /etc/apt/sources.list.d/kubernetes.list
+apt-get update
+#shellcheck disable=SC2046
+apt-cache depends --recurse --no-recommends --no-suggests --no-conflicts --no-breaks --no-replaces --no-enhances --no-pre-depends $(< packages.txt) | grep "^\w" > /tmp/packages
+
+# The list returned by apt-cache depends does not contain the versions
+# Append the bare Kubernetes packages with the provided versions
+sed -i 's/kubelet/kubelet='"{{ .KubernetesVersion }}-${KUBERNETES_DEB_BUILD_VERSION}"'/' /tmp/packages
+sed -i 's/kubectl/kubectl='"{{ .KubernetesVersion }}-${KUBERNETES_DEB_BUILD_VERSION}"'/' /tmp/packages
+sed -i 's/kubeadm/kubeadm='"{{ .KubernetesVersion }}-${KUBERNETES_DEB_BUILD_VERSION}"'/' /tmp/packages
+sed -i 's/cri-tools/cri-tools='"{{ .CRIToolsVersion }}-${CRI_TOOLS_DEB_BUILD_VERSION}"'/' /tmp/packages
+# https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4745 pins version for CAPA
+# enable it back if https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4745, https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5115 are resolved
+echo 'cloud-init=23.1.2-0ubuntu0~22.04.1' >> /tmp/packages
+
+TMP_DIR="$(mktemp -d repodata-XXXX)"
+pushd "${TMP_DIR}"
+#shellcheck disable=SC2046
+apt-get download $(< /tmp/packages)
+dpkg-scanpackages -m . | gzip > Packages.gz
+#shellcheck disable=SC1083,SC2035
+tar -czf  {{ .OutputDirectory }}/{{ .KubernetesVersion }}_ubuntu_22.04_x86_64.tar.gz *
+#shellcheck disable=SC1083
+chmod 777 {{ .OutputDirectory }}/{{ .KubernetesVersion }}_ubuntu_22.04_x86_64.tar.gz
+popd
+rm -rf "${TMP_DIR}"

--- a/bundles/ubuntu22.04/packages.txt.gotmpl
+++ b/bundles/ubuntu22.04/packages.txt.gotmpl
@@ -1,0 +1,19 @@
+apt-transport-https
+chrony
+nfs-common
+python3-cryptography
+python3-pip
+libseccomp2
+kubectl={{ .KubernetesVersion }}-1.1
+kubelet={{ .KubernetesVersion }}-1.1
+kubeadm={{ .KubernetesVersion }}-1.1
+cloud-init
+cloud-guest-utils
+cloud-initramfs-copymods
+cloud-initramfs-dyn-netconf
+open-iscsi
+lvm2
+xfsprogs
+ipvsadm
+lsscsi
+sysstat

--- a/cmd/konvoy-image-wrapper/cmd/create-package-bundle.go
+++ b/cmd/konvoy-image-wrapper/cmd/create-package-bundle.go
@@ -47,6 +47,10 @@ var osToConfig = map[string]OSConfig{
 		configDir:      "bundles/ubuntu20.04",
 		containerImage: "docker.io/library/ubuntu:20.04",
 	},
+	"ubuntu-22.04": {
+		configDir:      "bundles/ubuntu22.04",
+		containerImage: "docker.io/library/ubuntu:22.04",
+	},
 	"oracle-9.4": {
 		configDir:      "bundles/oracle9.4",
 		containerImage: "docker.io/library/oraclelinux:9",
@@ -296,7 +300,7 @@ func templateObjects(targetOS, kubernetesVersion, outputDir string, fips, fetchK
 			}
 			var criToolsVersion string
 			var kubernetesMajorMinorVersion string
-			if targetOS == "ubuntu-20.04" {
+			if strings.Contains(targetOS, "ubuntu") {
 				kubernetesMajorMinorVersionNoV := strings.Join(strings.Split(kubernetesVersion, ".")[0:2], ".")
 				// according to ansible.group_vars/all/defaults.yaml L18 this is k8s major minor.1
 				criToolsVersion = fmt.Sprintf("%s.1", kubernetesMajorMinorVersionNoV)


### PR DESCRIPTION
**What problem does this PR solve?**:
- Create package bundle for ubuntu-22.04
- ensure that the cloud-init version supported by CAPA is installed. `cloud-init_23.1.2-0ubuntu0~22.04.1_all`  https://github.com/mesosphere/konvoy-image-builder/blob/main/images/ami/ubuntu-2204.yaml#L8
- ensure that latest cloud-init version is installed that is needed for all other providers than CAPA

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.nutanix.com/browse/NCN-104852


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
tested manually and GHA e2e tests will verify this. 
ensure that both cloud-init packages are installed.
```
❯ tar -tvf 1.31.4_ubuntu_22.04_x86_64.tar.gz | grep cloud-init
-rw-r--r--  0 501    dialout  530940 Apr 25  2023 cloud-init_23.1.2-0ubuntu0~22.04.1_all.deb
-rw-r--r--  0 501    dialout  564688 Dec  5 03:13 cloud-init_24.4-0ubuntu1~22.04.1_all.deb
-rw-r--r--  0 501    dialout    4028 Aug 17  2020 cloud-initramfs-copymods_0.47ubuntu1_all.deb
-rw-r--r--  0 501    dialout    6540 Aug 17  2020 cloud-initramfs-dyn-netconf_0.47ubuntu1_all.deb
```

**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
