### PR TITLE
fix: Update RHEL 8.8 kernel headers version

### DIFF
--- a/bundles/redhat8.8/README.md
+++ b/bundles/redhat8.8/README.md
@@ -1,0 +1,11 @@
+# Updating packages.txt.gotmpl
+
+The package list includes packages required by the NVIDIA GPU drivers, kernel- headers, and kernel-devel. These headers need to match the kernel version in the base image.
+
+Periodically, the base image is updated, and we need to update the package versions. To find the expected kernel version, look for the error message, e.g.
+
+```log
+amazon-ebs.kib_image: fatal: [default]: FAILED! => {"changed": false, "failures": ["No package kernel-headers-4.18.0-477.86.1.el8_8.x86_64 available.", "No package kernel-devel-4.18.0-477.86.1.el8_8.x86_64 available."], "msg": "Failed to install some of the specified packages", "rc": 1, "results": []}
+```
+
+In this example, the expected kernel version is 4.18.0-488.86.1.

--- a/bundles/redhat8.8/packages.txt.gotmpl
+++ b/bundles/redhat8.8/packages.txt.gotmpl
@@ -36,6 +36,6 @@ gssproxy
 libverto-module-base
 libverto
 {{ if .FetchKernelHeaders -}}
-kernel-headers-4.18.0-477.81.1.el8_8
-kernel-devel-4.18.0-477.81.1.el8_8
+kernel-headers-4.18.0-477.86.1.el8_8
+kernel-devel-4.18.0-477.86.1.el8_8
 {{- end }}


### PR DESCRIPTION
**What problem does this PR solve?**:
Updates RHEL 8.8 kernel headers version. The previous version is no longer in the repository.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.nutanix.com/browse/NCN-105791


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
