### PR TITLE
fix: moves sysctl settings to a common place for preprovisioned and providers

### DIFF
--- a/ansible/roles/config/tasks/main.yaml
+++ b/ansible/roles/config/tasks/main.yaml
@@ -34,3 +34,15 @@
     dest: "/etc/containerd/config.toml"
   notify:
     - restart containerd
+
+- name: set and persist kernel params
+  ansible.posix.sysctl:
+    name: "{{ item.param }}"
+    value: "{{ item.val }}"
+    state: present
+    sysctl_set: true
+    sysctl_file: "{{ sysctl_conf_file }}"
+    reload: true
+  loop:
+    - { param: fs.inotify.max_user_instances, val: 8192 }
+    - { param: fs.inotify.max_user_watches, val: 524288 }

--- a/ansible/roles/providers/tasks/misc.yml
+++ b/ansible/roles/providers/tasks/misc.yml
@@ -114,14 +114,3 @@
     packer_builder_type is search('vsphere')) and
     ansible_os_family != "Flatcar"
 
-- name: Set and persist kernel params
-  ansible.posix.sysctl:
-    name: "{{ item.param }}"
-    value: "{{ item.val }}"
-    state: present
-    sysctl_set: true
-    sysctl_file: "{{ sysctl_conf_file }}"
-    reload: true
-  loop:
-    - { param: fs.inotify.max_user_instances, val: 8192 }
-    - { param: fs.inotify.max_user_watches, val: 524288 }


### PR DESCRIPTION
**What problem does this PR solve?**:
Sets sysctl settings for inotify in a common place between preprovisioned and cloud providers. 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
*[NCN-105830](https://jira.nutanix.com/browse/NCN-105830)


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note
sets sysctl settings for inotify on preprovisioned nodes
```
