### PR TITLE
feat: download kubernetes images in the KIB container 

### DIFF
--- a/.github/workflows/podman-aws-e2e.yaml
+++ b/.github/workflows/podman-aws-e2e.yaml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Run E2E test for AWS Rocky 9.1 using podman
         run: |-
-          KIB_CONTAINER_ENGINE=podman dist/konvoy-image-wrapper-for-podman_linux_amd64_v1/konvoy-image build aws images/ami/rocky-91.yaml --dry-run
+          KIB_CONTAINER_ENGINE=podman dist/konvoy-image-wrapper-for-podman_linux_amd64_v1/konvoy-image build aws images/ami/ubuntu-2204.yaml --dry-run
         env:
           GITHUB_TOKEN: ${{ secrets.MESOSPHERECI_USER_TOKEN }}
           KIB_CONTAINER_ENGINE: podman

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ ARG BUILDARCH
 # Packer copies /usr/local/bin/goss-amd64 from this container to the remote host
 COPY --from=devkit /usr/local/bin/goss-amd64 /usr/local/bin/goss-amd64
 COPY --from=devkit /opt/*.rpm /opt
+COPY --from=devkit /opt/kubernetes-images /opt/kubernetes-images
 COPY --from=devkit /opt/d2iq-sign-authority-gpg-public-key /opt/d2iq-sign-authority-gpg-public-key
 # we copy this to remote hosts to execute mindthegap so its always amd64
 COPY --from=devkit /usr/local/bin/mindthegap /usr/local/bin/

--- a/Dockerfile.devkit
+++ b/Dockerfile.devkit
@@ -81,37 +81,12 @@ RUN \
     curl --fail -v -L -o /usr/local/bin/goss-amd64 "https://github.com/goss-org/goss/releases/download/${GOSS_VERSION}/goss-linux-amd64" \
     && chmod +rx /usr/local/bin/goss-amd64 \
     && ln -s /usr/local/bin/goss-amd64 /usr/local/bin/goss
-
-RUN curl --fail -v -o /opt/amazon-ssm-agent.rpm https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
-
 # Copy the Ansible plybooks into the image
 COPY ansible ansible
 
 # Download nokmem RPMs to be used at image creation time
-RUN \
-  export KUBERNETES_VERSION=$(awk -F': ' '/kubernetes_version/ {print $2}' ansible/group_vars/all/defaults.yaml | sed -n '2p' | xargs) && \
-  echo ${KUBERNETES_VERSION} && \
-  curl --fail -v -o /opt/kubectl-${KUBERNETES_VERSION}-0.rpm https://packages.d2iq.com/konvoy/stable/linux/repos/el/kubernetes-v${KUBERNETES_VERSION}-nokmem/x86_64/kubectl-${KUBERNETES_VERSION}-0.x86_64.rpm && \
-  curl --fail -v -o /opt/kubeadm-${KUBERNETES_VERSION}-0.rpm https://packages.d2iq.com/konvoy/stable/linux/repos/el/kubernetes-v${KUBERNETES_VERSION}-nokmem/x86_64/kubeadm-${KUBERNETES_VERSION}-0.x86_64.rpm && \
-  curl --fail -v -o /opt/kubelet-${KUBERNETES_VERSION}-0.rpm https://packages.d2iq.com/konvoy/stable/linux/repos/el/kubernetes-v${KUBERNETES_VERSION}-nokmem/x86_64/kubelet-${KUBERNETES_VERSION}-0.x86_64.rpm && \
-  export CRICTL_TOOLS_VERSION="$(echo ${KUBERNETES_VERSION} | cut -d. -f1-2).1" && \
-  curl --fail -v -o /opt/cri-tools-${CRICTL_TOOLS_VERSION}-0.rpm https://packages.d2iq.com/konvoy/stable/linux/repos/el/kubernetes-v${KUBERNETES_VERSION}-nokmem/x86_64/cri-tools-${CRICTL_TOOLS_VERSION}-0.x86_64.rpm && \
-  export CNI_VERSION=$(awk -F': ' '/kubernetes_cni_version/ {print $2}' ansible/group_vars/all/defaults.yaml | sed -n '1p' | xargs) && \
-  curl --fail -v -o /opt/kubernetes-cni-${CNI_VERSION}-0.rpm https://packages.d2iq.com/konvoy/stable/linux/repos/el/kubernetes-v${KUBERNETES_VERSION}-nokmem/x86_64/kubernetes-cni-${CNI_VERSION}-0.x86_64.rpm
-
-# Download FIPS RPMs to be used at image creation time
-RUN \
-  export KUBERNETES_VERSION=$(awk -F': ' '/kubernetes_version/ {print $2}' ansible/group_vars/all/defaults.yaml | sed -n '2p' | xargs) && \
-  echo ${KUBERNETES_VERSION} && \
-  curl --fail -v -o /opt/kubectl-${KUBERNETES_VERSION}-0-fips.rpm https://packages.d2iq.com/konvoy/stable/linux/repos/el/kubernetes-v${KUBERNETES_VERSION}-fips/x86_64/kubectl-${KUBERNETES_VERSION}-0.x86_64.rpm && \
-  curl --fail -v -o /opt/kubeadm-${KUBERNETES_VERSION}-0-fips.rpm https://packages.d2iq.com/konvoy/stable/linux/repos/el/kubernetes-v${KUBERNETES_VERSION}-fips/x86_64/kubeadm-${KUBERNETES_VERSION}-0.x86_64.rpm && \
-  curl --fail -v -o /opt/kubelet-${KUBERNETES_VERSION}-0-fips.rpm https://packages.d2iq.com/konvoy/stable/linux/repos/el/kubernetes-v${KUBERNETES_VERSION}-fips/x86_64/kubelet-${KUBERNETES_VERSION}-0.x86_64.rpm && \
-  export CRICTL_TOOLS_VERSION="$(echo ${KUBERNETES_VERSION} | cut -d. -f1-2).1" && \
-  curl --fail -v -o /opt/cri-tools-${CRICTL_TOOLS_VERSION}-0-fips.rpm https://packages.d2iq.com/konvoy/stable/linux/repos/el/kubernetes-v${KUBERNETES_VERSION}-fips/x86_64/cri-tools-${CRICTL_TOOLS_VERSION}-0.x86_64.rpm && \
-  export CNI_VERSION=$(awk -F': ' '/kubernetes_cni_version/ {print $2}' ansible/group_vars/all/defaults.yaml | sed -n '1p' | xargs) && \
-  curl --fail -v -o /opt/kubernetes-cni-${CNI_VERSION}-0-fips.rpm https://packages.d2iq.com/konvoy/stable/linux/repos/el/kubernetes-v${KUBERNETES_VERSION}-fips/x86_64/kubernetes-cni-${CNI_VERSION}-0.x86_64.rpm
-
-RUN curl --fail -v -o /opt/d2iq-sign-authority-gpg-public-key https://packages.d2iq.com/konvoy/stable/linux/repos/d2iq-sign-authority-gpg-public-key
+COPY hack/download-artifacts.sh hack/download-artifacts.sh
+RUN hack/download-artifacts.sh
 
 COPY --from=packer-amd64 /bin/packer /usr/local/bin/packer-amd64
 COPY --from=packer-arm64 /bin/packer /usr/local/bin/packer-arm64

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ buildx:
 ###### Devkit container image
 DEVKIT_IMAGE_DOCKERFILE ?= Dockerfile.devkit
 DEVKIT_IMAGE_NAME ?= mesosphere/konvoy-image-builder-devkit
-DEVKIT_IMAGE_TAG ?= $(shell cat ${DEVKIT_IMAGE_DOCKERFILE} requirements.txt requirements-devkit.txt ansible/group_vars/all/defaults.yaml  | sha256sum | cut -d" " -f 1)
+DEVKIT_IMAGE_TAG ?= $(shell cat ${DEVKIT_IMAGE_DOCKERFILE} requirements.txt requirements-devkit.txt ansible/group_vars/all/defaults.yaml hack/download-artifacts.sh | sha256sum | cut -d" " -f 1)
 
 .PHONY: devkit-image
 ## first tries to pull an image, if doesn't exist build and push the image

--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -83,7 +83,8 @@ kubernetes_bins:
 
 sysprep: true
 
-images_local_bundle_dir: ""
+# The KIB container will have the images pre-pulled and available in the local cache at /opt/kubernetes-images
+images_local_bundle_dir: "/opt/kubernetes-images"
 images_cache: /opt/dkp/images
 # use the mindthegap in the container by default
 mindthegap_binary_location: /usr/local/bin/mindthegap

--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -88,7 +88,8 @@ images_local_bundle_dir: "/opt/kubernetes-images"
 images_cache: /opt/dkp/images
 # use the mindthegap in the container by default
 mindthegap_binary_location: /usr/local/bin/mindthegap
-mindthegap_binary_location_on_remote: /usr/local/bin/mindthegap
+# /opt is writable on flatcar and other operating systems. Use /opt for the mindthegap binary location.
+mindthegap_binary_location_on_remote: /opt/mindthegap
 
 os_packages_local_bundle_file: ""
 os_packages_remote_bundle_path: "/opt/dkp/packages/"

--- a/ansible/roles/images/tasks/main.yaml
+++ b/ansible/roles/images/tasks/main.yaml
@@ -5,6 +5,9 @@
     state: restarted
     daemon_reload: true
 
+- name: upload images
+  import_tasks: upload.yaml
+
 - name: load images
   import_tasks: load.yaml
 

--- a/ansible/roles/images/tasks/upload.yaml
+++ b/ansible/roles/images/tasks/upload.yaml
@@ -11,7 +11,7 @@
         paths:
           - "{{ images_local_bundle_dir }}"
         patterns:
-          - "{{ '.*-fips' if fips.enabled else '.*' }}\.tar(\.gz)?"
+          - "{{ '.*-fips' if fips.enabled else '^(?!.*-fips).*' }}\\.tar(\\.gz)?"
         file_type: file
         use_regex: true
       register: images_cache_find_result

--- a/ansible/roles/images/tasks/upload.yaml
+++ b/ansible/roles/images/tasks/upload.yaml
@@ -1,0 +1,33 @@
+---
+
+- block:
+    - name: create images directory
+      file:
+        path: "{{ images_cache }}"
+        state: directory
+
+    - name: list tar.gz files in the local image cache
+      find:
+        paths:
+          - "{{ images_local_bundle_dir }}"
+        patterns:
+          - "{{ '.*-fips' if fips.enabled else '.*' }}\.tar(\.gz)?"
+        file_type: file
+        use_regex: true
+      register: images_cache_find_result
+      delegate_to: 127.0.0.1
+      become: no
+      changed_when: false
+
+    - name: upload image bundles to remote
+      copy:
+        src: "{{ item }}"
+        dest: "{{ images_cache}}/{{ item | basename }}"
+      with_items: "{{  images_cache_find_result.files | map(attribute='path') | list }}"
+
+    - name: upload mindthegap
+      copy:
+        src: "{{ mindthegap_binary_location }}"
+        dest: "{{ mindthegap_binary_location_on_remote }}"
+        mode: 0755
+  when: images_local_bundle_dir != ""

--- a/ansible/roles/offline/tasks/upload.yaml
+++ b/ansible/roles/offline/tasks/upload.yaml
@@ -19,38 +19,6 @@
     containerd_tar_file: "containerd-{{ containerd_version }}-d2iq.1-{{ os_release.ID }}-{{ ansible_distribution_version }}-{{ ansible_architecture }}{{ '_fips' if fips.enabled else '' }}.tar.gz"
 
 - block:
-    - name: create images directory
-      file:
-        path: "{{ images_cache }}"
-        state: directory
-
-    - name: list tar.gz files in the local image cache
-      find:
-        paths:
-          - "{{ images_local_bundle_dir }}"
-        patterns:
-          - .*\.tar(\.gz)?
-        file_type: file
-        use_regex: true
-      register: images_cache_find_result
-      delegate_to: 127.0.0.1
-      become: no
-      changed_when: false
-
-    - name: upload image bundles to remote
-      copy:
-        src: "{{ item }}"
-        dest: "{{ images_cache}}/{{ item | basename }}"
-      with_items: "{{  images_cache_find_result.files | map(attribute='path') | list }}"
-
-    - name: upload mindthegap
-      copy:
-        src: "{{ mindthegap_binary_location }}"
-        dest: "{{ mindthegap_binary_location_on_remote }}"
-        mode: 0755
-  when: images_local_bundle_dir != ""
-
-- block:
     - name: create offline OS packages directory
       file:
         path: "{{ offline.os_packages_remote_filesystem_repo_path }}"

--- a/hack/download-artifacts.sh
+++ b/hack/download-artifacts.sh
@@ -14,7 +14,7 @@ TARGET_ARTIFACTS_DIR="${TARGET_ARTIFACTS_DIR:-"/opt"}"
 TARGET_KUBERNETES_IMAGES_DIR="${TARGET_KUBERNETES_IMAGES_DIR:-"${TARGET_ARTIFACTS_DIR}/kubernetes-images"}"
 
 KUBERNETES_VERSION=$(awk -F': ' '/kubernetes_version/ {print $2}' "${PROJECT_DIR}/ansible/group_vars/all/defaults.yaml" | sed -n '2p' | xargs)
-CRICTL_TOOLS_VERSION="$(echo ${KUBERNETES_VERSION} | cut -d. -f1-2).1"
+CRICTL_TOOLS_VERSION="$(echo "${KUBERNETES_VERSION}" | cut -d. -f1-2).1"
 CNI_VERSION=$(awk -F': ' '/kubernetes_cni_version/ {print $2}' "${PROJECT_DIR}/ansible/group_vars/all/defaults.yaml" | sed -n '1p' | xargs)
 
 # ensure target directories exist

--- a/hack/download-artifacts.sh
+++ b/hack/download-artifacts.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+set -x
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+PROJECT_DIR="$(cd ${SCRIPT_DIR}/.. &> /dev/null && pwd )"
+PACKAGES_BASE_URL="https://packages.d2iq.com/konvoy/stable/linux/repos"
+IMAGES_BASE_URL="https://downloads.d2iq.com/dkp/airgapped/kubernetes-images"
+
+TARGET_ARTIFACTS_DIR="${TARGET_ARTIFACTS_DIR:-"/opt"}"
+TARGET_KUBERNETES_IMAGES_DIR="${TARGET_KUBERNETES_IMAGES_DIR:-"${TARGET_ARTIFACTS_DIR}/kubernetes-images"}"
+
+export KUBERNETES_VERSION=$(awk -F': ' '/kubernetes_version/ {print $2}' "${PROJECT_DIR}/ansible/group_vars/all/defaults.yaml" | sed -n '2p' | xargs)
+export CRICTL_TOOLS_VERSION="$(echo ${KUBERNETES_VERSION} | cut -d. -f1-2).1"
+export CNI_VERSION=$(awk -F': ' '/kubernetes_cni_version/ {print $2}' "${PROJECT_DIR}/ansible/group_vars/all/defaults.yaml" | sed -n '1p' | xargs)
+
+# ensure target directories exist
+mkdir -p "${TARGET_ARTIFACTS_DIR}"
+
+# Download non-fips rpms
+curl --fail -v -o "${TARGET_ARTIFACTS_DIR}/kubectl-${KUBERNETES_VERSION}-0.rpm" "${PACKAGES_BASE_URL}/el/kubernetes-v${KUBERNETES_VERSION}-nokmem/x86_64/kubectl-${KUBERNETES_VERSION}-0.x86_64.rpm"
+curl --fail -v -o "${TARGET_ARTIFACTS_DIR}/kubeadm-${KUBERNETES_VERSION}-0.rpm" "${PACKAGES_BASE_URL}/el/kubernetes-v${KUBERNETES_VERSION}-nokmem/x86_64/kubeadm-${KUBERNETES_VERSION}-0.x86_64.rpm"
+curl --fail -v -o "${TARGET_ARTIFACTS_DIR}/kubelet-${KUBERNETES_VERSION}-0.rpm" "${PACKAGES_BASE_URL}/el/kubernetes-v${KUBERNETES_VERSION}-nokmem/x86_64/kubelet-${KUBERNETES_VERSION}-0.x86_64.rpm"
+curl --fail -v -o "${TARGET_ARTIFACTS_DIR}/cri-tools-${CRICTL_TOOLS_VERSION}-0.rpm" "${PACKAGES_BASE_URL}/el/kubernetes-v${KUBERNETES_VERSION}-nokmem/x86_64/cri-tools-${CRICTL_TOOLS_VERSION}-0.x86_64.rpm"
+curl --fail -v -o "${TARGET_ARTIFACTS_DIR}/kubernetes-cni-${CNI_VERSION}-0.rpm" "${PACKAGES_BASE_URL}/el/kubernetes-v${KUBERNETES_VERSION}-nokmem/x86_64/kubernetes-cni-${CNI_VERSION}-0.x86_64.rpm"
+  
+# Download FIPS RPMs
+curl --fail -v -o "${TARGET_ARTIFACTS_DIR}/kubectl-${KUBERNETES_VERSION}-0-fips.rpm" "${PACKAGES_BASE_URL}/el/kubernetes-v${KUBERNETES_VERSION}-fips/x86_64/kubectl-${KUBERNETES_VERSION}-0.x86_64.rpm"
+curl --fail -v -o "${TARGET_ARTIFACTS_DIR}/kubeadm-${KUBERNETES_VERSION}-0-fips.rpm" "${PACKAGES_BASE_URL}/el/kubernetes-v${KUBERNETES_VERSION}-fips/x86_64/kubeadm-${KUBERNETES_VERSION}-0.x86_64.rpm"
+curl --fail -v -o "${TARGET_ARTIFACTS_DIR}/kubelet-${KUBERNETES_VERSION}-0-fips.rpm" "${PACKAGES_BASE_URL}/el/kubernetes-v${KUBERNETES_VERSION}-fips/x86_64/kubelet-${KUBERNETES_VERSION}-0.x86_64.rpm"
+curl --fail -v -o "${TARGET_ARTIFACTS_DIR}/cri-tools-${CRICTL_TOOLS_VERSION}-0-fips.rpm" "${PACKAGES_BASE_URL}/el/kubernetes-v${KUBERNETES_VERSION}-fips/x86_64/cri-tools-${CRICTL_TOOLS_VERSION}-0.x86_64.rpm"
+curl --fail -v -o "${TARGET_ARTIFACTS_DIR}/kubernetes-cni-${CNI_VERSION}-0-fips.rpm" "${PACKAGES_BASE_URL}/el/kubernetes-v${KUBERNETES_VERSION}-fips/x86_64/kubernetes-cni-${CNI_VERSION}-0.x86_64.rpm"
+
+# download gpg key
+curl --fail -v -o "${TARGET_ARTIFACTS_DIR}/d2iq-sign-authority-gpg-public-key" "${PACKAGES_BASE_URL}/d2iq-sign-authority-gpg-public-key"
+
+# Download kubernetes images
+mkdir -p "${TARGET_KUBERNETES_IMAGES_DIR}"
+curl --fail -v -o "${TARGET_KUBERNETES_IMAGES_DIR}/kubernetes-images-${KUBERNETES_VERSION}-d2iq.1.tar" "${IMAGES_BASE_URL}/kubernetes-images-${KUBERNETES_VERSION}-d2iq.1.tar"
+curl --fail -v -o "${TARGET_KUBERNETES_IMAGES_DIR}/kubernetes-images-${KUBERNETES_VERSION}-d2iq.1-fips.tar" "${IMAGES_BASE_URL}/kubernetes-images-${KUBERNETES_VERSION}-d2iq.1-fips.tar"
+
+# Amazon SSM agent
+curl --fail -v -o "${TARGET_ARTIFACTS_DIR}/amazon-ssm-agent.rpm" https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm

--- a/hack/download-artifacts.sh
+++ b/hack/download-artifacts.sh
@@ -6,16 +6,16 @@ set -o nounset
 set -x
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-PROJECT_DIR="$(cd ${SCRIPT_DIR}/.. &> /dev/null && pwd )"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." &> /dev/null && pwd )"
 PACKAGES_BASE_URL="https://packages.d2iq.com/konvoy/stable/linux/repos"
 IMAGES_BASE_URL="https://downloads.d2iq.com/dkp/airgapped/kubernetes-images"
 
 TARGET_ARTIFACTS_DIR="${TARGET_ARTIFACTS_DIR:-"/opt"}"
 TARGET_KUBERNETES_IMAGES_DIR="${TARGET_KUBERNETES_IMAGES_DIR:-"${TARGET_ARTIFACTS_DIR}/kubernetes-images"}"
 
-export KUBERNETES_VERSION=$(awk -F': ' '/kubernetes_version/ {print $2}' "${PROJECT_DIR}/ansible/group_vars/all/defaults.yaml" | sed -n '2p' | xargs)
-export CRICTL_TOOLS_VERSION="$(echo ${KUBERNETES_VERSION} | cut -d. -f1-2).1"
-export CNI_VERSION=$(awk -F': ' '/kubernetes_cni_version/ {print $2}' "${PROJECT_DIR}/ansible/group_vars/all/defaults.yaml" | sed -n '1p' | xargs)
+KUBERNETES_VERSION=$(awk -F': ' '/kubernetes_version/ {print $2}' "${PROJECT_DIR}/ansible/group_vars/all/defaults.yaml" | sed -n '2p' | xargs)
+CRICTL_TOOLS_VERSION="$(echo ${KUBERNETES_VERSION} | cut -d. -f1-2).1"
+CNI_VERSION=$(awk -F': ' '/kubernetes_cni_version/ {print $2}' "${PROJECT_DIR}/ansible/group_vars/all/defaults.yaml" | sed -n '1p' | xargs)
 
 # ensure target directories exist
 mkdir -p "${TARGET_ARTIFACTS_DIR}"

--- a/magefile.go
+++ b/magefile.go
@@ -383,9 +383,6 @@ func downloadAirgappedArtifacts(buildOS, buildConfig string) error {
 	}
 	// Fetch artifacts
 	isFips := buildConfig == offlineFIPS
-	if err := fetchImageBundle(kubeVersion, artifactsDir, isFips); err != nil {
-		return fmt.Errorf("failed to fetch Image bundle %w", err)
-	}
 	if err := fetchContainerd(buildOS, artifactsDir, containerdVersion, isFips); err != nil {
 		return fmt.Errorf("failed to fetch containerd %w", err)
 	}
@@ -420,21 +417,6 @@ func createOSBundle(osName, kubernetesVersion, downloadDir string, fips, gpu boo
 		args = append(args, "--fetch-kernel-headers=true")
 	}
 	return sh.RunV(wrapperCmd, args...)
-}
-
-func fetchImageBundle(kubernetesVersion, downloadDir string, fips bool) error {
-	imageBundleName := fmt.Sprintf("kubernetes-images-%s-d2iq.1", kubernetesVersion)
-	if fips {
-		imageBundleName += "-fips"
-	}
-	imageBundleName += ".tar"
-	srcURL, err := url.Parse(baseURL)
-	if err != nil {
-		return fmt.Errorf("failed to parse url %w", err)
-	}
-	srcURL.Path = path.Join(srcURL.Path, "airgapped", "kubernetes-images", imageBundleName)
-	destPath := filepath.Join(downloadDir, "images", imageBundleName)
-	return downloadArtifact(srcURL, destPath)
 }
 
 func fetchPipPackages(downloadDir string) error {

--- a/overrides/offline-fips.yaml
+++ b/overrides/offline-fips.yaml
@@ -2,4 +2,3 @@
 os_packages_local_bundle_file: "{{ playbook_dir }}/../artifacts/{{ kubernetes_version }}_{{ ansible_distribution|lower }}_{{ ansible_distribution_version }}_x86_64_fips.tar.gz"
 containerd_local_bundle_file: "{{ playbook_dir }}/../artifacts/{{ containerd_tar_file }}"
 pip_packages_local_bundle_file: "{{ playbook_dir }}/../artifacts/pip-packages.tar.gz"
-images_local_bundle_dir: "{{ playbook_dir}}/../artifacts/images"

--- a/overrides/offline.yaml
+++ b/overrides/offline.yaml
@@ -1,4 +1,3 @@
 os_packages_local_bundle_file: "{{ playbook_dir }}/../artifacts/{{ kubernetes_version }}_{{ ansible_distribution|lower }}_{{ ansible_distribution_version }}_x86_64.tar.gz"
 containerd_local_bundle_file: "{{ playbook_dir }}/../artifacts/{{ containerd_tar_file }}"
 pip_packages_local_bundle_file: "{{ playbook_dir }}/../artifacts/pip-packages.tar.gz"
-images_local_bundle_dir: "{{ playbook_dir}}/../artifacts/images"


### PR DESCRIPTION
**What problem does this PR solve?**:
include kuberentes images in the KIB container image. This will help with avoiding rate limited by docker hub.
includes both fips and non-fips images
moved downloading artifacts to the script so that its easier to sync it with NIB
uses included kubernetes images in both airgap and networked installations. 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.nutanix.com/browse/NCN-106565


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
