### PR TITLE
[release-2.22] fix: custom cloudinit script

### DIFF
--- a/ansible/roles/providers/files/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceEc2Kubernetes.py
+++ b/ansible/roles/providers/files/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceEc2Kubernetes.py
@@ -110,7 +110,7 @@ class DataSourceEc2Kubernetes(DataSourceEc2.DataSourceEc2):
         util.write_file(
             "/etc/cloud/cloud.cfg.d/99_kubeadm_bootstrap.cfg", rendered_payload
         )
-        self.userdata_raw = rendered_payload
+
         return True
 
 

--- a/ansible/roles/providers/files/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceEc2Kubernetes.py
+++ b/ansible/roles/providers/files/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceEc2Kubernetes.py
@@ -82,13 +82,12 @@ class DataSourceEc2Kubernetes(DataSourceEc2.DataSourceEc2):
                 "excluded": [],
             },
         )
-        LOG.info("User-data before update:[\n%s]", self.userdata_raw)
+
         secret_userdata = "/etc/secret-userdata.txt"
         # Get the boothook output, save it as user-data
         # TODO: work with upstream to put this somewhere more sensible like:
         # /var/lib/cloud/instances/{{v1.instance_id}}/ec2-kubernetes-userdata.txt
         userdata_raw = util.load_text_file(secret_userdata)
-        LOG.info("Secret user-data:[\n%s]", self.userdata_raw)
 
         uid = os.getuid()
         redacted_data_fn = self.paths.get_runpath("instance_data")


### PR DESCRIPTION
**What problem does this PR solve?**:

Backport of https://github.com/mesosphere/konvoy-image-builder/pull/1272

This fixes the linter error. While looking at this, I also noticed that the second log message was using the wrong variable.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
