### PR TITLE
ci: run the release job with large runner

### DIFF
--- a/.github/workflows/release-kib.yaml
+++ b/.github/workflows/release-kib.yaml
@@ -14,7 +14,7 @@ jobs:
   release-to-github:
     runs-on:
       - self-hosted
-      - small
+      - large
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
**What problem does this PR solve?**:
Since we are adding the k8s images in the binary, the macos signing and notarization during the release job is timing out.
Increasing the runner size to "large" to see if it fixes it.

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
