### PR TITLE
ci: remove RHEL 8.6 from the vSphere release matrix

### DIFF
--- a/.github/workflows/release-vsphere-template.yaml
+++ b/.github/workflows/release-vsphere-template.yaml
@@ -13,10 +13,6 @@ jobs:
       max-parallel: 10
       matrix:
         include:
-          - os: "redhat 8.6"
-            buildConfig: "offline"
-          - os: "redhat 8.6"
-            buildConfig: "offline-fips"
           - os: "redhat 8.8"
             buildConfig: "offline"
           - os: "redhat 8.8"


### PR DESCRIPTION
**What problem does this PR solve?**:
RHEL 8.6 is no longer supported and the builds fail https://github.com/mesosphere/konvoy-image-builder/actions/runs/14040676595/job/39872319392

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
