### PR TITLE
ci(release-2.18): run vsphere e2e tests on nkp vcenter

### DIFF
--- a/.github/workflows/release-vsphere-template.yaml
+++ b/.github/workflows/release-vsphere-template.yaml
@@ -42,8 +42,7 @@ jobs:
           - os: "flatcar"
             buildConfig: "basic"
     runs-on:
-    - self-hosted
-    - medium
+    - self-hosted-nutanix-docker-large
     continue-on-error: false
     steps:
       - name: Checkout konvoy-image-builder repository

--- a/.github/workflows/vsphere-e2e.yaml
+++ b/.github/workflows/vsphere-e2e.yaml
@@ -35,6 +35,8 @@ jobs:
           buildConfig: "basic"
         - os: "rocky 9.1"
           buildConfig: "offline"
+        - os: "rocky 9.1"
+          buildConfig: "basic"
         - os: "oracle 9.4"
           buildConfig: "basic"
         - os: "oracle 9.4"
@@ -46,8 +48,7 @@ jobs:
         - os: "flatcar"
           buildConfig: "basic"
     runs-on:
-    - self-hosted
-    - medium
+    - self-hosted-nutanix-docker-large
     continue-on-error: false
     steps:
       - uses: actions/checkout@v4

--- a/test/infra/vcd/bastion.tf
+++ b/test/infra/vcd/bastion.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     vsphere = {
       source  = "hashicorp/vsphere"
-      version = "~> 2.4.0"
+      version = "~> 2.11.0"
     }
   }
 }

--- a/test/infra/vcd/variables.tf
+++ b/test/infra/vcd/variables.tf
@@ -18,7 +18,7 @@ variable "bastion_base_template" {
 
 variable "vcd_bastion_vsphere_folder" {
   description = "Name of the folder where the bastion vm will be created"
-  default     = "users/users-ksphere-platform"
+  default     = "ci-kib"
   type        = string
 }
 
@@ -29,7 +29,7 @@ variable "datastore_name" {
 
 variable "vcd_bastion_resource_pool_name" {
   description = "Name of the vsphere resource pool"
-  default     = "users-ksphere-platform"
+  default     = "ci-kib"
   type        = string
 }
 

--- a/test/infra/vsphere/main.tf
+++ b/test/infra/vsphere/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     vsphere = {
       source  = "hashicorp/vsphere"
-      version = "~> 2.4.0"
+      version = "~> 2.11.0"
     }
   }
 }
@@ -27,6 +27,7 @@ module "bastion_node" {
   custom_attribute_owner      = var.bastion_owner
   custom_attribute_expiration = "4h"
   vsphere_network             = var.vsphere_network
+  port_calculation            = "nutanix"
 }
 
 output "bastion_node_ssh_user" {

--- a/test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl
+++ b/test/infra/vsphere/packer-vsphere-airgap.yaml.tmpl
@@ -14,6 +14,6 @@ packer:
   datastore: "${VSPHERE_DATASTORE}"
   folder: "cluster-api"
   network: "Airgapped"
-  resource_pool: "Users"
+  resource_pool: "ci/ci-kib"
   ssh_username: "kib"
   linked_clone: "false"

--- a/test/infra/vsphere/packer-vsphere-basic.yaml.tmpl
+++ b/test/infra/vsphere/packer-vsphere-basic.yaml.tmpl
@@ -3,7 +3,7 @@ packer:
   datacenter: "dc1"
   datastore: ${VSPHERE_DATASTORE}
   folder: "cluster-api"
-  network: "Public"
-  resource_pool: "Users"
+  network: "VMs"
+  resource_pool: "ci/ci-kib"
   ssh_username: "builder"
   linked_clone: false

--- a/test/infra/vsphere/variables.tf
+++ b/test/infra/vsphere/variables.tf
@@ -10,7 +10,7 @@ variable "bastion_base_template" {
 
 variable "resource_pool_name" {
   description = "The resource pool name"
-  default     = "cluster-api"
+  default     = "ci-kib"
 }
 
 variable "root_volume_size" {


### PR DESCRIPTION
**What problem does this PR solve?**:
Updates the GHA workflow to use our current vSphere environment to build vSphere images for konvoy e2e tests.

Backport of  #1289

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
