### PR TITLE
fix(release-2.22): bump nvidia kernel headers for RHEL 8.10

### DIFF
--- a/bundles/redhat8.10/packages.txt.gotmpl
+++ b/bundles/redhat8.10/packages.txt.gotmpl
@@ -38,6 +38,6 @@ libverto-module-base
 libverto
 nfs-utils
 {{ if .FetchKernelHeaders -}}
-kernel-headers-4.18.0-553.40.1.el8_10
-kernel-devel-4.18.0-553.40.1.el8_10
+kernel-headers-4.18.0-553.54.1.el8_10
+kernel-devel-4.18.0-553.54.1.el8_10
 {{- end }}


### PR DESCRIPTION
**What problem does this PR solve?**:
Building Airgapped images for GPU on AWS for RHEL 8.10

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-107968

**Special notes for your reviewer**:
solely bumping kernel versions

**Does this PR introduce a user-facing change?**:
n/a