### PR TITLE
fix(release-2.22): bump nvidia kernel headers for RHEL 8.8

### DIFF
--- a/bundles/redhat8.8/packages.txt.gotmpl
+++ b/bundles/redhat8.8/packages.txt.gotmpl
@@ -36,6 +36,6 @@ gssproxy
 libverto-module-base
 libverto
 {{ if .FetchKernelHeaders -}}
-kernel-headers-4.18.0-477.89.1.el8_8
-kernel-devel-4.18.0-477.89.1.el8_8
+kernel-headers-4.18.0-477.97.1.el8_8
+kernel-devel-4.18.0-477.97.1.el8_8
 {{- end }}


### PR DESCRIPTION
**What problem does this PR solve?**:
Building Airgapped images for GPU on AWS for RHEL 8.8

**Which issue(s) does this PR fix?**:
https://jira.nutanix.com/browse/NCN-107970

**Special notes for your reviewer**:
solely bumping kernel versions

**Does this PR introduce a user-facing change?**:
n/a