### PR TITLE
fix: adds download name to file for containerd download

### DIFF
--- a/ansible/roles/containerd/tasks/install.yaml
+++ b/ansible/roles/containerd/tasks/install.yaml
@@ -15,7 +15,7 @@
   when:
     - not containerd_tar_file_exists.stat.exists
 
-- name: download containerd
+- name: download containerd for {{ containerd_tar_file }}
   get_url:
     url: "{{ containerd_base_url }}/{{ containerd_tar_file }}"
     dest: "{{ containerd_remote_bundle_path }}/{{ containerd_tar_file }}"


### PR DESCRIPTION
**What problem does this PR solve?**:

adds the containerd file so we can see what version we are attempting to download. this will help us validate if we're supporting rocky 9.6 for azure


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
