### PR TITLE
fix: ensure environment and activation key are mutually exclusive in RHEL registration

### DIFF
--- a/ansible/roles/repo/tasks/redhat.yaml
+++ b/ansible/roles/repo/tasks/redhat.yaml
@@ -33,7 +33,6 @@
     force_register: true
     consumer_name: "{{ rhsm_consumer_name }}"
     pool_ids: "{{ [rhsm_pool_id] if rhsm_pool_id | default('') | length > 0 else [] }}"
-    environment: "{{ rhsm_environment }}"
     release: "{{ ansible_distribution_version }}"
   register: rhelorg
   when:

--- a/bundles/redhat8.10/bundle.sh.gotmpl
+++ b/bundles/redhat8.10/bundle.sh.gotmpl
@@ -17,7 +17,8 @@ RHSM_CONSUMER_NAME=${RHSM_CONSUMER_NAME:-""}
 RHSM_POOL_ID=${RHSM_POOL_ID:-""}
 
 RHSM_REGISTER_ARGS=()
-if [[ -n "${RHSM_ENVIRONMENT}" ]]; then
+# environment and activationkey are mutually exclusive
+if [[ -n "${RHSM_ENVIRONMENT}" && -z "${RHSM_ACTIVATION_KEY}" ]]; then
   RHSM_REGISTER_ARGS+=("--environment=${RHSM_ENVIRONMENT}")
 fi
 if [[ -n "${RHSM_CONSUMER_NAME}" ]]; then

--- a/bundles/redhat8.6/bundle.sh.gotmpl
+++ b/bundles/redhat8.6/bundle.sh.gotmpl
@@ -17,7 +17,8 @@ RHSM_CONSUMER_NAME=${RHSM_CONSUMER_NAME:-""}
 RHSM_POOL_ID=${RHSM_POOL_ID:-""}
 
 RHSM_REGISTER_ARGS=()
-if [[ -n "${RHSM_ENVIRONMENT}" ]]; then
+# environment and activationkey are mutually exclusive
+if [[ -n "${RHSM_ENVIRONMENT}" && -z "${RHSM_ACTIVATION_KEY}" ]]; then
   RHSM_REGISTER_ARGS+=("--environment=${RHSM_ENVIRONMENT}")
 fi
 if [[ -n "${RHSM_CONSUMER_NAME}" ]]; then

--- a/bundles/redhat8.8/bundle.sh.gotmpl
+++ b/bundles/redhat8.8/bundle.sh.gotmpl
@@ -17,7 +17,8 @@ RHSM_CONSUMER_NAME=${RHSM_CONSUMER_NAME:-""}
 RHSM_POOL_ID=${RHSM_POOL_ID:-""}
 
 RHSM_REGISTER_ARGS=()
-if [[ -n "${RHSM_ENVIRONMENT}" ]]; then
+# environment and activationkey are mutually exclusive
+if [[ -n "${RHSM_ENVIRONMENT}" && -z "${RHSM_ACTIVATION_KEY}" ]]; then
   RHSM_REGISTER_ARGS+=("--environment=${RHSM_ENVIRONMENT}")
 fi
 if [[ -n "${RHSM_CONSUMER_NAME}" ]]; then


### PR DESCRIPTION
**What problem does this PR solve?**:
The activation key and environment are mutually exclusive.
```
 amazon-ebs.kib_image: TASK [repo : RHEL subscription using org_id and activationkey] *****************
    amazon-ebs.kib_image: fatal: [default]: FAILED! => {"changed": false, "msg": "parameters are mutually exclusive: activationkey|environment"}
```
https://github.com/mesosphere/konvoy-image-builder/actions/runs/16552164833/job/46808690957?pr=1318#step:9:614

We introduced this change as part of https://github.com/mesosphere/konvoy-image-builder/pull/1317 where we run vsphere e2e tests. however all vsphere e2e tests are `offline` and does not exercise this part. 
The bundle generation does not use environment so we didnt catch it.

We will run `basic` aws e2e tests to verify this behavior. 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
