### PR TITLE
fix: update kernel header versions for rhel-8.10

### DIFF
--- a/bundles/redhat8.10/packages.txt.gotmpl
+++ b/bundles/redhat8.10/packages.txt.gotmpl
@@ -34,6 +34,6 @@ libseccomp
 iproute-tc
 nfs-utils
 {{ if .FetchKernelHeaders -}}
-kernel-headers-4.18.0-553.54.1.el8_10
-kernel-devel-4.18.0-553.54.1.el8_10
+kernel-headers-4.18.0-553.60.1.el8_10
+kernel-devel-4.18.0-553.60.1.el8_10
 {{- end }}


### PR DESCRIPTION
**What problem does this PR solve?**:
Update kernel header version to `kernel-headers-4.18.0-553.60.1.el8_10` 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
