### PR TITLE
fix: only use Ec2Kubernetes datasource in aws

### DIFF
--- a/ansible/roles/providers/tasks/misc.yml
+++ b/ansible/roles/providers/tasks/misc.yml
@@ -90,6 +90,7 @@
   when:
     - ansible_os_family != "Flatcar"
     - system_cloud_init_version is version('24.2', '>')
+    - packer_builder_type.startswith('amazon')
 
 - name: Create custom cloud-init data source for Ubuntu
   ansible.builtin.copy:


### PR DESCRIPTION
**What problem does this PR solve?**:

on azure rocky builds cloud init fails because there is no datasource called EC2Kubernetes, which gets added because of this file.we should just run this file for AWS 

```shell
[  OK  ] Started User Login Management.
[   14.847463] cloud-init[925]: [2025-07-30 21:12:27] Cloud-init v. 24.4-4.el9.0.1 running 'init-local' at Wed, 30 Jul 2025 21:12:27 +0000. Up 14.22 seconds.
[  OK  ] Finished Cloud-init: Local Stage (pre-network).
[   14.867461] cloud-init[925]: [2025-07-30 21:12:28] 2025-07-30 21:12:28,282 - sources[ERROR]: Could not import DataSourceEc2Kubernetes. Does the DataSource exist and is it importable?
[  OK  ] Reached target Preparation for Network.
         Starting Network Manager...
         Starting Hostname Service...
[  OK  ] Started Hostname Service.
         Starting Network Manager Script Dispatcher Service...
[  OK  ] Started Network Manager Script Dispatcher Serv
``` 

**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
*https://jira.nutanix.com/browse/NCN-108626


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
