### PR TITLE
fix: update cache after adding offline repository

### DIFF
--- a/ansible/roles/packages/tasks/debian.yaml
+++ b/ansible/roles/packages/tasks/debian.yaml
@@ -4,28 +4,10 @@
     name: apt-transport-https
     state: latest
     update_cache: true
-  register: apt_result
-  until: apt_result is not failed
+  register: apt_lock_status
+  until: apt_lock_status is not failed
   retries: 5
   delay: 10
-  ignore_errors: true
-
-- name: Debug apt_result summary
-  debug:
-    msg:
-      - "RC: {{ apt_result.rc | default('N/A') }}"
-      - "STDOUT: {{ apt_result.stdout | default('') }}"
-      - "STDERR: {{ apt_result.stderr | default('') }}"
-      - "MSG: {{ apt_result.msg | default('') }}"
-
-- name: install apt-transport-https deb package without cache
-  apt:
-    name: apt-transport-https
-    state: present
-    update_cache: false
-  register: apt_transport_result
-  ignore_errors: true
-  when: apt_result is failed
 
 - name: apt update package management cache
   apt:
@@ -34,7 +16,6 @@
   until: apt_lock_status is not failed
   retries: 5
   delay: 10
-  when: apt_result is not failed
 
 - name: install common debs
   apt:

--- a/ansible/roles/repo/tasks/debian-offline.yaml
+++ b/ansible/roles/repo/tasks/debian-offline.yaml
@@ -19,5 +19,6 @@
     apt_repository:
       repo: 'deb [trusted=yes] file:{{ offline.os_packages_remote_filesystem_repo_path }} /'
       filename: offline
+      update_cache: true
     retries: 3
     delay: 3


### PR DESCRIPTION
**What problem does this PR solve?**:

This attempts to fix the problem where we can't install items from the offline repository as seen here:

https://github.com/mesosphere/konvoy-image-builder/actions/runs/17097491616/job/48820722266#step:9:2826

```
    amazon-ebs.kib_image: fatal: [default]: FAILED! => {"attempts": 5, "changed": false, "msg": "Failed to update apt cache: unknown reason"}
```

this updates the cache as soon as we start using the offline repository. strangely, this error is not occurring on the main builds despite using the same AMI 


**Which issue(s) does this PR fix?**:
<!-- Add a link to the JIRA issue for both items below
* jql=key in (D2IQ-NUMBER)
-->
* https://jira.d2iq.com/browse/D2IQ-NUMBER


**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->


**Does this PR introduce a user-facing change?**:
<!--
If yes, add a message in the 'release-note' block below.
If this PR fixes a COPS ticket, include it after the note like: "CLI: Some bug fix. (COPS-xxxx)"
-->
```release-note

```
