### PR TITLE
feat: upgrade the containerd 1.7.29 to fix cve [release-2.28]

### DIFF
--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -32,7 +32,7 @@ critools_deb: "{{ crictl_version }}-1.1"
 critools_rpm: "{{ crictl_version }}-0"
 
 # Containerd container runtime version.
-containerd_version: "1.7.27"
+containerd_version: "1.7.28"
 
 # NOTE(jkoelker) `nvidia_cuda_version` is set via an override, it is listed
 #                empty here for documentation.


### PR DESCRIPTION
What problem does this PR solve?

Upgrade containerd to v1.7.29 to fix cve

NKP: runc Container Escape Vulnerabilities - https://github.com/advisories/GHSA-9493-h29p-rfm2, https://github.com/advisories/GHSA-qw9x-cqr3-wc7r, https://github.com/advisories/GHSA-cgrx-mc8f-2prm

Which issue(s) does this PR fix?

https://jira.nutanix.com/browse/NCN-111490