### PR TITLE
fix: upgrade open-vm-tools for all OS based on respective RSHA

### DIFF
--- a/bundles/oracle9.4/packages.txt.gotmpl
+++ b/bundles/oracle9.4/packages.txt.gotmpl
@@ -2,7 +2,7 @@ audit
 ca-certificates
 conntrack-tools
 chrony
-open-vm-tools
+open-vm-tools-12.5.0-1.0.1.el9_6.2
 python3-pip
 socat
 sysstat

--- a/bundles/redhat8.10/packages.txt.gotmpl
+++ b/bundles/redhat8.10/packages.txt.gotmpl
@@ -2,7 +2,7 @@ audit
 ca-certificates
 conntrack-tools
 chrony
-open-vm-tools >= 12.3.5-2.el8_10.1
+open-vm-tools-12.3.5-2.el8_10.1
 python2-pip
 python3-pip
 python3-requests

--- a/bundles/redhat8.10/packages.txt.gotmpl
+++ b/bundles/redhat8.10/packages.txt.gotmpl
@@ -2,7 +2,7 @@ audit
 ca-certificates
 conntrack-tools
 chrony
-open-vm-tools
+open-vm-tools >= 12.3.5-2.el8_10.1
 python2-pip
 python3-pip
 python3-requests

--- a/bundles/rocky9.8/packages.txt.gotmpl
+++ b/bundles/rocky9.8/packages.txt.gotmpl
@@ -12,7 +12,7 @@ kernel-core >= 5.14.0-687.24.1
 kernel-modules >= 5.14.0-687.24.1
 kernel-modules-core >= 5.14.0-687.24.1
 kernel-modules-extra >= 5.14.0-687.24.1
-open-vm-tools
+open-vm-tools >= 13.0.10-1.el9
 python3-pip
 python3-netifaces
 python3-requests


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What problem does this PR solve?
Update Open-vm-tools version to resolve CVE-2025-41244 vulnerability based on respective RHSA
| Bundle | File | Distro Fix Advisory | Minimum Fixed Version |
|--------|------|----------------------|------------------------|
| rhel-9.6 | bundles/rhel-9.6/packages.txt.gotmpl | RHSA-2025:17428 | open-vm-tools >= 12.5.0-1.el9_6.2 |
| rhel-8.10 | bundles/rhel-8.10/packages.txt.gotmpl | RHSA-2025:17509 | open-vm-tools >= 12.3.5-2.el8_10.1 |
| rocky-9.7 | bundles/rocky-9.7/packages.txt.gotmpl | No dedicated CVE advisory (fix baked in at GA) | open-vm-tools >= 13.0.0-1.el9_7.1 |
| rocky-9.8 | bundles/rocky-9.8/packages.txt.gotmpl | No dedicated CVE advisory (fix baked in at GA) | open-vm-tools >= 13.0.10-1.el9 |
| oracle-9.4 | bundles/oracle-9.4/packages.txt.gotmpl | ELSA-2025-17428 (Oracle Linux 9 unified stream) | open-vm-tools >= 12.5.0-1.0.1.el9_6.2 |
| oracle-8.9 | bundles/oracle-8.9/packages.txt.gotmpl | ELSA-2025-17509 (Oracle Linux 8 unified stream) | open-vm-tools >= 12.3.5-2.0.1.el8_10.1 |
#### Which issue(s) does this PR fix?
<!-- Add a link to the JIRA issue for both items below
* jql=key in (NCN-NUMBER)
-->
- https://jira.nutanix.com/browse/ENG-960668

#### Special notes for your reviewer
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Manual testing steps.
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
